### PR TITLE
fix: fix status bar height calculation in landscape mode (SDKCF-3203)

### DIFF
--- a/RInAppMessaging/Classes/Views/FullScreenView.swift
+++ b/RInAppMessaging/Classes/Views/FullScreenView.swift
@@ -1,6 +1,8 @@
 /// Class that initializes the modal view using the passed in campaign information to build the UI.
 internal class FullScreenView: FullView {
 
+    private weak var statusBarBackgroundHeightConstraint: NSLayoutConstraint?
+
     override var mode: FullViewMode {
         return .fullScreen
     }
@@ -30,12 +32,22 @@ internal class FullScreenView: FullView {
         statusBarBackground.translatesAutoresizingMaskIntoConstraints = false
         statusBarBackground.backgroundColor = .statusBarOverlayColor
 
+        let heightConstraint = statusBarBackground.heightAnchor.constraint(
+            equalToConstant: UIApplication.shared.statusBarFrame.height)
+        statusBarBackgroundHeightConstraint = heightConstraint
+
         contentView.addSubview(statusBarBackground)
         NSLayoutConstraint.activate([
             statusBarBackground.topAnchor.constraint(equalTo: contentView.topAnchor),
             statusBarBackground.leftAnchor.constraint(equalTo: contentView.leftAnchor),
             statusBarBackground.rightAnchor.constraint(equalTo: contentView.rightAnchor),
-            statusBarBackground.heightAnchor.constraint(equalToConstant: UIApplication.shared.statusBarFrame.height)
+            heightConstraint
         ])
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        // statusBarFrame.height is 0 when status bar is hidden
+        statusBarBackgroundHeightConstraint?.constant = UIApplication.shared.statusBarFrame.height
     }
 }

--- a/RInAppMessaging/Classes/Views/FullView.swift
+++ b/RInAppMessaging/Classes/Views/FullView.swift
@@ -85,6 +85,14 @@ internal class FullView: UIView, FullViewType, RichContentBrowsable {
         fatalError("init(coder:) has not been implemented")
     }
 
+    override func layoutSubviews() {
+        super.layoutSubviews()
+
+        updateUIConstants()
+        exitButtonYPositionConstraint.constant = uiConstants.exitButtonVerticalOffset
+        bodyViewOffsetYConstraint.constant = hasImage ? 0 : uiConstants.bodyViewSafeAreaOffsetY
+    }
+
     func setup(viewModel: FullViewModel) {
 
         removeAllSubviews()


### PR DESCRIPTION
# Description
This is a fix for Full-screen campaigns when:
* status bar overlay was present after transitioning to landscape mode where status bar got hidden.
* exit button and other elements position wasn't updated when transitioning between screen orientation modes.

## Links
SDKCF-3203

# Checklist
- [X] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [ ] I wrote/updated tests for new/changed code
- [X] I removed all sensitive data **before every commit**, including API endpoints and keys
- [ ] I ran `fastlane ci` without errors
