### PR TITLE
improve: improve URLSessionMock

### DIFF
--- a/RInAppMessaging/Classes/Utilities/WeakWrapper.swift
+++ b/RInAppMessaging/Classes/Utilities/WeakWrapper.swift
@@ -1,4 +1,4 @@
-/// Class that stores weak reference to wrapped object.
+/// Class that stores weak reference to the wrapped object.
 /// It can be used used to avoid retain cycles in some cases.
  internal class WeakWrapper<T> {
     // T cannot be restricted to AnyObject in order to support protocols

--- a/Tests/ConfigurationServiceSpec.swift
+++ b/Tests/ConfigurationServiceSpec.swift
@@ -19,7 +19,7 @@ class ConfigurationServiceSpec: QuickSpec {
 
                 service = ConfigurationService(configURL: configURL,
                                                sessionConfiguration: .default)
-                httpSession = URLSessionMock(originalInstance: service.httpSession)
+                httpSession = URLSessionMock.mock(originalInstance: service.httpSession)
             }
 
             afterEach {

--- a/Tests/DisplayPermissionServiceSpec.swift
+++ b/Tests/DisplayPermissionServiceSpec.swift
@@ -41,7 +41,7 @@ class DisplayPermissionServiceSpec: QuickSpec {
                 service = DisplayPermissionService(campaignRepository: campaignRepository,
                                                    preferenceRepository: preferenceRepository,
                                                    configurationRepository: configurationRepository)
-                httpSession = URLSessionMock(originalInstance: service.httpSession)
+                httpSession = URLSessionMock.mock(originalInstance: service.httpSession)
             }
 
             afterEach {

--- a/Tests/HttpRequestableSpec.swift
+++ b/Tests/HttpRequestableSpec.swift
@@ -17,6 +17,10 @@ class HttpRequestableSpec: QuickSpec {
                 httpRequestable = HttpRequestableObject()
             }
 
+            afterEach {
+                httpRequestable = nil // force deallocation of .httpSessionMock
+            }
+
             context("when calling requestFromServerSync") {
 
                 it("will send a reqest using provided URL") {
@@ -612,7 +616,7 @@ enum HttpRequestableObjectError: Error {
 }
 
 private class HttpRequestableObject: HttpRequestable {
-    private(set) var httpSession: URLSession = URLSessionMock(originalInstance: nil)
+    private(set) var httpSession: URLSession = URLSessionMock.mock(originalInstance: .shared)
     var httpSessionMock: URLSessionMock {
         // swiftlint:disable:next force_cast
         return httpSession as! URLSessionMock

--- a/Tests/ImpressionServiceSpec.swift
+++ b/Tests/ImpressionServiceSpec.swift
@@ -41,7 +41,7 @@ class ImpressionServiceSpec: QuickSpec {
                 service = ImpressionService(preferenceRepository: preferenceRepository,
                                             configurationRepository: configurationRepository)
                 service.errorDelegate = errorDelegate
-                httpSession = URLSessionMock(originalInstance: service.httpSession)
+                httpSession = URLSessionMock.mock(originalInstance: service.httpSession)
             }
 
             afterEach {

--- a/Tests/MessageMixerServiceSpec.swift
+++ b/Tests/MessageMixerServiceSpec.swift
@@ -37,7 +37,7 @@ class MessageMixerServiceSpec: QuickSpec {
                 configurationRepository.saveConfiguration(configData)
                 service = MessageMixerService(preferenceRepository: preferenceRepository,
                                               configurationRepository: configurationRepository)
-                httpSession = URLSessionMock(originalInstance: service.httpSession)
+                httpSession = URLSessionMock.mock(originalInstance: service.httpSession)
             }
 
             afterEach {


### PR DESCRIPTION
# Description
The improvement includes:
* Prevent executing real request after returning mocked response
* Mock objects are now deallocated properly
* Resolve a potential issue when another mock object for the same session disables the previous one
* Mock object are now created by a factory than can reuse existing mocks

# Checklist
- [X] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [X] I wrote/updated tests for new/changed code
- [X] I removed all sensitive data **before every commit**, including API endpoints and keys
- [X] I ran `fastlane ci` without errors
