### PR TITLE
fix: remove unnecessary campaign sync logic (SDKCF-2467)

### DIFF
--- a/RInAppMessaging/Classes/Repositories/CampaignRepository.swift
+++ b/RInAppMessaging/Classes/Repositories/CampaignRepository.swift
@@ -36,17 +36,12 @@ internal class CampaignRepository: CampaignRepositoryType {
         let oldList = self.campaigns.get()
         var newList = [Campaign]()
 
-        // Preserving information about opt out state and number of impressions left
-        // is necessary in case when server didn't process impressions sent from the SDK yet.
-        // maxImpressions value from the server will decrease (on the server) after every impression
-        // causing situation when SDK could loose track on how many more times campaign message should be displayed.
-        // In the future the number of times campaign was displayed should be stored on the server
-        // which will avoid using this logic and it will also allow updating maxImpressions in the IAM web dashboard.
+        // Preserving information about opt out state in case when server didn't process impressions sent from the SDK yet.
+        // There is an assumption that maxImpressions value from the server is the most recent one.
+        // (Considering any possible updates to the campaign in the IAM web dashboard)
         list.forEach { newCampaign in
             var updatedCampaign = newCampaign
             if let oldCampaign = oldList.first(where: { $0.id == newCampaign.id }) {
-                updatedCampaign = Campaign.updatedCampaign(updatedCampaign,
-                    withImpressionLeft: min(newCampaign.data.maxImpressions, oldCampaign.impressionsLeft))
                 updatedCampaign = Campaign.updatedCampaign(updatedCampaign,
                     asOptedOut: oldCampaign.isOptedOut)
             }

--- a/Tests/CampaignRepositoryTests.swift
+++ b/Tests/CampaignRepositoryTests.swift
@@ -11,6 +11,10 @@ class CampaignRepositoryTests: QuickSpec {
             var firstPersistedCampaign: Campaign? {
                 return campaignRepository.list.first
             }
+            let testCampaign = TestHelpers.generateCampaign(id: "testImpressions",
+                                                            test: false,
+                                                            delay: 0,
+                                                            maxImpressions: 3)
 
             func insertRandomCampaigns() {
                 let campaigns = TestHelpers.MockResponse.withGeneratedCampaigns(count: 2, test: false, delay: 1).data
@@ -40,47 +44,21 @@ class CampaignRepositoryTests: QuickSpec {
                     expect(campaignRepository.list).to(haveCount(1))
                 }
 
-                it("will persist impressionsLeft value if maxImpressions number is bigger") {
-                    let campaign = TestHelpers.generateCampaign(id: "testImpressions",
-                                                                test: false,
-                                                                delay: 0,
-                                                                maxImpressions: 3)
-                    campaignRepository.syncWith(list: [campaign], timestampMilliseconds: 0)
-                    expect(firstPersistedCampaign?.impressionsLeft).to(equal(3))
-
-                    _ = campaignRepository.decrementImpressionsLeftInCampaign(campaign)
-                    campaignRepository.syncWith(list: [campaign], timestampMilliseconds: 0)
+                it("will override impressionsLeft value even if maxImpressions number is bigger") {
+                    campaignRepository.syncWith(list: [testCampaign], timestampMilliseconds: 0)
+                    _ = campaignRepository.decrementImpressionsLeftInCampaign(testCampaign)
                     expect(firstPersistedCampaign?.impressionsLeft).to(equal(2))
-                    expect(firstPersistedCampaign?.data.maxImpressions).to(equal(3))
-                }
 
-                it("will update impressionsLeft value if maxImpressions number is smaller") {
-                    let campaign = TestHelpers.generateCampaign(id: "testImpressions",
-                                                                test: false,
-                                                                delay: 0,
-                                                                maxImpressions: 3)
-                    campaignRepository.syncWith(list: [campaign], timestampMilliseconds: 0)
+                    campaignRepository.syncWith(list: [testCampaign], timestampMilliseconds: 0)
                     expect(firstPersistedCampaign?.impressionsLeft).to(equal(3))
-
-                    let updatedCampaign = TestHelpers.generateCampaign(id: "testImpressions",
-                                                                       test: false,
-                                                                       delay: 0,
-                                                                       maxImpressions: 1)
-                    campaignRepository.syncWith(list: [updatedCampaign], timestampMilliseconds: 0)
-                    expect(firstPersistedCampaign?.impressionsLeft).to(equal(1))
-                    expect(firstPersistedCampaign?.data.maxImpressions).to(equal(1))
                 }
 
                 it("will persist isOptedOut value") {
-                    let campaign = TestHelpers.generateCampaign(id: "testOptedOut",
-                                                                test: false,
-                                                                delay: 0,
-                                                                maxImpressions: 3)
-                    campaignRepository.syncWith(list: [campaign], timestampMilliseconds: 0)
+                    campaignRepository.syncWith(list: [testCampaign], timestampMilliseconds: 0)
                     expect(firstPersistedCampaign?.isOptedOut).to(beFalse())
 
-                    _ = campaignRepository.optOutCampaign(campaign)
-                    campaignRepository.syncWith(list: [campaign], timestampMilliseconds: 0)
+                    _ = campaignRepository.optOutCampaign(testCampaign)
+                    campaignRepository.syncWith(list: [testCampaign], timestampMilliseconds: 0)
                     expect(firstPersistedCampaign?.isOptedOut).to(beTrue())
                 }
             }
@@ -88,42 +66,22 @@ class CampaignRepositoryTests: QuickSpec {
             context("when optOutCampaign is called") {
 
                 it("will mark campaign as opted out") {
-                    let campaign = TestHelpers.generateCampaign(id: "testOptedOut",
-                                                                test: false,
-                                                                delay: 0,
-                                                                maxImpressions: 3)
-                    campaignRepository.syncWith(list: [campaign], timestampMilliseconds: 0)
-                    expect(firstPersistedCampaign).to(equal(campaign))
+                    campaignRepository.syncWith(list: [testCampaign], timestampMilliseconds: 0)
                     expect(firstPersistedCampaign?.isOptedOut).to(beFalse())
 
-                    _ = campaignRepository.optOutCampaign(campaign)
+                    _ = campaignRepository.optOutCampaign(testCampaign)
                     expect(firstPersistedCampaign?.isOptedOut).to(beTrue())
                 }
             }
 
             context("when decrementImpressionsLeftInCampaign is called") {
 
-                let campaign = TestHelpers.generateCampaign(id: "testImpressionsLeft",
-                                                            test: false,
-                                                            delay: 0,
-                                                            maxImpressions: 3)
-
                 it("will decrement campaign's impressionsLeft value") {
-                    campaignRepository.syncWith(list: [campaign], timestampMilliseconds: 0)
-                    expect(firstPersistedCampaign).to(equal(campaign))
+                    campaignRepository.syncWith(list: [testCampaign], timestampMilliseconds: 0)
                     expect(firstPersistedCampaign?.impressionsLeft).to(equal(3))
 
-                    _ = campaignRepository.decrementImpressionsLeftInCampaign(campaign)
+                    _ = campaignRepository.decrementImpressionsLeftInCampaign(testCampaign)
                     expect(firstPersistedCampaign?.impressionsLeft).to(equal(2))
-                }
-
-                it("will not decrement campaign data's impressions") {
-                    campaignRepository.syncWith(list: [campaign], timestampMilliseconds: 0)
-                    expect(firstPersistedCampaign).to(equal(campaign))
-                    expect(firstPersistedCampaign?.data.maxImpressions).to(equal(3))
-
-                    _ = campaignRepository.decrementImpressionsLeftInCampaign(campaign)
-                    expect(firstPersistedCampaign?.data.maxImpressions).to(equal(3))
                 }
             }
         }


### PR DESCRIPTION
# Description
Server is considered a source of truth for maxImpressions/impressionsLeft value

## Links
SDKCF-2467

# Checklist
- [X] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [X] I wrote/updated tests for new/changed code
- [X] I removed all sensitive data **before every commit**, including API endpoints and keys
- [X] I ran `fastlane ci` without errors
