### PR TITLE
fix: fix GetConfig models to match backend API contract

### DIFF
--- a/.jazzy.yaml
+++ b/.jazzy.yaml
@@ -5,7 +5,7 @@ module_version: 3.0.0
 module: RInAppMessaging
 xcodebuild_arguments:
   - -workspace
-  - RInAppMessaging.xcworkspace.xcworkspace
+  - RInAppMessaging.xcworkspace
   - -scheme
   - RInAppMessaging-Example
 podspec: RInAppMessaging.podspec

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,8 +1,8 @@
 PODS:
   - Nimble (9.0.0)
-  - Quick (3.0.0)
+  - Quick (3.1.2)
   - RInAppMessaging (3.0.0)
-  - SwiftLint (0.42.0)
+  - SwiftLint (0.43.1)
 
 DEPENDENCIES:
   - Nimble
@@ -22,9 +22,9 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Nimble: 3b4ec3fd40f1dc178058e0981107721c615643d8
-  Quick: 6d9559f40647bc4d510103842ef2fdd882d753e2
+  Quick: 60f0ea3b8e0cfc0df3259a5c06a238ad8b3c46e0
   RInAppMessaging: c71ee2432ac1e0031e575dd56909e972626f79a4
-  SwiftLint: 4fa9579c63416865179bc416f0a92d55f009600d
+  SwiftLint: 99f82d07b837b942dd563c668de129a03fc3fb52
 
 PODFILE CHECKSUM: 16bc5c166162d97d8cbb769a79595dc56529493a
 

--- a/RInAppMessaging.xcodeproj/project.pbxproj
+++ b/RInAppMessaging.xcodeproj/project.pbxproj
@@ -13,7 +13,6 @@
 		4534947223C6ABF700189A81 /* SerializationSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4534947123C6ABF700189A81 /* SerializationSpec.swift */; };
 		45357AE52457EBBC007D8FDC /* config_success.json in Resources */ = {isa = PBXBuildFile; fileRef = 45357AE42457EBBC007D8FDC /* config_success.json */; };
 		45357AE72458361F007D8FDC /* config_success_optional.json in Resources */ = {isa = PBXBuildFile; fileRef = 45357AE62458361F007D8FDC /* config_success_optional.json */; };
-		45357AEA245A69FD007D8FDC /* config_fail_ping.json in Resources */ = {isa = PBXBuildFile; fileRef = 45357AE8245A69FC007D8FDC /* config_fail_ping.json */; };
 		45357AEB245A69FD007D8FDC /* config_fail_enabled.json in Resources */ = {isa = PBXBuildFile; fileRef = 45357AE9245A69FD007D8FDC /* config_fail_enabled.json */; };
 		45357AED245A8C57007D8FDC /* ping_success.json in Resources */ = {isa = PBXBuildFile; fileRef = 45357AEC245A8C57007D8FDC /* ping_success.json */; };
 		45357AF0245A8CAA007D8FDC /* ping_success_empty.json in Resources */ = {isa = PBXBuildFile; fileRef = 45357AEE245A8CAA007D8FDC /* ping_success_empty.json */; };
@@ -21,6 +20,7 @@
 		45357AF4245AC836007D8FDC /* displayPermission_invalid.json in Resources */ = {isa = PBXBuildFile; fileRef = 45357AF2245AC836007D8FDC /* displayPermission_invalid.json */; };
 		45357AF5245AC836007D8FDC /* displayPermission_success.json in Resources */ = {isa = PBXBuildFile; fileRef = 45357AF3245AC836007D8FDC /* displayPermission_success.json */; };
 		45357AF7245AD49E007D8FDC /* HttpRequestableSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45357AF6245AD49E007D8FDC /* HttpRequestableSpec.swift */; };
+		4538BAE326282DE4009952BE /* GetConfigResponseSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4538BAE226282DE4009952BE /* GetConfigResponseSpec.swift */; };
 		45491059247F58660019864D /* CustomAttributeSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45491058247F58660019864D /* CustomAttributeSpec.swift */; };
 		45563B03240614AE004EAFD3 /* ReadyCampaignDispatcherSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45563B02240614AE004EAFD3 /* ReadyCampaignDispatcherSpec.swift */; };
 		45563B0724064D78004EAFD3 /* CampaignRepositorySpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45563B0624064D78004EAFD3 /* CampaignRepositorySpec.swift */; };
@@ -89,7 +89,6 @@
 		4534947123C6ABF700189A81 /* SerializationSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SerializationSpec.swift; sourceTree = "<group>"; };
 		45357AE42457EBBC007D8FDC /* config_success.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = config_success.json; sourceTree = "<group>"; };
 		45357AE62458361F007D8FDC /* config_success_optional.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = config_success_optional.json; sourceTree = "<group>"; };
-		45357AE8245A69FC007D8FDC /* config_fail_ping.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = config_fail_ping.json; sourceTree = "<group>"; };
 		45357AE9245A69FD007D8FDC /* config_fail_enabled.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = config_fail_enabled.json; sourceTree = "<group>"; };
 		45357AEC245A8C57007D8FDC /* ping_success.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = ping_success.json; sourceTree = "<group>"; };
 		45357AEE245A8CAA007D8FDC /* ping_success_empty.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = ping_success_empty.json; sourceTree = "<group>"; };
@@ -97,6 +96,7 @@
 		45357AF2245AC836007D8FDC /* displayPermission_invalid.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = displayPermission_invalid.json; sourceTree = "<group>"; };
 		45357AF3245AC836007D8FDC /* displayPermission_success.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = displayPermission_success.json; sourceTree = "<group>"; };
 		45357AF6245AD49E007D8FDC /* HttpRequestableSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HttpRequestableSpec.swift; sourceTree = "<group>"; };
+		4538BAE226282DE4009952BE /* GetConfigResponseSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetConfigResponseSpec.swift; sourceTree = "<group>"; };
 		45491058247F58660019864D /* CustomAttributeSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomAttributeSpec.swift; sourceTree = "<group>"; };
 		45563B02240614AE004EAFD3 /* ReadyCampaignDispatcherSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadyCampaignDispatcherSpec.swift; sourceTree = "<group>"; };
 		45563B0624064D78004EAFD3 /* CampaignRepositorySpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CampaignRepositorySpec.swift; sourceTree = "<group>"; };
@@ -183,7 +183,6 @@
 				45357AE42457EBBC007D8FDC /* config_success.json */,
 				45357AE62458361F007D8FDC /* config_success_optional.json */,
 				45357AE9245A69FD007D8FDC /* config_fail_enabled.json */,
-				45357AE8245A69FC007D8FDC /* config_fail_ping.json */,
 				45357AEC245A8C57007D8FDC /* ping_success.json */,
 				45357AEE245A8CAA007D8FDC /* ping_success_empty.json */,
 				45357AEF245A8CAA007D8FDC /* ping_invalid.json */,
@@ -279,6 +278,7 @@
 				459B228124528A7D00D218CE /* DisplayPermissionServiceSpec.swift */,
 				456FE1E62428513200304872 /* ErrorReportableSpec.swift */,
 				459DE86924074F720002F451 /* EventMatcherSpec.swift */,
+				4538BAE226282DE4009952BE /* GetConfigResponseSpec.swift */,
 				45357AF6245AD49E007D8FDC /* HttpRequestableSpec.swift */,
 				4557A8B0257E544C00C9D241 /* IAMPreferenceSpec.swift */,
 				D911DC56211159DE0082B950 /* IdRegistrationSpec.swift */,
@@ -455,7 +455,6 @@
 				45357AF1245A8CAA007D8FDC /* ping_invalid.json in Resources */,
 				45357AF0245A8CAA007D8FDC /* ping_success_empty.json in Resources */,
 				45357AF4245AC836007D8FDC /* displayPermission_invalid.json in Resources */,
-				45357AEA245A69FD007D8FDC /* config_fail_ping.json in Resources */,
 				45357AE72458361F007D8FDC /* config_success_optional.json in Resources */,
 				45357AED245A8C57007D8FDC /* ping_success.json in Resources */,
 				45357AEB245A69FD007D8FDC /* config_fail_enabled.json in Resources */,
@@ -543,6 +542,7 @@
 				4516601223CD411300310181 /* DependencyManagerSpec.swift in Sources */,
 				45563B0724064D78004EAFD3 /* CampaignRepositorySpec.swift in Sources */,
 				456FE1EB2428C51E00304872 /* CommonUtilitySpec.swift in Sources */,
+				4538BAE326282DE4009952BE /* GetConfigResponseSpec.swift in Sources */,
 				45ADA53E247CFE9E00A9E2A3 /* ConfigurationRepositorySpec.swift in Sources */,
 				45EA720D25B72002001B2049 /* UIViewExtensionSpec.swift in Sources */,
 				459B227E24528A5100D218CE /* MessageMixerServiceSpec.swift in Sources */,

--- a/RInAppMessaging/Classes/Models/Responses/GetConfigResponse.swift
+++ b/RInAppMessaging/Classes/Models/Responses/GetConfigResponse.swift
@@ -4,11 +4,11 @@ internal struct GetConfigResponse: Decodable {
 
 internal struct ConfigData: Decodable {
     let enabled: Bool
-    let endpoints: EndpointURL
+    let endpoints: EndpointURL?
 }
 
 internal struct EndpointURL: Decodable, Equatable {
-    let ping: URL
+    let ping: URL?
     let displayPermission: URL?
     let impression: URL?
 }

--- a/Sample/Example-Release.xcconfig
+++ b/Sample/Example-Release.xcconfig
@@ -1,4 +1,4 @@
 #include "Pods/Target Support Files/Pods-RInAppMessaging_Example/Pods-RInAppMessaging_Example.release.xcconfig"
 
-// IMPORTANT: Secrets MUST be added to Example-Secrets.xcconfig and that file MUST NOT be added to git.
+// IMPORTANT: Secrets MUST be added to below xcconfig file and that file MUST NOT be added to git.
 #include "../../InAppMessaging-Secrets.xcconfig"

--- a/Tests/ConfigurationServiceSpec.swift
+++ b/Tests/ConfigurationServiceSpec.swift
@@ -69,7 +69,7 @@ class ConfigurationServiceSpec: QuickSpec {
                         httpSession.responseData = TestHelpers.getJSONData(fileName: "config_success")
                         fetchConfig()
 
-                        expect(configModel?.endpoints.ping)
+                        expect(configModel?.endpoints?.ping)
                             .to(equal(URL( string: "https://endpoint.com/ping")!))
                     }
 
@@ -77,7 +77,7 @@ class ConfigurationServiceSpec: QuickSpec {
                         httpSession.responseData = TestHelpers.getJSONData(fileName: "config_success")
                         fetchConfig()
 
-                        expect(configModel?.endpoints.impression)
+                        expect(configModel?.endpoints?.impression)
                             .to(equal(URL( string: "https://endpoint.com/impression")!))
                     }
 
@@ -85,7 +85,7 @@ class ConfigurationServiceSpec: QuickSpec {
                         httpSession.responseData = TestHelpers.getJSONData(fileName: "config_success")
                         fetchConfig()
 
-                        expect(configModel?.endpoints.displayPermission)
+                        expect(configModel?.endpoints?.displayPermission)
                             .to(equal(URL( string: "https://endpoint.com/display_permission")!))
                     }
 
@@ -93,8 +93,8 @@ class ConfigurationServiceSpec: QuickSpec {
                         httpSession.responseData = TestHelpers.getJSONData(fileName: "config_success_optional")
                         fetchConfig()
 
-                        expect(configModel?.endpoints.ping)
-                            .to(equal(URL( string: "https://endpoint.com/ping")!))
+                        expect(configModel).toNot(beNil())
+                        expect(configModel?.endpoints).to(beNil())
                     }
                 }
 
@@ -102,25 +102,6 @@ class ConfigurationServiceSpec: QuickSpec {
 
                     it("will return .jsonDecodingError when `enabled` is missing") {
                         httpSession.responseData = TestHelpers.getJSONData(fileName: "config_fail_enabled")
-
-                        waitUntil { done in
-                            requestQueue.async {
-                                let result = service.getConfigData()
-                                let error = result.getError()
-                                expect(error).toNot(beNil())
-
-                                guard case .jsonDecodingError = error else {
-                                    fail("Unexpected error type \(String(describing: error)). Expected .jsonDecodingError")
-                                    done()
-                                    return
-                                }
-                                done()
-                            }
-                        }
-                    }
-
-                    it("will return .jsonDecodingError when ping endpoint is missing") {
-                        httpSession.responseData = TestHelpers.getJSONData(fileName: "config_fail_ping")
 
                         waitUntil { done in
                             requestQueue.async {

--- a/Tests/ConfigurationSpec.swift
+++ b/Tests/ConfigurationSpec.swift
@@ -34,8 +34,11 @@ class ConfigurationSpec: QuickSpec {
 
             context("when configuration returned false") {
 
-                it("will disable module") {
+                beforeEach {
                     configurationManager.isConfigEnabled = false
+                }
+
+                it("will disable module") {
                     waitUntil { done in
                         configurationManager.fetchCalledClosure = {
                             expect(RInAppMessaging.initializedModule).toNot(beNil())
@@ -48,7 +51,6 @@ class ConfigurationSpec: QuickSpec {
                 }
 
                 it("will not call ping") {
-                    configurationManager.isConfigEnabled = false
                     RInAppMessaging.configure(dependencyManager: dependencyManager)
 
                     expect(mockMessageMixer.wasPingCalled).toAfterTimeout(beFalse())

--- a/Tests/DisplayPermissionServiceSpec.swift
+++ b/Tests/DisplayPermissionServiceSpec.swift
@@ -51,7 +51,7 @@ class DisplayPermissionServiceSpec: QuickSpec {
             it("will use provided URL in a request") {
                 sendRequestAndWaitForResponse()
                 expect(httpSession.sentRequest).toNot(beNil())
-                expect(httpSession.sentRequest?.url).to(equal(configData.endpoints.displayPermission))
+                expect(httpSession.sentRequest?.url).to(equal(configData.endpoints?.displayPermission))
             }
 
             it("will give permission if url is not available") {
@@ -75,7 +75,7 @@ class DisplayPermissionServiceSpec: QuickSpec {
             context("when request succeeds") {
 
                 beforeEach {
-                    httpSession.httpResponse = HTTPURLResponse(url: configData.endpoints.displayPermission!,
+                    httpSession.httpResponse = HTTPURLResponse(url: configData.endpoints!.displayPermission!,
                                                                statusCode: 200,
                                                                httpVersion: nil,
                                                                headerFields: nil)

--- a/Tests/GetConfigResponseSpec.swift
+++ b/Tests/GetConfigResponseSpec.swift
@@ -1,0 +1,172 @@
+import Quick
+import Nimble
+@testable import RInAppMessaging
+
+class GetConfigResponseSpec: QuickSpec {
+
+    override func spec() {
+
+        describe("GetConfigResponse model") {
+            context("when decoding JSON payload") {
+
+                it("will be correctly created if all fields are present") {
+                    let model = try? JSONDecoder().decode(GetConfigResponse.self, from: Payloads.allFields.utf8Data!)
+
+                    expect(model).toNot(beNil())
+                    expect(model?.data.enabled).to(beFalse())
+                    expect(model?.data.endpoints?.ping).toNot(beNil())
+                    expect(model?.data.endpoints?.impression).toNot(beNil())
+                    expect(model?.data.endpoints?.displayPermission).toNot(beNil())
+                }
+
+                it("will be correctly created if there are no endpoints") {
+                    let model = try? JSONDecoder().decode(GetConfigResponse.self, from: Payloads.noEndpoints.utf8Data!)
+
+                    expect(model).toNot(beNil())
+                    expect(model?.data.enabled).to(beFalse())
+                    expect(model?.data.endpoints).to(beNil())
+                }
+
+                it("will be correctly created if endpoints field is empty") {
+                    let model = try? JSONDecoder().decode(GetConfigResponse.self, from: Payloads.emptyEndpoints.utf8Data!)
+
+                    expect(model).toNot(beNil())
+                    expect(model?.data.enabled).to(beFalse())
+                    expect(model?.data.endpoints?.ping).to(beNil())
+                    expect(model?.data.endpoints?.impression).to(beNil())
+                    expect(model?.data.endpoints?.displayPermission).to(beNil())
+                }
+
+                it("will be correctly created if there is no ping endpoint") {
+                    let model = try? JSONDecoder().decode(GetConfigResponse.self, from: Payloads.noPingEndpoint.utf8Data!)
+
+                    expect(model).toNot(beNil())
+                    expect(model?.data.enabled).to(beFalse())
+                    expect(model?.data.endpoints?.ping).to(beNil())
+                    expect(model?.data.endpoints?.impression).toNot(beNil())
+                    expect(model?.data.endpoints?.displayPermission).toNot(beNil())
+                }
+
+                it("will be correctly created if there is no impression endpoint") {
+                    let model = try? JSONDecoder().decode(GetConfigResponse.self, from: Payloads.noImpressionEndpoint.utf8Data!)
+
+                    expect(model).toNot(beNil())
+                    expect(model?.data.enabled).to(beFalse())
+                    expect(model?.data.endpoints?.ping).toNot(beNil())
+                    expect(model?.data.endpoints?.impression).to(beNil())
+                    expect(model?.data.endpoints?.displayPermission).toNot(beNil())
+                }
+
+                it("will be correctly created if there is no display permission endpoint") {
+                    let model = try? JSONDecoder().decode(GetConfigResponse.self, from: Payloads.noDisplayPermissionEndpoint.utf8Data!)
+
+                    expect(model).toNot(beNil())
+                    expect(model?.data.enabled).to(beFalse())
+                    expect(model?.data.endpoints?.ping).toNot(beNil())
+                    expect(model?.data.endpoints?.impression).toNot(beNil())
+                    expect(model?.data.endpoints?.displayPermission).to(beNil())
+                }
+
+                it("will not be correctly created if there is no enabled flag") {
+                    let model = try? JSONDecoder().decode(GetConfigResponse.self, from: Payloads.noEnabled.utf8Data!)
+
+                    expect(model).to(beNil())
+                }
+
+                it("will not be correctly created if there is no data") {
+                    let model = try? JSONDecoder().decode(GetConfigResponse.self, from: Payloads.noData.utf8Data!)
+
+                    expect(model).to(beNil())
+                }
+            }
+        }
+    }
+
+    private enum Payloads {
+        static let allFields = """
+        {
+          "data": {
+            "enabled": false,
+            "endpoints": {
+              "ping": "https://something",
+              "impression": "https://something",
+              "displayPermission": "https://something"
+            }
+          }
+        }
+        """
+
+        static let noEndpoints = """
+        {
+          "data": {
+            "enabled": false
+          }
+        }
+        """
+
+        static let noPingEndpoint = """
+        {
+          "data": {
+            "enabled": false,
+            "endpoints": {
+              "impression": "https://something",
+              "displayPermission": "https://something"
+            }
+          }
+        }
+        """
+
+        static let noImpressionEndpoint = """
+        {
+          "data": {
+            "enabled": false,
+            "endpoints": {
+              "ping": "https://something",
+              "displayPermission": "https://something"
+            }
+          }
+        }
+        """
+
+        static let noDisplayPermissionEndpoint = """
+        {
+          "data": {
+            "enabled": false,
+            "endpoints": {
+              "ping": "https://something",
+              "impression": "https://something"
+            }
+          }
+        }
+        """
+
+        static let noEnabled = """
+        {
+          "data": {
+            "endpoints": {
+              "ping": "https://something",
+              "impression": "https://something",
+              "displayPermission": "https://something"
+            }
+          }
+        }
+        """
+
+        static let emptyEndpoints = """
+        {
+          "data": {
+            "enabled": false,
+            "endpoints": { }
+          }
+        }
+        """
+
+        static let noData = "{ }"
+    }
+}
+
+private extension String {
+    var utf8Data: Data? {
+        data(using: .utf8)
+    }
+}

--- a/Tests/ImpressionServiceSpec.swift
+++ b/Tests/ImpressionServiceSpec.swift
@@ -51,7 +51,7 @@ class ImpressionServiceSpec: QuickSpec {
             it("will use provided URL in a request") {
                 sendRequestAndWaitForResponse()
                 expect(httpSession.sentRequest).toNot(beNil())
-                expect(httpSession.sentRequest?.url).to(equal(configData.endpoints.impression))
+                expect(httpSession.sentRequest?.url).to(equal(configData.endpoints?.impression))
             }
 
             it("will report an error if url is not available") {
@@ -69,7 +69,7 @@ class ImpressionServiceSpec: QuickSpec {
             context("when request succeeds") {
 
                 beforeEach {
-                    httpSession.httpResponse = HTTPURLResponse(url: configData.endpoints.impression!,
+                    httpSession.httpResponse = HTTPURLResponse(url: configData.endpoints!.impression!,
                                                                statusCode: 200,
                                                                httpVersion: nil,
                                                                headerFields: nil)

--- a/Tests/MessageMixerServiceSpec.swift
+++ b/Tests/MessageMixerServiceSpec.swift
@@ -7,11 +7,7 @@ class MessageMixerServiceSpec: QuickSpec {
     override func spec() {
 
         let requestQueue = DispatchQueue(label: "iam.test.request")
-        let configData = ConfigData(enabled: true,
-                                    endpoints: EndpointURL(
-                                        ping: URL(string: "https://ping.url")!,
-                                        displayPermission: nil,
-                                        impression: nil))
+        let configData = ConfigData(enabled: true, endpoints: .empty)
 
         var service: MessageMixerService!
         var preferenceRepository: IAMPreferenceRepository!
@@ -47,13 +43,13 @@ class MessageMixerServiceSpec: QuickSpec {
             it("will use provided URL in a request") {
                 sendRequestAndWaitForResponse()
                 expect(httpSession.sentRequest).toNot(beNil())
-                expect(httpSession.sentRequest?.url).to(equal(configData.endpoints.ping))
+                expect(httpSession.sentRequest?.url).to(equal(configData.endpoints?.ping))
             }
 
             context("when request succeeds") {
 
                 beforeEach {
-                    httpSession.httpResponse = HTTPURLResponse(url: configData.endpoints.ping,
+                    httpSession.httpResponse = HTTPURLResponse(url: configData.endpoints!.ping!,
                                                                statusCode: 200,
                                                                httpVersion: nil,
                                                                headerFields: nil)

--- a/Tests/Payloads/config_fail_ping.json
+++ b/Tests/Payloads/config_fail_ping.json
@@ -1,9 +1,0 @@
-{
-    "data": {
-        "enabled": true,
-        "endpoints": {
-            "impression": "https://endpoint.com/impression",
-            "displayPermission": "https://endpoint.com/display_permission"
-        }
-    }
-}

--- a/Tests/Payloads/config_success_optional.json
+++ b/Tests/Payloads/config_success_optional.json
@@ -1,9 +1,5 @@
 {
     "data": {
-        "enabled": true,
-        "endpoints": {
-            "ping": "https://endpoint.com/ping",
-            "impression": null
-        }
+        "enabled": true
     }
 }


### PR DESCRIPTION
# Description
This fix ensures that there will be no JSON parsing error when endpoints property is missing in the payload.
(Causing SDK to be successfully disabled when `enabled` flag is false)

# Checklist
- [X] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [X] I wrote/updated tests for new/changed code
- [X] I removed all sensitive data **before every commit**, including API endpoints and keys
- [X] I ran `fastlane ci` without errors
