### PR TITLE
fix: update slack webhook

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -96,8 +96,8 @@ workflows:
           {{enveq "BUILD_STATUS_CHANGED" "true"}}
           {{end}}
         inputs:
-        - channel: "$SLACK_CHANNEL"
-        - webhook_url: "$SLACK_URL"
+        - channel: ''
+        - webhook_url: "$SLACK_CHANNEL_WEBHOOK"
         - text: ''
         - title: ''
         - author_name: ''


### PR DESCRIPTION
# Description
`$SLACK_URL` is a default var used by fastlane/scan which we don't want to send any reports to slack.
Slack channel name/id property is not necessary when using a webhook url.
(Tested)

# Checklist
- [X] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [ ] I wrote/updated tests for new/changed code
- [X] I removed all sensitive data **before every commit**, including API endpoints and keys
- [ ] I ran `fastlane ci` without errors
