### PR TITLE
fix: update status bar overlay color when orientation is changed (SDKCF-3203)

### DIFF
--- a/RInAppMessaging/Classes/Views/FullScreenView.swift
+++ b/RInAppMessaging/Classes/Views/FullScreenView.swift
@@ -1,7 +1,16 @@
+import UIKit
+
 /// Class that initializes the modal view using the passed in campaign information to build the UI.
 internal class FullScreenView: FullView {
 
-    private weak var statusBarBackgroundHeightConstraint: NSLayoutConstraint?
+    private lazy var statusBarBackgroundView: UIView = {
+        let backgroundView = UIView()
+        backgroundView.translatesAutoresizingMaskIntoConstraints = false
+        backgroundView.backgroundColor = .statusBarOverlayColor
+        return backgroundView
+    }()
+    private lazy var statusBarBackgroundViewHeightConstraint = statusBarBackgroundView.heightAnchor
+        .constraint(equalToConstant: UIApplication.shared.statusBarFrame.height)
 
     override var mode: FullViewMode {
         return .fullScreen
@@ -28,26 +37,20 @@ internal class FullScreenView: FullView {
     override func setup(viewModel: FullViewModel) {
         super.setup(viewModel: viewModel)
 
-        let statusBarBackground = UIView()
-        statusBarBackground.translatesAutoresizingMaskIntoConstraints = false
-        statusBarBackground.backgroundColor = .statusBarOverlayColor
-
-        let heightConstraint = statusBarBackground.heightAnchor.constraint(
-            equalToConstant: UIApplication.shared.statusBarFrame.height)
-        statusBarBackgroundHeightConstraint = heightConstraint
-
-        contentView.addSubview(statusBarBackground)
+        contentView.addSubview(statusBarBackgroundView)
         NSLayoutConstraint.activate([
-            statusBarBackground.topAnchor.constraint(equalTo: contentView.topAnchor),
-            statusBarBackground.leftAnchor.constraint(equalTo: contentView.leftAnchor),
-            statusBarBackground.rightAnchor.constraint(equalTo: contentView.rightAnchor),
-            heightConstraint
+            statusBarBackgroundView.topAnchor.constraint(equalTo: contentView.topAnchor),
+            statusBarBackgroundView.leftAnchor.constraint(equalTo: contentView.leftAnchor),
+            statusBarBackgroundView.rightAnchor.constraint(equalTo: contentView.rightAnchor),
+            statusBarBackgroundViewHeightConstraint
         ])
     }
 
     override func layoutSubviews() {
         super.layoutSubviews()
+
+        statusBarBackgroundView.backgroundColor = .statusBarOverlayColor
         // statusBarFrame.height is 0 when status bar is hidden
-        statusBarBackgroundHeightConstraint?.constant = UIApplication.shared.statusBarFrame.height
+        statusBarBackgroundViewHeightConstraint.constant = UIApplication.shared.statusBarFrame.height
     }
 }

--- a/RInAppMessaging/Classes/Views/ModalView.swift
+++ b/RInAppMessaging/Classes/Views/ModalView.swift
@@ -1,3 +1,5 @@
+import UIKit
+
 /// Class that initializes the modal view using the passed in campaign information to build the UI.
 internal class ModalView: FullView {
 

--- a/RInAppMessaging/Classes/Views/SlideUpView.swift
+++ b/RInAppMessaging/Classes/Views/SlideUpView.swift
@@ -1,3 +1,5 @@
+import UIKit
+
 /// SlideUpView for InAppMessaging campaign.
 internal class SlideUpView: UIView, SlideUpViewType {
 


### PR DESCRIPTION
# Description
Color update is needed because at the moment of `setup()` in `FullScreenView` the status bar information (color, height) might be outdated. That can happen when app is started in landscape mode, where status bar is hidden, and then orientation is changed to portrait after campaign has been displayed.
Added UIKit imports for consistency.

Tested on iOS Simulator.

## Links
SDKCF-3203

# Checklist
- [X] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [ ] I wrote/updated tests for new/changed code
- [X] I removed all sensitive data **before every commit**, including API endpoints and keys
- [X] I ran `fastlane ci` without errors
