### PR TITLE
fix: fix an issue when a logout causes persistent event only campaigns to be shown again (SDKCF-3061)

### DIFF
--- a/RInAppMessaging/Classes/EventMatcher.swift
+++ b/RInAppMessaging/Classes/EventMatcher.swift
@@ -18,7 +18,8 @@ internal protocol EventMatcherType: AnyObject, Lockable {
 
     /// Removes all stored events and campaign data.
     /// The list of logged persistent events is not cleared.
-    func clearStoredData()
+    /// - Parameter nonPersistentEventsOnly: if set to `true`, the list of triggered persistent event only campaigns won't be cleared
+    func clearStoredData(nonPersistentEventsOnly: Bool)
 }
 
 internal enum EventMatcherError: Error {
@@ -108,9 +109,11 @@ internal class EventMatcher: EventMatcherType {
         }
     }
 
-    func clearStoredData() {
+    func clearStoredData(nonPersistentEventsOnly: Bool) {
         matchedEvents.set(value: [:])
-        triggeredPersistentEventOnlyCampaigns.removeAll()
+        if !nonPersistentEventsOnly {
+            triggeredPersistentEventOnlyCampaigns.removeAll()
+        }
     }
 
     private func isEventMatchingOneOfTriggers(event: Event, triggers: [Trigger]) -> Bool {

--- a/RInAppMessaging/Classes/InAppMessagingModule.swift
+++ b/RInAppMessaging/Classes/InAppMessagingModule.swift
@@ -91,7 +91,10 @@ internal class InAppMessagingModule: AnalyticsBroadcaster,
 
         // clear data only if there was a change in user ids
         if !(diff == nil || diff == [] || diff == [.accessToken]) {
-            eventMatcher.clearStoredData()
+            let isLogout = preference == nil
+            // we leave triggered persistent event only campaigns untouched
+            // so they won't be displayed again immediately after logout (only after login)
+            eventMatcher.clearStoredData(nonPersistentEventsOnly: isLogout)
         }
         campaignsListManager.refreshList()
     }

--- a/Tests/InAppMessagingModuleTests.swift
+++ b/Tests/InAppMessagingModuleTests.swift
@@ -207,19 +207,21 @@ class InAppMessagingModuleTests: QuickSpec {
                                 expect(campaignsListManager.wasRefreshListCalled).to(beTrue())
                             }
 
-                            it("will clear stored data if one of IDs is updated") {
+                            it("will clear stored data with nonPersistentEventsOnly set to false if one of IDs is updated") {
                                 let preference = IAMPreferenceBuilder().setUserId("user1").build()
                                 iamModule.registerPreference(preference)
                                 let newPreference = IAMPreferenceBuilder().setUserId("user2").build()
                                 iamModule.registerPreference(newPreference)
                                 expect(eventMatcher.wasClearStoredDataCalled).to(beTrue())
+                                expect(eventMatcher.clearStoredDataCallArguments).to(equal((false)))
                             }
 
-                            it("will clear stored data if user logs out") {
+                            it("will clear stored data with nonPersistentEventsOnly set to true if user logs out") {
                                 let preference = IAMPreferenceBuilder().setUserId("user1").build()
                                 iamModule.registerPreference(preference)
                                 iamModule.registerPreference(nil)
                                 expect(eventMatcher.wasClearStoredDataCalled).to(beTrue())
+                                expect(eventMatcher.clearStoredDataCallArguments).to(equal((true)))
                             }
 
                             it("will not clear stored data if only access token was updated") {

--- a/Tests/SharedMocks.swift
+++ b/Tests/SharedMocks.swift
@@ -58,6 +58,7 @@ class CampaignDispatcherMock: CampaignDispatcherType {
 class EventMatcherMock: EventMatcherType {
     private(set) var loggedEvents = [Event]()
     private(set) var wasClearStoredDataCalled = false
+    private(set) var clearStoredDataCallArguments: (Bool)?
     var simulateMatchingSuccess = true
     var simulateMatcherError: EventMatcherError?
     var resourcesToLock: [LockableResource] = []
@@ -81,8 +82,9 @@ class EventMatcherMock: EventMatcherType {
         }
     }
 
-    func clearStoredData() {
+    func clearStoredData(nonPersistentEventsOnly: Bool) {
         wasClearStoredDataCalled = true
+        clearStoredDataCallArguments = (nonPersistentEventsOnly)
     }
 }
 


### PR DESCRIPTION
## Description
I hope it didn't get overly complicated

## Links
SDKCF-3061

# Checklist
- [X] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [X] I wrote/updated tests for new/changed code
- [X] I removed all sensitive data **before every commit**, including API endpoints and keys
- [X] I ran `fastlane ci` without errors
