### PR TITLE
improve: disable user interaction for the time of message animation (SDKCF-3027)

### DIFF
--- a/RInAppMessaging/Classes/Views/BaseView.swift
+++ b/RInAppMessaging/Classes/Views/BaseView.swift
@@ -10,7 +10,7 @@ internal protocol BaseView: UIView {
     func show(accessibilityCompatible: Bool, onDismiss: @escaping () -> Void)
 
     /// Handle animation just after `show(accessibilityCompatible:onDismiss:)` call
-    func animateOnShow()
+    func animateOnShow(completion: @escaping () -> Void)
 
     /// Dismiss the presented IAM view
     func dismiss()
@@ -83,6 +83,9 @@ internal extension BaseView {
         NSLayoutConstraint.activate(constraintsForParent(parentView))
 
         parentView.layoutIfNeeded()
-        animateOnShow()
+        parentView.isUserInteractionEnabled = false
+        animateOnShow(completion: {
+            parentView.isUserInteractionEnabled = true
+        })
     }
 }

--- a/RInAppMessaging/Classes/Views/FullView.swift
+++ b/RInAppMessaging/Classes/Views/FullView.swift
@@ -116,7 +116,7 @@ internal class FullView: UIView, FullViewType, RichContentBrowsable {
 
     func updateUIConstants() { }
 
-    func animateOnShow() { }
+    func animateOnShow(completion: @escaping () -> Void) { completion() }
 
     func constraintsForParent(_ parent: UIView) -> [NSLayoutConstraint] {
         return constraintsFilling(parent: parent, activate: false)

--- a/RInAppMessaging/Classes/Views/SlideUpView.swift
+++ b/RInAppMessaging/Classes/Views/SlideUpView.swift
@@ -52,10 +52,11 @@ internal class SlideUpView: UIView, SlideUpViewType {
         presenter.logImpression(type: .impression)
     }
 
-    func animateOnShow() {
+    func animateOnShow(completion: @escaping () -> Void) {
         guard [leftConstraint, bottomConstraint, rightConstraint].allSatisfy({ $0 != nil }) else {
             CommonUtility.debugPrint("Error: Constraints not set up. Cancelling animation")
             assertionFailure()
+            completion()
             return
         }
 
@@ -76,13 +77,15 @@ internal class SlideUpView: UIView, SlideUpViewType {
 
         self.superview?.layoutIfNeeded()
 
-        UIView.animate(withDuration: UIConstants.slideAnimationDuration) {
+        UIView.animate(withDuration: UIConstants.slideAnimationDuration, animations: {
             self.leftConstraint.constant = 0
             self.rightConstraint.constant = 0
             self.bottomConstraint.constant = 0
 
             self.superview?.layoutIfNeeded()
-        }
+        }, completion: { _ in
+            completion()
+        })
     }
 
     func constraintsForParent(_ parent: UIView) -> [NSLayoutConstraint] {

--- a/Tests/ViewPresenterTests.swift
+++ b/Tests/ViewPresenterTests.swift
@@ -355,7 +355,7 @@ private class FullViewMock: UIView, FullViewType {
         addedButtons = buttons
     }
 
-    func animateOnShow() { }
+    func animateOnShow(completion: @escaping () -> Void) { completion() }
     func constraintsForParent(_ parent: UIView) -> [NSLayoutConstraint] { [] }
 }
 
@@ -373,6 +373,6 @@ private class SlideUpViewMock: UIView, SlideUpViewType {
         wasDismissCalled = true
     }
 
-    func animateOnShow() { }
+    func animateOnShow(completion: @escaping () -> Void) { completion() }
     func constraintsForParent(_ parent: UIView) -> [NSLayoutConstraint] { [] }
 }

--- a/Tests/ViewTests.swift
+++ b/Tests/ViewTests.swift
@@ -52,6 +52,13 @@ class ViewTests: QuickSpec {
                     expect(view.wasAnimateOnShowCalled).to(beTrue())
                 }
 
+                it("will disable user interaction in parent view for the time of animation") {
+                    view.show(accessibilityCompatible: false, onDismiss: {})
+                    expect(view.superview?.isUserInteractionEnabled).to(beFalse())
+                    expect(view.wasAnimationCompletionCalled).toEventually(beTrue())
+                    expect(view.superview?.isUserInteractionEnabled).to(beTrue())
+                }
+
                 it("will not show when another one is still displayed") {
                     let window = UIApplication.shared.keyWindow
                     let anotherView = BaseViewTestObject()
@@ -223,9 +230,14 @@ class ViewTests: QuickSpec {
 private class BaseViewTestObject: UIView, BaseView {
     var onDismiss: (() -> Void)?
     private(set) var wasAnimateOnShowCalled = false
+    private(set) var wasAnimationCompletionCalled = false
 
-    func animateOnShow() {
+    func animateOnShow(completion: @escaping () -> Void) {
         wasAnimateOnShowCalled = true
+        DispatchQueue.main.async {
+            self.wasAnimationCompletionCalled = true
+            completion()
+        }
     }
     func constraintsForParent(_ parent: UIView) -> [NSLayoutConstraint] { [] }
 }


### PR DESCRIPTION
# Description
At the request of our client, the following improvement will help preventing user from changing screen when slide up campaign message animation is ongoing.

## Links
SDKCF-3027

# Checklist
- [X] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [X] I wrote/updated tests for new/changed code
- [X] I removed all sensitive data **before every commit**, including API endpoints and keys
- [X] I ran `fastlane ci` without errors
