### PR TITLE
feat: use status bar overlay in all Full Screen type view layouts (SDKCF-3203)

### DIFF
--- a/RInAppMessaging/Classes/Views/FullScreenView.swift
+++ b/RInAppMessaging/Classes/Views/FullScreenView.swift
@@ -26,10 +26,6 @@ internal class FullScreenView: FullView {
     override func setup(viewModel: FullViewModel) {
         super.setup(viewModel: viewModel)
 
-        guard hasImage else {
-            return
-        }
-
         let statusBarBackground = UIView()
         statusBarBackground.translatesAutoresizingMaskIntoConstraints = false
         statusBarBackground.backgroundColor = .statusBarOverlayColor


### PR DESCRIPTION
# Description
Previously status bar overlay in Full Screen message type was intended for image-only and image + text layouts.
Now it's present also in text-only layout.

## Links
SDKCF-3203

# Checklist
- [X] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [ ] I wrote/updated tests for new/changed code
- [X] I removed all sensitive data **before every commit**, including API endpoints and keys
- [ ] I ran `fastlane ci` without errors
