### PR TITLE
improve: use connectedScenes property to find a window to display campaign message

### DIFF
--- a/RInAppMessaging/Classes/Views/BaseView.swift
+++ b/RInAppMessaging/Classes/Views/BaseView.swift
@@ -33,6 +33,19 @@ internal extension BaseView {
         onDismiss?()
     }
 
+    private func getKeyWindow() -> UIWindow? {
+        var keySceneWindow: UIWindow?
+        if #available(iOS 13.0, *) {
+            keySceneWindow = UIApplication.shared.connectedScenes
+                .filter({ $0.activationState == .foregroundActive })
+                .compactMap({ $0 as? UIWindowScene })
+                .first?.windows
+                .first(where: { $0.isKeyWindow })
+        }
+
+        return keySceneWindow ?? UIApplication.shared.keyWindow
+    }
+
     /// Find the presented view controller and add the `BaseView` on top.
     private func displayView(accessibilityCompatible: Bool) {
         self.accessibilityIdentifier = viewIdentifier
@@ -49,7 +62,7 @@ internal extension BaseView {
             return nil
         }
 
-        guard let window =  UIApplication.shared.keyWindow,
+        guard let window = getKeyWindow(),
             findPresentedIAMView(from: window) == nil else {
                 return
         }


### PR DESCRIPTION
This change will be useful for apps that have multiple scenes/windows

# Checklist
- [X] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [ ] I wrote/updated tests for new/changed code
- [X] I removed all sensitive data **before every commit**, including API endpoints and keys
- [ ] I ran `fastlane ci` without errors
