### PR TITLE
SDKCF-2842: [Bug][IAM][iOS] - getConfig call is blocking and the retry can occur on main thread

### DIFF
--- a/RInAppMessaging/Classes/DependencyManager/MainContainer.swift
+++ b/RInAppMessaging/Classes/DependencyManager/MainContainer.swift
@@ -34,10 +34,14 @@ internal enum MainContainerFactory {
             ContainerElement(type: ConfigurationRepositoryType.self, factory: {
                 ConfigurationRepository()
             }),
+            ContainerElement(type: DispatchQueue.self, factory: {
+                DispatchQueue(label: "IAM.Main", qos: .utility, attributes: [])
+            }),
             ContainerElement(type: ConfigurationManagerType.self, factory: {
                 ConfigurationManager(reachability: manager.resolve(type: ReachabilityType.self),
                                      configurationService: manager.resolve(type: ConfigurationServiceType.self)!,
-                                     configurationRepository: manager.resolve(type: ConfigurationRepositoryType.self)!)
+                                     configurationRepository: manager.resolve(type: ConfigurationRepositoryType.self)!,
+                                     resumeQueue: manager.resolve(type: DispatchQueue.self)!)
             }),
             ContainerElement(type: CampaignRepositoryType.self, factory: { CampaignRepository() }),
             ContainerElement(type: EventMatcherType.self, factory: {

--- a/RInAppMessaging/Classes/RInAppMessaging.swift
+++ b/RInAppMessaging/Classes/RInAppMessaging.swift
@@ -13,6 +13,9 @@
 
     internal private(set) static var initializedModule: InAppMessagingModule?
     private(set) static var dependencyManager: DependencyManager?
+    private static var inAppQueue: DispatchQueue? {
+        dependencyManager?.resolve(type: DispatchQueue.self)
+    }
 
     private override init() { super.init() }
 
@@ -87,7 +90,7 @@
     /// Log the event name passed in and also pass the event name to the view controller to display a matching campaign.
     /// - Parameter event: The Event object to log.
     @objc public static func logEvent(_ event: Event) {
-        dependencyManager?.resolve(type: DispatchQueue.self)?.async(flags: .barrier) {
+        inAppQueue?.async(flags: .barrier) {
             initializedModule?.logEvent(event)
         }
     }
@@ -95,13 +98,13 @@
     /// Register user preference to the IAM SDK.
     /// - Parameter preference: Preferences of the user.
     @objc public static func registerPreference(_ preference: IAMPreference?) {
-        dependencyManager?.resolve(type: DispatchQueue.self)?.async(flags: .barrier) {
+        inAppQueue?.async(flags: .barrier) {
             initializedModule?.registerPreference(preference)
         }
     }
 
     internal static func deinitializeModule() {
-        dependencyManager?.resolve(type: DispatchQueue.self)?.sync {
+        inAppQueue?.sync {
             initializedModule = nil
         }
     }

--- a/RInAppMessaging/Classes/RInAppMessaging.swift
+++ b/RInAppMessaging/Classes/RInAppMessaging.swift
@@ -11,7 +11,6 @@
 /// Conforms to NSObject and exposed with objc tag to make it work with Obj-c projects.
 @objc public class RInAppMessaging: NSObject {
 
-    private static let inAppQueue = DispatchQueue(label: "IAM.Main", qos: .utility, attributes: [])
     internal private(set) static var initializedModule: InAppMessagingModule?
     private(set) static var dependencyManager: DependencyManager?
 
@@ -47,7 +46,7 @@
     static func configure(dependencyManager: DependencyManager) {
         self.dependencyManager = dependencyManager
 
-        inAppQueue.async(flags: .barrier) {
+        dependencyManager.resolve(type: DispatchQueue.self)?.async(flags: .barrier) {
             guard initializedModule == nil else {
                 return
             }
@@ -88,7 +87,7 @@
     /// Log the event name passed in and also pass the event name to the view controller to display a matching campaign.
     /// - Parameter event: The Event object to log.
     @objc public static func logEvent(_ event: Event) {
-        inAppQueue.async(flags: .barrier) {
+        dependencyManager?.resolve(type: DispatchQueue.self)?.async(flags: .barrier) {
             initializedModule?.logEvent(event)
         }
     }
@@ -96,13 +95,13 @@
     /// Register user preference to the IAM SDK.
     /// - Parameter preference: Preferences of the user.
     @objc public static func registerPreference(_ preference: IAMPreference?) {
-        inAppQueue.async(flags: .barrier) {
+        dependencyManager?.resolve(type: DispatchQueue.self)?.async(flags: .barrier) {
             initializedModule?.registerPreference(preference)
         }
     }
 
     internal static func deinitializeModule() {
-        inAppQueue.sync {
+        dependencyManager?.resolve(type: DispatchQueue.self)?.sync {
             initializedModule = nil
         }
     }

--- a/RInAppMessaging/Classes/RInAppMessaging.swift
+++ b/RInAppMessaging/Classes/RInAppMessaging.swift
@@ -49,7 +49,7 @@
     static func configure(dependencyManager: DependencyManager) {
         self.dependencyManager = dependencyManager
 
-        dependencyManager.resolve(type: DispatchQueue.self)?.async(flags: .barrier) {
+        inAppQueue?.async(flags: .barrier) {
             guard initializedModule == nil else {
                 return
             }

--- a/Tests/ConfigurationManagerTests.swift
+++ b/Tests/ConfigurationManagerTests.swift
@@ -18,7 +18,8 @@ class ConfigurationManagerTests: QuickSpec {
                 configurationRepository = ConfigurationRepository()
                 configurationManager = ConfigurationManager(reachability: reachability,
                                                             configurationService: configurationService,
-                                                            configurationRepository: configurationRepository)
+                                                            configurationRepository: configurationRepository,
+                                                            resumeQueue: DispatchQueue(label: "iam.test.request"))
             }
 
             context("fetchAndSaveConfigData") {


### PR DESCRIPTION
# Description
RInAppMessaging is blocking the main thread.
Running the retry handler on the in app queue solves this issue.

Steps:
* disconnect network
* launch demoapp and go to analytics and tap track event
* put app in background
* connect to network
* bring app to foreground

## Links
https://jira.rakuten-it.com/jira/browse/SDKCF-2842