### PR TITLE
fix: test compilation issues on Xcode 12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: swift
 xcode_workspace: Example/InAppMessaging.xcworkspace
 xcode_scheme: InAppMessaging-Example
-osx_image: xcode11.5
+osx_image: xcode11.7
 
 script:
   - bundle exec fastlane ci

--- a/Podfile
+++ b/Podfile
@@ -3,7 +3,7 @@ platform :ios, '10.0'
 
 target 'RInAppMessaging_Example' do
   pod 'RInAppMessaging', :path => '.'
-  pod 'SwiftLint', '~> 0.39.0'
+  pod 'SwiftLint', '~> 0.40.0'
 
   target 'Tests' do
     pod 'RInAppMessaging', :path => '.'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,14 +1,14 @@
 PODS:
-  - Nimble (8.0.7)
-  - Quick (2.2.0)
+  - Nimble (9.0.0)
+  - Quick (3.0.0)
   - RInAppMessaging (2.0.0)
-  - SwiftLint (0.39.1)
+  - SwiftLint (0.40.3)
 
 DEPENDENCIES:
   - Nimble
   - Quick
   - RInAppMessaging (from `.`)
-  - SwiftLint (~> 0.39.0)
+  - SwiftLint (~> 0.40.0)
 
 SPEC REPOS:
   trunk:
@@ -21,11 +21,11 @@ EXTERNAL SOURCES:
     :path: "."
 
 SPEC CHECKSUMS:
-  Nimble: a73af6ecd4c9106f434f3d55fc54570be3739e0b
-  Quick: 7fb19e13be07b5dfb3b90d4f9824c855a11af40e
+  Nimble: 3b4ec3fd40f1dc178058e0981107721c615643d8
+  Quick: 6d9559f40647bc4d510103842ef2fdd882d753e2
   RInAppMessaging: 16c9fe8e28be1d03aa5208b38a13dbf5f6c282fd
-  SwiftLint: 55e96a4a4d537d4a3156859fc1c54bd24851a046
+  SwiftLint: dfd554ff0dff17288ee574814ccdd5cea85d76f7
 
-PODFILE CHECKSUM: cade48b594a1c0fe3ab3d602967297325f383b44
+PODFILE CHECKSUM: 28dc4c45502f0ab0cc2a5647a7de9aa8747d072b
 
 COCOAPODS: 1.9.3

--- a/Tests/ConfigurationManagerTests.swift
+++ b/Tests/ConfigurationManagerTests.swift
@@ -50,7 +50,7 @@ class ConfigurationManagerTests: QuickSpec {
                     }
 
                     it("should call retry handler when connection becomes available (cellular)") {
-                        waitUntil(timeout: 1) { done in
+                        waitUntil { done in
                             configurationManager.fetchAndSaveConfigData(completion: { _ in
                                 done()
                             })
@@ -59,7 +59,7 @@ class ConfigurationManagerTests: QuickSpec {
                     }
 
                     it("should call retry handler when connection becomes available (wifi)") {
-                        waitUntil(timeout: 1) { done in
+                        waitUntil { done in
                             configurationManager.fetchAndSaveConfigData(completion: { _ in
                                 done()
                             })
@@ -78,11 +78,11 @@ class ConfigurationManagerTests: QuickSpec {
                     configurationService.simulateRequestFailure = true
                     configurationManager.fetchAndSaveConfigData(completion: { _ in })
                     expect(configurationService.getConfigDataCallCount).to(equal(1))
-                    expect(configurationService.getConfigDataCallCount).toEventually(equal(2), timeout: 11)
+                    expect(configurationService.getConfigDataCallCount).toEventually(equal(2), timeout: .seconds(11))
                 }
 
                 it("should call completion after retry attempt was successful") {
-                    waitUntil(timeout: 11) { done in
+                    waitUntil(timeout: .seconds(11)) { done in
                         configurationService.simulateRequestFailure = true
                         configurationManager.fetchAndSaveConfigData(completion: { _ in
                             done()

--- a/Tests/ConfigurationTests.swift
+++ b/Tests/ConfigurationTests.swift
@@ -36,7 +36,7 @@ class ConfigurationTests: QuickSpec {
 
                 it("will disable module") {
                     configurationManager.isConfigEnabled = false
-                    waitUntil(timeout: 1) { done in
+                    waitUntil { done in
                         configurationManager.fetchCalledClosure = {
                             expect(RInAppMessaging.initializedModule).toNot(beNil())
                             done()

--- a/Tests/HttpRequestableTests.swift
+++ b/Tests/HttpRequestableTests.swift
@@ -213,7 +213,7 @@ class HttpRequestableTests: QuickSpec {
                             let error = result.getError()
                             expect(error).to(matchError(RequestError.self))
 
-                            guard case .httpError(_, _, _) = error else {
+                            guard case .httpError = error else {
                                 fail("Unexpected error type \(String(describing: error)). Expected .httpError")
                                 done()
                                 return
@@ -243,7 +243,7 @@ class HttpRequestableTests: QuickSpec {
                             let error = result.getError()
                             expect(error).to(matchError(RequestError.self))
 
-                            guard case .httpError(_, _, _) = error else {
+                            guard case .httpError = error else {
                                 fail("Unexpected error type \(String(describing: error)). Expected .httpError")
                                 done()
                                 return
@@ -505,7 +505,7 @@ class HttpRequestableTests: QuickSpec {
                     let error = result?.getError()
                     expect(error).to(matchError(RequestError.self))
 
-                    guard case .httpError(_, _, _) = error else {
+                    guard case .httpError = error else {
                         fail("Unexpected error type \(String(describing: error)). Expected .httpError")
                         return
                     }
@@ -536,7 +536,7 @@ class HttpRequestableTests: QuickSpec {
                     let error = result?.getError()
                     expect(error).to(matchError(RequestError.self))
 
-                    guard case .httpError(_, _, _) = error else {
+                    guard case .httpError = error else {
                         fail("Unexpected error type \(String(describing: error)). Expected .httpError")
                         return
                     }

--- a/Tests/IdRegistrationTests.swift
+++ b/Tests/IdRegistrationTests.swift
@@ -50,7 +50,7 @@ class IdRegistrationTests: QuickSpec {
                 )
 
                 let expected = [UserIdentifier(type: .userId, identifier: "whales and dolphins")]
-                expect(preferenceRepository.getUserIdentifiers()).toEventually(equal(expected), timeout: 3, pollInterval: 1)
+                expect(preferenceRepository.getUserIdentifiers()).toEventually(equal(expected), timeout: .seconds(3), pollInterval: .seconds(1))
             }
 
             it("should have two matching id type and id value") {

--- a/Tests/ImpressionServiceTests.swift
+++ b/Tests/ImpressionServiceTests.swift
@@ -42,7 +42,7 @@ class ImpressionServiceTests: QuickSpec {
             it("will use provided URL in a request") {
                 waitUntil { done in
                     requestQueue.async {
-                        _ = service.pingImpression(impressions: [], campaignData: campaign.data)
+                        service.pingImpression(impressions: [], campaignData: campaign.data)
                         done()
                     }
                 }

--- a/Tests/NimbleExtensions.swift
+++ b/Tests/NimbleExtensions.swift
@@ -6,9 +6,10 @@ extension Expectation {
                         timeout: TimeInterval = 1.0) {
 
         let timeForExecution: TimeInterval = 1.0
-        waitUntil(timeout: timeout + timeForExecution) { done in
+        let totalTimeoutMS = Int((timeout + timeForExecution) * TimeInterval(USEC_PER_SEC))
+        waitUntil(timeout: .microseconds(totalTimeoutMS)) { done in
             DispatchQueue.global(qos: .userInteractive).async {
-                usleep(useconds_t(timeout * pow(10, 6)))
+                usleep(useconds_t(timeout * TimeInterval(USEC_PER_SEC)))
 
                 DispatchQueue.main.async {
                     expect {

--- a/Tests/PublicAPITests.swift
+++ b/Tests/PublicAPITests.swift
@@ -103,8 +103,8 @@ class PublicAPITests: QuickSpec {
                 RInAppMessaging.logEvent(LoginSuccessfulEvent())
                 expect(eventMatcher.loggedEvents).toAfterTimeout(beEmpty())
                 expect(eventMatcher.loggedEvents).toEventually(haveCount(1),
-                                                               timeout: messageMixerService.delay + 1,
-                                                               pollInterval: 0.5)
+                                                               timeout: .seconds(Int(messageMixerService.delay + 1)),
+                                                               pollInterval: .milliseconds(500))
             }
         }
     }

--- a/Tests/ReadyCampaignDispatcherTests.swift
+++ b/Tests/ReadyCampaignDispatcherTests.swift
@@ -54,7 +54,7 @@ class ReadyCampaignDispatcherTests: QuickSpec {
                         dispatcher.addToQueue(campaign: firstCampaign)
                         dispatcher.dispatchAllIfNeeded()
                         dispatcher.addToQueue(campaign: secondCampaign)
-                        expect(router.lastDisplayedCampaign).toEventually(equal(secondCampaign), timeout: 2)
+                        expect(router.lastDisplayedCampaign).toEventually(equal(secondCampaign), timeout: .seconds(2))
                     }
 
                     it("won't start another dispatch procedure if one has already started") {

--- a/Tests/SharedMocks.swift
+++ b/Tests/SharedMocks.swift
@@ -205,8 +205,8 @@ class URLSessionMock: URLSession {
             #selector(dummyObject.dataTask(with:completionHandler:)
                 as (URLRequest, @escaping SessionTaskCompletion) -> URLSessionDataTask))!
 
-        method_exchangeImplementations(originalMethod, swizzledMethod)
         swizzledMethods = (originalMethod, swizzledMethod)
+        method_exchangeImplementations(originalMethod, swizzledMethod)
     }
 
     static func stopMockingURLSession() {
@@ -235,8 +235,9 @@ class URLSessionMock: URLSession {
             mockedSession = URLSessionMock.mockSessionLinks[self]
         }
 
+        let originalSession = mockedSession?.originalInstance ?? URLSession(configuration: .default)
         guard let mockContainer = mockedSession else {
-            return URLSessionDataTask()
+            return originalSession.dataTask(with: request)
         }
 
         mockContainer.sentRequest = request
@@ -244,7 +245,8 @@ class URLSessionMock: URLSession {
                           mockContainer.httpResponse,
                           mockContainer.responseError)
 
-        return URLSessionDataTask()
+        // URLSessionDataTask object must be created by URLSession object
+        return originalSession.dataTask(with: request)
     }
 }
 

--- a/Tests/ViewTests.swift
+++ b/Tests/ViewTests.swift
@@ -146,7 +146,7 @@ class ViewTests: QuickSpec {
 
                 let scriptHandler = WebViewScriptMessageHandler()
                 webView.configuration.userContentController.add(scriptHandler, name: "echo")
-                waitUntil(timeout: 2.0) { done in
+                waitUntil(timeout: .seconds(2)) { done in
                     DispatchQueue.global(qos: .userInteractive).async {
                         sleep(1)
                         expect(scriptHandler.result).toNot(equal("Echo"))
@@ -183,7 +183,7 @@ class ViewTests: QuickSpec {
             }
 
             it("will have .modal mode set") {
-                if case .modal(_) = view.mode {
+                if case .modal = view.mode {
                     // expected
                 } else {
                     fail("Expected ModalView to have .modal mode. Actual: \(view.mode)")


### PR DESCRIPTION
# Description
I had some "Illegal statement" errors on Xcode 12 while trying to compile Test target.
According to this thread: https://github.com/Quick/Nimble/issues/809
it seems like it's some kind of Swift regression so as a workaround all `expect` calls with trailing closures have been wrapped in parentheses.

## Links
https://github.com/Quick/Nimble/issues/809

# Checklist
- [X] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [X] I wrote/updated tests for new/changed code
- [X] I removed all sensitive data **before every commit**, including API endpoints and keys
- [ ] I ran `fastlane ci` without errors
