### PR TITLE
improve: adjust status bar overlay colour in full screen campaigns (iOS 13+)

### DIFF
--- a/RInAppMessaging/Classes/Extensions/UIApplication+IAM.swift
+++ b/RInAppMessaging/Classes/Extensions/UIApplication+IAM.swift
@@ -1,0 +1,31 @@
+import UIKit
+
+extension UIApplication {
+
+    func getKeyWindow() -> UIWindow? {
+        var keySceneWindow: UIWindow?
+        if #available(iOS 13.0, *) {
+            keySceneWindow = connectedScenes
+                .filter({ $0.activationState == .foregroundActive })
+                .compactMap({ $0 as? UIWindowScene })
+                .first?.windows
+                .first(where: { $0.isKeyWindow })
+        }
+
+        return keySceneWindow ?? windows.first { $0.isKeyWindow }
+    }
+
+    func getCurrentStatusBarStyle() -> UIStatusBarStyle? {
+        if #available(iOS 13.0, *),
+           let keyScene = connectedScenes
+                .filter({ $0.activationState == .foregroundActive })
+                .compactMap({ $0 as? UIWindowScene })
+                .first {
+            return keyScene.statusBarManager?.statusBarStyle
+
+        } else {
+            // Not supported
+        }
+        return nil
+    }
+}

--- a/RInAppMessaging/Classes/Extensions/UIApplication+IAM.swift
+++ b/RInAppMessaging/Classes/Extensions/UIApplication+IAM.swift
@@ -22,7 +22,6 @@ extension UIApplication {
                 .compactMap({ $0 as? UIWindowScene })
                 .first {
             return keyScene.statusBarManager?.statusBarStyle
-
         }
 
         // Only iOS 13+ is supported

--- a/RInAppMessaging/Classes/Extensions/UIApplication+IAM.swift
+++ b/RInAppMessaging/Classes/Extensions/UIApplication+IAM.swift
@@ -23,9 +23,9 @@ extension UIApplication {
                 .first {
             return keyScene.statusBarManager?.statusBarStyle
 
-        } else {
-            // Not supported
         }
+
+        // Only iOS 13+ is supported
         return nil
     }
 }

--- a/RInAppMessaging/Classes/Extensions/UIColor+IAM.swift
+++ b/RInAppMessaging/Classes/Extensions/UIColor+IAM.swift
@@ -1,6 +1,14 @@
 /// Extension to `UIColor` class to provide addtional initializers required by InAppMessaging.
 internal extension UIColor {
 
+    static var statusBarOverlayColor: UIColor {
+        if UIApplication.shared.getCurrentStatusBarStyle() == .lightContent {
+            return black.withAlphaComponent(0.4)
+        } else {
+            return white.withAlphaComponent(0.4)
+        }
+    }
+
     /// Convert hexadecimal string to `UIColor` object.
     /// Can fail if string format is invalid.
     ///

--- a/RInAppMessaging/Classes/Protocols/AlertPresentable.swift
+++ b/RInAppMessaging/Classes/Protocols/AlertPresentable.swift
@@ -21,6 +21,6 @@ extension AlertPresentable {
                                       message: message,
                                       preferredStyle: style)
         actions.forEach { alert.addAction($0) }
-        UIApplication.shared.keyWindow?.rootViewController?.present(alert, animated: true)
+        UIApplication.shared.getKeyWindow()?.rootViewController?.present(alert, animated: true)
     }
 }

--- a/RInAppMessaging/Classes/Router.swift
+++ b/RInAppMessaging/Classes/Router.swift
@@ -29,7 +29,7 @@ internal class Router: RouterType {
 
     func discardDisplayedCampaign() {
         DispatchQueue.main.async {
-            guard let rootView = self.getKeyWindow() else {
+            guard let rootView = UIApplication.shared.getKeyWindow() else {
                 return
             }
 
@@ -89,7 +89,7 @@ internal class Router: RouterType {
                     completion(true)
                     return
                 }
-                guard let rootView = self.getKeyWindow(),
+                guard let rootView = UIApplication.shared.getKeyWindow(),
                       self.findPresentedIAMView(from: rootView) == nil else {
                     return
                 }
@@ -128,18 +128,5 @@ internal class Router: RouterType {
         }
 
         return nil
-    }
-
-    private func getKeyWindow() -> UIWindow? {
-        var keySceneWindow: UIWindow?
-        if #available(iOS 13.0, *) {
-            keySceneWindow = UIApplication.shared.connectedScenes
-                .filter({ $0.activationState == .foregroundActive })
-                .compactMap({ $0 as? UIWindowScene })
-                .first?.windows
-                .first(where: { $0.isKeyWindow })
-        }
-
-        return keySceneWindow ?? UIApplication.shared.keyWindow
     }
 }

--- a/RInAppMessaging/Classes/Views/FullScreenView.swift
+++ b/RInAppMessaging/Classes/Views/FullScreenView.swift
@@ -32,7 +32,11 @@ internal class FullScreenView: FullView {
 
         let statusBarBackground = UIView()
         statusBarBackground.translatesAutoresizingMaskIntoConstraints = false
-        statusBarBackground.backgroundColor = UIColor.white.withAlphaComponent(0.4)
+        if UIApplication.shared.getCurrentStatusBarStyle() == .lightContent {
+            statusBarBackground.backgroundColor = UIColor.black.withAlphaComponent(0.4)
+        } else {
+            statusBarBackground.backgroundColor = UIColor.white.withAlphaComponent(0.4)
+        }
 
         contentView.addSubview(statusBarBackground)
         NSLayoutConstraint.activate([

--- a/RInAppMessaging/Classes/Views/FullScreenView.swift
+++ b/RInAppMessaging/Classes/Views/FullScreenView.swift
@@ -1,14 +1,6 @@
 /// Class that initializes the modal view using the passed in campaign information to build the UI.
 internal class FullScreenView: FullView {
 
-    private var statusBarOverlayColor: UIColor {
-        if UIApplication.shared.getCurrentStatusBarStyle() == .lightContent {
-            return UIColor.black.withAlphaComponent(0.4)
-        } else {
-            return UIColor.white.withAlphaComponent(0.4)
-        }
-    }
-
     override var mode: FullViewMode {
         return .fullScreen
     }
@@ -40,7 +32,7 @@ internal class FullScreenView: FullView {
 
         let statusBarBackground = UIView()
         statusBarBackground.translatesAutoresizingMaskIntoConstraints = false
-        statusBarBackground.backgroundColor = statusBarOverlayColor
+        statusBarBackground.backgroundColor = UIColor.statusBarOverlayColor
 
         contentView.addSubview(statusBarBackground)
         NSLayoutConstraint.activate([

--- a/RInAppMessaging/Classes/Views/FullScreenView.swift
+++ b/RInAppMessaging/Classes/Views/FullScreenView.swift
@@ -32,7 +32,7 @@ internal class FullScreenView: FullView {
 
         let statusBarBackground = UIView()
         statusBarBackground.translatesAutoresizingMaskIntoConstraints = false
-        statusBarBackground.backgroundColor = UIColor.statusBarOverlayColor
+        statusBarBackground.backgroundColor = .statusBarOverlayColor
 
         contentView.addSubview(statusBarBackground)
         NSLayoutConstraint.activate([

--- a/RInAppMessaging/Classes/Views/FullScreenView.swift
+++ b/RInAppMessaging/Classes/Views/FullScreenView.swift
@@ -1,6 +1,14 @@
 /// Class that initializes the modal view using the passed in campaign information to build the UI.
 internal class FullScreenView: FullView {
 
+    private var statusBarOverlayColor: UIColor {
+        if UIApplication.shared.getCurrentStatusBarStyle() == .lightContent {
+            return UIColor.black.withAlphaComponent(0.4)
+        } else {
+            return UIColor.white.withAlphaComponent(0.4)
+        }
+    }
+
     override var mode: FullViewMode {
         return .fullScreen
     }
@@ -32,11 +40,7 @@ internal class FullScreenView: FullView {
 
         let statusBarBackground = UIView()
         statusBarBackground.translatesAutoresizingMaskIntoConstraints = false
-        if UIApplication.shared.getCurrentStatusBarStyle() == .lightContent {
-            statusBarBackground.backgroundColor = UIColor.black.withAlphaComponent(0.4)
-        } else {
-            statusBarBackground.backgroundColor = UIColor.white.withAlphaComponent(0.4)
-        }
+        statusBarBackground.backgroundColor = statusBarOverlayColor
 
         contentView.addSubview(statusBarBackground)
         NSLayoutConstraint.activate([

--- a/RInAppMessaging/Classes/Views/SlideUpView.swift
+++ b/RInAppMessaging/Classes/Views/SlideUpView.swift
@@ -10,8 +10,8 @@ internal class SlideUpView: UIView, SlideUpViewType {
         static var messageBodyPadding: UIEdgeInsets {
             var bottomSafeArea = CGFloat(0)
 
-            if #available(iOS 11.0, *) {
-                bottomSafeArea = UIApplication.shared.keyWindow!.safeAreaInsets.bottom
+            if #available(iOS 11.0, *), let keyWindow = UIApplication.shared.getKeyWindow() {
+                bottomSafeArea = keyWindow.safeAreaInsets.bottom
             }
             return UIEdgeInsets(top: 16,
                                 left: 24,

--- a/Tests/UIApplicationExtensionTests.swift
+++ b/Tests/UIApplicationExtensionTests.swift
@@ -1,0 +1,65 @@
+import Quick
+import Nimble
+@testable import RInAppMessaging
+
+class UIApplicationExtensionsTests: QuickSpec {
+
+    override func spec() {
+
+        describe("UIApplication+IAM") {
+
+            let application = UIApplication.shared
+
+            context("when calling getKeyWindow method") {
+
+                let window = UIWindow()
+                let originalWindow = UIApplication.shared.keyWindow
+
+                afterEach {
+                    originalWindow?.makeKeyAndVisible()
+                }
+
+                it("will return current key window (legacy)") {
+                    window.makeKeyAndVisible()
+                    expect(application.getKeyWindow()).to(equal(window))
+                }
+
+                // Tests below will run only on iOS 13+
+                guard #available(iOS 13.0, *) else {
+                    return
+                }
+
+                let scene = application.connectedScenes.first as? UIWindowScene
+
+                it("will return key window from connected scene") {
+                    expect(scene).toNot(beNil())
+                    window.windowScene = scene
+                    window.makeKeyAndVisible()
+                    expect(application.getKeyWindow()).to(equal(window))
+                }
+
+                it("will return key window from connected scene with multiple windows") {
+                    window.windowScene = scene
+                    // keep window references till the end of the test
+                    let windowA = UIWindow(windowScene: scene!)
+                    let windowB = UIWindow(windowScene: scene!)
+                    window.makeKeyAndVisible()
+
+                    expect(scene?.windows.count).to(beGreaterThan(3))
+                    expect(application.getKeyWindow()).to(equal(window))
+                }
+            }
+
+            context("when calling getCurrentStatusBarStyle method") {
+
+                it("will not return nil on iOS 13+") {
+                    if #available(iOS 13.0, *) {
+                        expect(application.statusBarStyle).toNot(beNil())
+                    } else {
+                        expect(application.statusBarStyle).to(beNil())
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
# Description
Unfortunately getting the current status bar style can't be done on iOS versions lower than 13.0.
Then best that can be done usually results in getting `default` style which doesn't help in this feature.

Tested on iOS 14.3 and 11.0.1 simulators

## Links
SDKCF-3175

# Checklist
- [X] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [X] I wrote/updated tests for new/changed code
- [X] I removed all sensitive data **before every commit**, including API endpoints and keys
- [X] I ran `fastlane ci` without errors
