### PR TITLE
feat: add new API method to close campaign's message manually (SDKCF-3201)

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ The SDK provides 3 public methods for the host applications to use:
 1. `configure()`
 2. `logEvent()`
 3. `registerPreference()`
+4. `closeMessage()`
 
 ### **configure()**  
 This method is called to initialize the SDK and should be placed in your AppDelegate's `didFinishLaunchingWithOptions`.
@@ -111,8 +112,8 @@ A preference is what will allow IAM to identify users for targeting and segmenta
 
 To help IAM identify users, please set a new preference every time a user changes their login state i.e. when they log in or log out.  
 After logout is complete please call  `registerPreference()` with nil parameter.  
-Not all identifiers have to be provided*.  
-**NOTE**: *For our internal users - for user targeting you must provide an accessToken. If you are setting an accessToken you must also provide associated userId in `IAMPreference`.
+Not all identifiers have to be provided.  
+**NOTE:** For our internal users - for user targeting you must provide an accessToken. If you are setting an accessToken you must also provide associated userId in `IAMPreference`.
 
 ```swift
 let preference = IAMPreferenceBuilder()
@@ -123,6 +124,19 @@ let preference = IAMPreferenceBuilder()
 
 RInAppMessaging.registerPreference(preference)
 ```
+
+### **closeMessage()**
+
+In certain cases there might be a need to manually close a campaign's message without user interaction.
+An example is when a different user logs in and the currently displayed campaign does not target the new user.
+(Or when a campaign's message appears after login process has started).
+In that case, to avoid user's confusion, host app can force-close the campaign by calling `closeMessage()` API method.
+
+```swift
+RInAppMessaging.closeMessage()
+```
+**Note:** Calling this API will not increment the campaign's impression (i.e. not counted as displayed).
+
 
 ## **Custom Events**
 

--- a/RInAppMessaging/Classes/InAppMessagingModule.swift
+++ b/RInAppMessaging/Classes/InAppMessagingModule.swift
@@ -84,19 +84,16 @@ internal class InAppMessagingModule: AnalyticsBroadcaster,
         guard isEnabled else {
             return
         }
-
-        let diff = preferenceRepository.preference?.diff(preference)
         preferenceRepository.setPreference(preference)
 
         guard isInitialized else {
             return
         }
-
-        // close campaign only if there was a change in user ids
-        if !(diff == nil || diff == [] || diff == [.accessToken]) {
-            router.discardDisplayedCampaign()
-        }
         campaignsListManager.refreshList()
+    }
+
+    func closeMessage() {
+        router.discardDisplayedCampaign()
     }
 }
 

--- a/RInAppMessaging/Classes/RInAppMessaging.swift
+++ b/RInAppMessaging/Classes/RInAppMessaging.swift
@@ -118,6 +118,15 @@
         }
     }
 
+    /// Close currently displayed campaign's message.
+    /// This method should be called when app needs to force-close the displayed message without user action.
+    /// Campaign's impressions won't be sent (i.e. the message won't be counted as displayed)
+    @objc public static func closeMessage() {
+        inAppQueue?.async(flags: .barrier) {
+            initializedModule?.closeMessage()
+        }
+    }
+
     /// For testing purposes
     internal static func deinitializeModule() {
         inAppQueue?.sync {

--- a/Tests/InAppMessagingModuleSpec.swift
+++ b/Tests/InAppMessagingModuleSpec.swift
@@ -209,33 +209,6 @@ class InAppMessagingModuleSpec: QuickSpec {
                                 iamModule.registerPreference(IAMPreference())
                                 expect(campaignsListManager.wasRefreshListCalled).to(beTrue())
                             }
-
-                            it("will discard displayed campaign if user logs out") {
-                                let preference = IAMPreferenceBuilder().setUserId("user1").build()
-                                iamModule.registerPreference(preference)
-                                iamModule.registerPreference(nil)
-                                expect(router.wasDiscardCampaignCalled).to(beTrue())
-                            }
-
-                            it("will discard displayed campaign if user is changed") {
-                                let preference = IAMPreferenceBuilder().setUserId("user1").build()
-                                iamModule.registerPreference(preference)
-                                let newPreference = IAMPreferenceBuilder().setUserId("user2").build()
-                                iamModule.registerPreference(newPreference)
-                                expect(router.wasDiscardCampaignCalled).to(beTrue())
-                            }
-
-                            it("will not discard displayed campaign if user hasn't changed") {
-                                let preference = IAMPreferenceBuilder().setUserId("user1").setAccessToken("token1").build()
-                                iamModule.registerPreference(preference)
-                                let newPreference = IAMPreferenceBuilder().setUserId("user1").setAccessToken("token1").build()
-                                iamModule.registerPreference(newPreference)
-                                expect(router.wasDiscardCampaignCalled).toAfterTimeout(beFalse())
-
-                                let newPreferenceToken = IAMPreferenceBuilder().setUserId("user1").setAccessToken("token2").build()
-                                iamModule.registerPreference(newPreferenceToken)
-                                expect(router.wasDiscardCampaignCalled).toAfterTimeout(beFalse())
-                            }
                         }
 
                         context("and module is not initialized") {
@@ -269,6 +242,14 @@ class InAppMessagingModuleSpec: QuickSpec {
                             iamModule.registerPreference(IAMPreference())
                             expect(campaignsListManager.wasRefreshListCalled).toAfterTimeout(beFalse())
                         }
+                    }
+                }
+
+                context("when calling closeMessage") {
+
+                    it("will discard displayed campaign even if module is not initialized") {
+                        iamModule.closeMessage()
+                        expect(router.wasDiscardCampaignCalled).to(beTrue())
                     }
                 }
 

--- a/Tests/RouterSpec.swift
+++ b/Tests/RouterSpec.swift
@@ -115,7 +115,7 @@ class RouterSpec: QuickSpec {
                 }
             }
 
-            context("when calling displayCampaign") {
+            context("when calling discardDisplayedCampaign") {
 
                 it("will remove displayed campaign view") {
                     let campaign = TestHelpers.generateCampaign(id: "test", type: .modal)


### PR DESCRIPTION
# Description
Campaign's message can be closed manually now. It will not be closed automatically anymore (e.g. after logout)

## Links
SDKCF-3021

# Checklist
- [X] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [X] I wrote/updated tests for new/changed code
- [X] I removed all sensitive data **before every commit**, including API endpoints and keys
- [X] I ran `fastlane ci` without errors
