### PR TITLE
feat: extend closeMessage() API method to close all queued campaigns (SDKCF-3201)

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,9 +131,10 @@ In certain cases there might be a need to manually close a campaign's message wi
 An example is when a different user logs in and the currently displayed campaign does not target the new user.
 (Or when a campaign's message appears after login process has started).
 In that case, to avoid user's confusion, host app can force-close the campaign by calling `closeMessage()` API method.
+The `clearQueuedCampaigns` optional parameter, when set to `true` (`false` by default), will additionally remove all campaigns that were queued to be displayed.
 
 ```swift
-RInAppMessaging.closeMessage()
+RInAppMessaging.closeMessage(clearQueuedCampaigns: true)
 ```
 **Note:** Calling this API will not increment the campaign's impression (i.e. not counted as displayed).
 

--- a/RInAppMessaging/Classes/Extensions/UIView+IAM.swift
+++ b/RInAppMessaging/Classes/Extensions/UIView+IAM.swift
@@ -21,10 +21,10 @@ extension UIView {
         subviews.forEach { $0.removeFromSuperview() }
     }
 
-    func findIAMViewSubview() -> UIView? {
+    func findIAMViewSubview() -> BaseView? {
         for subview in subviews {
-            if subview is BaseView {
-                return subview
+            if let iamView = subview as? BaseView {
+                return iamView
             } else if let iamView = subview.findIAMViewSubview() {
                 return iamView
             }

--- a/RInAppMessaging/Classes/InAppMessagingModule.swift
+++ b/RInAppMessaging/Classes/InAppMessagingModule.swift
@@ -10,6 +10,7 @@ internal class InAppMessagingModule: AnalyticsBroadcaster,
     private var readyCampaignDispatcher: CampaignDispatcherType
     private var impressionService: ImpressionServiceType
     private let campaignTriggerAgent: CampaignTriggerAgentType
+    private let campaignRepository: CampaignRepositoryType
     private let router: RouterType
 
     private var isInitialized = false
@@ -26,6 +27,7 @@ internal class InAppMessagingModule: AnalyticsBroadcaster,
          eventMatcher: EventMatcherType,
          readyCampaignDispatcher: CampaignDispatcherType,
          campaignTriggerAgent: CampaignTriggerAgentType,
+         campaignRepository: CampaignRepositoryType,
          router: RouterType) {
 
         self.configurationManager = configurationManager
@@ -36,6 +38,7 @@ internal class InAppMessagingModule: AnalyticsBroadcaster,
         self.readyCampaignDispatcher = readyCampaignDispatcher
         self.impressionService = impressionService
         self.campaignTriggerAgent = campaignTriggerAgent
+        self.campaignRepository = campaignRepository
         self.router = router
 
         self.configurationManager.errorDelegate = self
@@ -92,8 +95,13 @@ internal class InAppMessagingModule: AnalyticsBroadcaster,
         campaignsListManager.refreshList()
     }
 
-    func closeMessage() {
-        router.discardDisplayedCampaign()
+    func closeMessage(clearQueuedCampaigns: Bool) {
+        if clearQueuedCampaigns {
+            readyCampaignDispatcher.resetQueue()
+        }
+        if let campaign = router.discardDisplayedCampaign() {
+            campaignRepository.incrementImpressionsLeftInCampaign(campaign)
+        }
     }
 }
 

--- a/RInAppMessaging/Classes/RInAppMessaging.swift
+++ b/RInAppMessaging/Classes/RInAppMessaging.swift
@@ -75,6 +75,7 @@
                 let campaignsValidator = dependencyManager.resolve(type: CampaignsValidatorType.self),
                 let readyCampaignDispatcher = dependencyManager.resolve(type: CampaignDispatcherType.self),
                 let campaignTriggerAgent = dependencyManager.resolve(type: CampaignTriggerAgentType.self),
+                let campaignRepository = dependencyManager.resolve(type: CampaignRepositoryType.self),
                 let router = dependencyManager.resolve(type: RouterType.self) else {
 
                     assertionFailure("In-App Messaging SDK module initialization failure: Dependencies could not be resolved")
@@ -90,6 +91,7 @@
                                                      eventMatcher: eventMatcher,
                                                      readyCampaignDispatcher: readyCampaignDispatcher,
                                                      campaignTriggerAgent: campaignTriggerAgent,
+                                                     campaignRepository: campaignRepository,
                                                      router: router)
             initializedModule?.aggregatedErrorHandler = { error in
                 errorDelegate?.inAppMessagingDidReturnError(error)
@@ -121,9 +123,11 @@
     /// Close currently displayed campaign's message.
     /// This method should be called when app needs to force-close the displayed message without user action.
     /// Campaign's impressions won't be sent (i.e. the message won't be counted as displayed)
-    @objc public static func closeMessage() {
+    /// - Parameter clearQueuedCampaigns: when set to true, it will clear also the list of campaigns that were
+    ///                                   triggered and are queued to be displayed.
+    @objc public static func closeMessage(clearQueuedCampaigns: Bool = false) {
         inAppQueue?.async(flags: .barrier) {
-            initializedModule?.closeMessage()
+            initializedModule?.closeMessage(clearQueuedCampaigns: clearQueuedCampaigns)
         }
     }
 

--- a/RInAppMessaging/Classes/Views/BaseView.swift
+++ b/RInAppMessaging/Classes/Views/BaseView.swift
@@ -5,11 +5,12 @@ import func Foundation.NSClassFromString
 internal protocol BaseView: UIView {
 
     static var viewIdentifier: String { get }
-    var onDismiss: (() -> Void)? { get set }
+    var onDismiss: ((_ cancelled: Bool) -> Void)? { get set }
+    var basePresenter: BaseViewPresenterType { get }
 
     func show(accessibilityCompatible: Bool,
               parentView: UIView,
-              onDismiss: @escaping () -> Void)
+              onDismiss: @escaping (_ cancelled: Bool) -> Void)
     func animateOnShow(completion: @escaping () -> Void)
     func dismiss()
     func constraintsForParent(_ parent: UIView) -> [NSLayoutConstraint]
@@ -21,7 +22,7 @@ internal extension BaseView {
 
     func show(accessibilityCompatible: Bool,
               parentView: UIView,
-              onDismiss: @escaping () -> Void) {
+              onDismiss: @escaping ((_ cancelled: Bool) -> Void)) {
 
         self.onDismiss = onDismiss
         displayView(accessibilityCompatible: accessibilityCompatible, parentView: parentView)
@@ -29,7 +30,7 @@ internal extension BaseView {
 
     func dismiss() {
         removeFromSuperview()
-        onDismiss?()
+        onDismiss?(false)
     }
 
     private func displayView(accessibilityCompatible: Bool, parentView: UIView) {

--- a/RInAppMessaging/Classes/Views/FullView.swift
+++ b/RInAppMessaging/Classes/Views/FullView.swift
@@ -65,7 +65,10 @@ internal class FullView: UIView, FullViewType, RichContentBrowsable {
     var isOptOutChecked: Bool {
         return !optOutView.isHidden && optOutView.isChecked
     }
-    var onDismiss: (() -> Void)?
+    var onDismiss: ((_ cancelled: Bool) -> Void)?
+    var basePresenter: BaseViewPresenterType {
+        return presenter
+    }
 
     private(set) var hasImage = false {
         didSet {

--- a/RInAppMessaging/Classes/Views/SlideUpView.swift
+++ b/RInAppMessaging/Classes/Views/SlideUpView.swift
@@ -17,7 +17,10 @@ internal class SlideUpView: UIView, SlideUpViewType {
         }
     }
 
-    var onDismiss: (() -> Void)?
+    var onDismiss: ((_ cancelled: Bool) -> Void)?
+    var basePresenter: BaseViewPresenterType {
+        return presenter
+    }
 
     private let presenter: SlideUpViewPresenterType
     private let dialogView = UIView()

--- a/Tests/Helpers/SharedMocks.swift
+++ b/Tests/Helpers/SharedMocks.swift
@@ -46,12 +46,16 @@ class CampaignDispatcherMock: CampaignDispatcherType {
     weak var delegate: CampaignDispatcherDelegate?
     private(set) var wasDispatchCalled = false
     private(set) var addedCampaigns = [Campaign]()
+    private(set) var wasResetQueueCalled = false
 
     func addToQueue(campaign: Campaign) {
         addedCampaigns.append(campaign)
     }
     func dispatchAllIfNeeded() {
         wasDispatchCalled = true
+    }
+    func resetQueue() {
+        wasResetQueueCalled = true
     }
 }
 
@@ -314,8 +318,9 @@ class RouterMock: RouterType {
         completion(false)
     }
 
-    func discardDisplayedCampaign() {
+    func discardDisplayedCampaign() -> Campaign? {
         wasDiscardCampaignCalled = true
+        return lastDisplayedCampaign
     }
 }
 

--- a/Tests/ReadyCampaignDispatcherSpec.swift
+++ b/Tests/ReadyCampaignDispatcherSpec.swift
@@ -211,6 +211,32 @@ class ReadyCampaignDispatcherSpec: QuickSpec {
                         expect(delegate.wasShouldShowCalled).toAfterTimeout(beFalse())
                     }
                 }
+
+                context("and resetQueue is called") {
+
+                    let testCampaigns = TestHelpers.MockResponse.withGeneratedCampaigns(count: 3, test: true, delay: 1000).data
+
+                    beforeEach {
+                        dispatcher.addToQueue(campaign: testCampaigns[0])
+                        dispatcher.addToQueue(campaign: testCampaigns[1])
+                        dispatcher.dispatchAllIfNeeded()
+                    }
+
+                    it("will stop dispatching") {
+                        expect(dispatcher.isDispatching).toEventually(beTrue())
+                        dispatcher.resetQueue()
+                        expect(dispatcher.isDispatching).toEventually(beFalse())
+                    }
+
+                    it("will remove all queued campaigns") {
+                        expect(dispatcher.isDispatching).toEventually(beTrue()) // wait
+                        dispatcher.resetQueue()
+                        dispatcher.addToQueue(campaign: testCampaigns[2])
+                        dispatcher.dispatchAllIfNeeded()
+                        expect(router.lastDisplayedCampaign).toEventually(equal(testCampaigns[2]))
+                        expect(router.displayedCampaignsCount).to(equal(2))
+                    }
+                }
             }
 
             context("after dispatching") {

--- a/Tests/RouterSpec.swift
+++ b/Tests/RouterSpec.swift
@@ -122,21 +122,23 @@ class RouterSpec: QuickSpec {
                     router.displayCampaign(campaign, confirmation: true, completion: { _ in })
                     expect(UIApplication.shared.keyWindow?.subviews)
                         .toEventually(containElementSatisfying({ $0 is BaseView }))
-                    router.discardDisplayedCampaign()
+                    let closedCampaignView = router.discardDisplayedCampaign()
+                    expect(closedCampaignView).toNot(beNil())
                     expect(UIApplication.shared.keyWindow?.subviews)
                         .toEventuallyNot(containElementSatisfying({ $0 is BaseView }))
                 }
 
-                it("will not call onDismiss/completion callback") {
+                it("will call onDismiss/completion callback with cancelled flag") {
                     let campaign = TestHelpers.generateCampaign(id: "test", type: .modal)
                     var completionCalled = false
-                    router.displayCampaign(campaign, confirmation: true, completion: { _ in
+                    router.displayCampaign(campaign, confirmation: true, completion: { cancelled in
                         completionCalled = true
+                        expect(cancelled).to(beTrue())
                     })
                     expect(UIApplication.shared.keyWindow?.subviews)
                         .toEventually(containElementSatisfying({ $0 is BaseView }))
-                    router.discardDisplayedCampaign()
-                    expect(completionCalled).toAfterTimeout(beFalse())
+                    _ = router.discardDisplayedCampaign()
+                    expect(completionCalled).toEventually(beTrue())
                 }
             }
         }

--- a/Tests/ViewPresenterSpec.swift
+++ b/Tests/ViewPresenterSpec.swift
@@ -336,8 +336,10 @@ class ViewPresenterSpec: QuickSpec {
 }
 
 private class FullViewMock: UIView, FullViewType {
+
     var isOptOutChecked: Bool = false
-    var onDismiss: (() -> Void)?
+    var onDismiss: ((_ cancelled: Bool) -> Void)?
+    var basePresenter: BaseViewPresenterType = BaseViewPresenterMock()
 
     private(set) var wasSetupCalled = false
     private(set) var wasDismissCalled = false
@@ -360,7 +362,8 @@ private class FullViewMock: UIView, FullViewType {
 }
 
 private class SlideUpViewMock: UIView, SlideUpViewType {
-    var onDismiss: (() -> Void)?
+    var onDismiss: ((_ cancelled: Bool) -> Void)?
+    var basePresenter: BaseViewPresenterType = BaseViewPresenterMock()
 
     private(set) var wasSetupCalled = false
     private(set) var wasDismissCalled = false


### PR DESCRIPTION
# Description
added `clearQueuedCampaigns` parameter to `closeMessage()` API method.

## Links
SDKCF-3201

# Checklist
- [X] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [X] I wrote/updated tests for new/changed code
- [X] I removed all sensitive data **before every commit**, including API endpoints and keys
- [X] I ran `fastlane ci` without errors
