### PR TITLE
fix: unify secure script with feedback from usage on MiniApp SDK project

### DIFF
--- a/Sample/Example-Debug.xcconfig
+++ b/Sample/Example-Debug.xcconfig
@@ -1,4 +1,4 @@
 #include "Pods/Target Support Files/Pods-RInAppMessaging_Example/Pods-RInAppMessaging_Example.debug.xcconfig"
 
 // IMPORTANT: Secrets MUST be added to Example-Secrets.xcconfig and that file MUST NOT be added to git.
-#include "Example-Secrets.xcconfig"
+#include "../../InAppMessaging-Secrets.xcconfig"

--- a/Sample/Example-Release.xcconfig
+++ b/Sample/Example-Release.xcconfig
@@ -1,4 +1,4 @@
 #include "Pods/Target Support Files/Pods-RInAppMessaging_Example/Pods-RInAppMessaging_Example.release.xcconfig"
 
 // IMPORTANT: Secrets MUST be added to Example-Secrets.xcconfig and that file MUST NOT be added to git.
-#include "Example-Secrets.xcconfig"
+#include "../../InAppMessaging-Secrets.xcconfig"

--- a/configure-secrets.sh
+++ b/configure-secrets.sh
@@ -40,7 +40,7 @@ echo "//" >> $SECRETS_FILE
 echo "// Add new secrets configuration in ./configure-secrets.sh" >> $SECRETS_FILE
 echo "//" >> $SECRETS_FILE
 echo "// In order to have the // in https://, we need to split it with an empty" >> $SECRETS_FILE
-echo "// variable substitution via $() e.g. ROOT_URL = https:/$()/www.endpoint.com" >> $SECRETS_FILE
+echo "// variable substitution via \$() e.g. ROOT_URL = https:/\$()/www.endpoint.com" >> $SECRETS_FILE
 
 # Set secrets from environment variables
 echo "RIAM_CONFIG_URL = $CONFIG_URL" >> $SECRETS_FILE

--- a/configure-secrets.sh
+++ b/configure-secrets.sh
@@ -1,8 +1,17 @@
 #!/bin/sh -e
 
+#In order to have the // in https://, we need to split it with an empty variable substitution via $()
+secureDoubleSlashForXCConfig() {
+	ENDPOINT=$1
+	URL_DOUBLE_SLASH_TO_BE_REPLACED="\/\/"
+	BY_2_SLASHES_SPLITTED_BY_EMPTY_VARIABLE="/\$()/"
+
+	SECURE_DOUBLE_SLASH_FOR_XCCONFIG_RESULT="${ENDPOINT/$URL_DOUBLE_SLASH_TO_BE_REPLACED/$BY_2_SLASHES_SPLITTED_BY_EMPTY_VARIABLE}" 
+}
+
 NOCOLOR='\033[0m'
 RED='\033[0;31m'
-SECRETS_FILE=Sample/Example-Secrets.xcconfig
+SECRETS_FILE=../InAppMessaging-Secrets.xcconfig
 
 echo "Configuring project's build secrets in $SECRETS_FILE..."
 
@@ -17,7 +26,8 @@ do
   fi
 done
 
-CONFIG_URL=${RIAM_CONFIG_URL}
+secureDoubleSlashForXCConfig ${RIAM_CONFIG_URL:=https://www.example.com}
+CONFIG_URL=$SECURE_DOUBLE_SLASH_FOR_XCCONFIG_RESULT
 SUBSCRIPTION_KEY=${RIAM_APP_SUBSCRIPTION_KEY}
 
 # Overwrite secrets xcconfig and add file header


### PR DESCRIPTION
# Description
After using script on MiniApp SDK we noted some improvement we could bring to the script, by securing the secret file location outside if the repository and by allowing regular URL stored in environment variables (that was useful when configuring Travis)

## Links
https://github.com/rakutentech/ios-miniapp/pull/115
https://github.com/rakutentech/ios-miniapp/pull/119

# Checklist
- [X] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [ ] I wrote/updated tests for new/changed code
- [X] I removed all sensitive data **before every commit**, including API endpoints and keys
- [ ] I ran `fastlane ci` without errors
