### PR TITLE
SDKCF-3654: [IAM][iOS] - Handle ‘429 too many requests’ response to Config/Ping APIs

### DIFF
--- a/RInAppMessaging.xcodeproj/project.pbxproj
+++ b/RInAppMessaging.xcodeproj/project.pbxproj
@@ -56,6 +56,7 @@
 		607FACDB1AFB9204008FA782 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 607FACD91AFB9204008FA782 /* Main.storyboard */; };
 		607FACDD1AFB9204008FA782 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 607FACDC1AFB9204008FA782 /* Images.xcassets */; };
 		607FACE01AFB9204008FA782 /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = 607FACDE1AFB9204008FA782 /* LaunchScreen.xib */; };
+		C9827558262C423C00476505 /* BackoffSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9827557262C423C00476505 /* BackoffSpec.swift */; };
 		D911DC4F211115730082B950 /* ConfigurationSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9F418282110FD9F00E2158F /* ConfigurationSpec.swift */; };
 		D911DC5821115B410082B950 /* IdRegistrationSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D911DC56211159DE0082B950 /* IdRegistrationSpec.swift */; };
 		D920D8C92277B80F008FB38D /* SecondPageViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = D920D8C82277B80F008FB38D /* SecondPageViewController.xib */; };
@@ -140,6 +141,7 @@
 		607FACEA1AFB9204008FA782 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		6DA608F3248603BA00A8260D /* Example-Debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Example-Debug.xcconfig"; sourceTree = "<group>"; };
 		6DA608F424860B7F00A8260D /* Example-Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Example-Release.xcconfig"; sourceTree = "<group>"; };
+		C9827557262C423C00476505 /* BackoffSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackoffSpec.swift; sourceTree = "<group>"; };
 		D911DC56211159DE0082B950 /* IdRegistrationSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdRegistrationSpec.swift; sourceTree = "<group>"; };
 		D920D8C82277B80F008FB38D /* SecondPageViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = SecondPageViewController.xib; sourceTree = "<group>"; };
 		D920D8CA2277B965008FB38D /* SecondPageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecondPageViewController.swift; sourceTree = "<group>"; };
@@ -263,6 +265,7 @@
 			children = (
 				45B572F625AE2163005A80F7 /* Helpers */,
 				45357AE32457EB49007D8FDC /* Payloads */,
+				C9827557262C423C00476505 /* BackoffSpec.swift */,
 				45563B0624064D78004EAFD3 /* CampaignRepositorySpec.swift */,
 				45BDFD022421D311004DEA0C /* CampaignsListManagerSpec.swift */,
 				D92D1F2122249833008EA748 /* CampaignsValidatorSpec.swift */,
@@ -543,6 +546,7 @@
 				45563B0724064D78004EAFD3 /* CampaignRepositorySpec.swift in Sources */,
 				456FE1EB2428C51E00304872 /* CommonUtilitySpec.swift in Sources */,
 				4538BAE326282DE4009952BE /* GetConfigResponseSpec.swift in Sources */,
+				C9827558262C423C00476505 /* BackoffSpec.swift in Sources */,
 				45ADA53E247CFE9E00A9E2A3 /* ConfigurationRepositorySpec.swift in Sources */,
 				45EA720D25B72002001B2049 /* UIViewExtensionSpec.swift in Sources */,
 				459B227E24528A5100D218CE /* MessageMixerServiceSpec.swift in Sources */,

--- a/RInAppMessaging/Classes/ConfigurationManager.swift
+++ b/RInAppMessaging/Classes/ConfigurationManager.swift
@@ -5,21 +5,20 @@ internal protocol ConfigurationManagerType: AnyObject, ErrorReportable {
 }
 
 internal class ConfigurationManager: ConfigurationManagerType {
-
-    private enum Constants {
-        static let initialRetryDelayMS = Int32(10000)
-    }
-
     private let configurationService: ConfigurationServiceType
     private let configurationRepository: ConfigurationRepositoryType
     private let reachability: ReachabilityType?
     private let resumeQueue: DispatchQueue
 
-    private var retryDelayMS = Constants.initialRetryDelayMS
+    private var retryDelayMS = Constants.Retry.Default.initialRetryDelayMS
     private var lastRequestTime: TimeInterval = 0
     private var onConnectionResumed: (() -> Void)?
 
     weak var errorDelegate: ErrorDelegate?
+    private(set) var scheduledTask: DispatchWorkItem?
+
+    private var state = ResponseState.success
+    private var previousState = ResponseState.success
 
     init(reachability: ReachabilityType?,
          configurationService: ConfigurationServiceType,
@@ -46,16 +45,31 @@ internal class ConfigurationManager: ConfigurationManagerType {
         let result = configurationService.getConfigData()
         switch result {
         case .success(let configData):
-            retryDelayMS = Constants.initialRetryDelayMS
+            previousState = state
+            state = ResponseState.success
+            retryDelayMS = Constants.Retry.Default.initialRetryDelayMS
 
             configurationRepository.saveConfiguration(configData)
             completion(configData)
 
         case .failure(let error):
+            previousState = state
+            state = ResponseState.error(error)
             reportError(description: "Error calling config server. Retrying in \(retryDelayMS)ms", data: error)
-            WorkScheduler.scheduleTask(milliseconds: Int(retryDelayMS), closure: retryHandler, wallDeadline: true)
-            // Exponential backoff for pinging Configuration server.
-            retryDelayMS = retryDelayMS.multipliedReportingOverflow(by: 2).partialValue
+            switch error {
+            case ConfigurationServiceError.tooManyRequestsError:
+                if case ResponseState.success = previousState {
+                    retryDelayMS = Constants.Retry.TooManyRequestsError.initialRetryDelayMS
+                }
+                scheduledTask = WorkScheduler.scheduleTask(milliseconds: Int(retryDelayMS), closure: retryHandler, wallDeadline: true)
+                // Exponential backoff for pinging Configuration server.
+                retryDelayMS.increaseRandomizedBackoff()
+
+            default:
+                scheduledTask = WorkScheduler.scheduleTask(milliseconds: Int(retryDelayMS), closure: retryHandler, wallDeadline: true)
+                // Exponential backoff for pinging Configuration server.
+                retryDelayMS.increaseBackOff()
+            }
         }
     }
 }

--- a/RInAppMessaging/Classes/Constants.swift
+++ b/RInAppMessaging/Classes/Constants.swift
@@ -40,4 +40,16 @@ internal enum Constants {
         static let impressions = "InAppMessaging_impressions"
         static let events = "InAppMessaging_events"
     }
+
+    enum Retry {
+        enum Default {
+            static let initialRetryDelayMS = Int32(10000)
+        }
+
+        enum TooManyRequestsError {
+            static let initialRetryDelayMS = Int32(60000)
+            static let backOffLowerBoundInSecond = Int32(1) // second
+            static let backOffUpperBoundInSecond = Int32(60) // second
+        }
+    }
 }

--- a/RInAppMessaging/Classes/Enums/ResponseState.swift
+++ b/RInAppMessaging/Classes/Enums/ResponseState.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+enum ResponseState {
+    case success
+    case error(Error)
+}

--- a/RInAppMessaging/Classes/Extensions/Int32+IAM.swift
+++ b/RInAppMessaging/Classes/Extensions/Int32+IAM.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+extension Int32 {
+    /// Exponential backoff
+    mutating func increaseBackOff() {
+        self = multipliedReportingOverflow(by: 2).partialValue
+    }
+
+    /// Exponential backoff with a random value
+    ///
+    /// - Parameters:
+    ///     - min: the minimum value in second.
+    ///     - max: the maximum value in second.
+    mutating func increaseRandomizedBackoff(min: Int32 = Constants.Retry.TooManyRequestsError.backOffLowerBoundInSecond,
+                                            max: Int32 = Constants.Retry.TooManyRequestsError.backOffUpperBoundInSecond) {
+        increaseBackOff()
+        self += Int32.random(in: min...max)*1000
+    }
+}

--- a/RInAppMessaging/Classes/Services/ConfigurationService.swift
+++ b/RInAppMessaging/Classes/Services/ConfigurationService.swift
@@ -5,6 +5,7 @@ internal protocol ConfigurationServiceType {
 internal enum ConfigurationServiceError: Error {
     case requestError(RequestError)
     case jsonDecodingError(Error)
+    case tooManyRequestsError
 }
 
 internal struct ConfigurationService: ConfigurationServiceType, HttpRequestable {
@@ -30,7 +31,12 @@ internal struct ConfigurationService: ConfigurationServiceType, HttpRequestable 
                 return ConfigurationServiceError.jsonDecodingError($0)
             }
         case .failure(let requestError):
-            return .failure(.requestError(requestError))
+            switch requestError {
+            case .httpError(let statusCode, _, _) where statusCode == 429:
+                return .failure(.tooManyRequestsError)
+            default:
+                return .failure(.requestError(requestError))
+            }
         }
     }
 

--- a/RInAppMessaging/Classes/Services/MessageMixerService.swift
+++ b/RInAppMessaging/Classes/Services/MessageMixerService.swift
@@ -6,6 +6,7 @@ internal enum MessageMixerServiceError: Error {
     case requestError(RequestError)
     case jsonDecodingError(Error)
     case invalidConfiguration
+    case tooManyRequestsError
 }
 
 internal class MessageMixerService: MessageMixerServiceType, HttpRequestable {
@@ -44,7 +45,12 @@ internal class MessageMixerService: MessageMixerServiceType, HttpRequestable {
                 return MessageMixerServiceError.jsonDecodingError($0)
             }
         case .failure(let requestError):
-            return .failure(.requestError(requestError))
+            switch requestError {
+            case .httpError(let statusCode, _, _) where statusCode == 429:
+                return .failure(.tooManyRequestsError)
+            default:
+                return .failure(.requestError(requestError))
+            }
         }
     }
 

--- a/Tests/BackoffSpec.swift
+++ b/Tests/BackoffSpec.swift
@@ -1,0 +1,28 @@
+import Quick
+import Nimble
+@testable import RInAppMessaging
+
+class BackoffSpec: QuickSpec {
+    override func spec() {
+        describe("Backoff") {
+            let initialValue: Int32 = 10000
+
+            it("should increase the retry delay") {
+                var retryMS: Int32 = initialValue
+                retryMS.increaseBackOff()
+
+                let expectedResult = initialValue.multipliedReportingOverflow(by: 2).partialValue
+                expect(retryMS).to(equal(expectedResult))
+            }
+
+            it("should increase the retry delay with a randomized value") {
+                var retryMS: Int32 = initialValue
+                retryMS.increaseRandomizedBackoff()
+
+                let expectedResult = initialValue.multipliedReportingOverflow(by: 2).partialValue
+                expect(retryMS >= expectedResult + (Constants.Retry.TooManyRequestsError.backOffLowerBoundInSecond * 1000)).to(beTrue())
+                expect(retryMS <= expectedResult + (Constants.Retry.TooManyRequestsError.backOffUpperBoundInSecond * 1000)).to(beTrue())
+            }
+        }
+    }
+}

--- a/Tests/CampaignsListManagerSpec.swift
+++ b/Tests/CampaignsListManagerSpec.swift
@@ -68,6 +68,12 @@ class CampaignsListManagerSpec: QuickSpec {
                         manager.refreshList()
                         expect(errorDelegate.wasErrorReceived).to(beFalse())
                     }
+
+                    it("will retry for .tooManyRequestsError error") {
+                        messageMixerService.mockedError = .tooManyRequestsError
+                        manager.refreshList()
+                        expect(manager.scheduledTask).toEventuallyNot(beNil())
+                    }
                 }
 
                 context("and ping call succeeded") {

--- a/Tests/ConfigurationManagerSpec.swift
+++ b/Tests/ConfigurationManagerSpec.swift
@@ -90,6 +90,13 @@ class ConfigurationManagerSpec: QuickSpec {
                         configurationService.simulateRequestFailure = false
                     }
                 }
+
+                it("should retry for .tooManyRequestsError error") {
+                    configurationService.simulateRequestFailure = true
+                    configurationService.mockedError = .tooManyRequestsError
+                    configurationManager.fetchAndSaveConfigData(completion: { _ in })
+                    expect(configurationManager.scheduledTask).toEventuallyNot(beNil())
+                }
             }
         }
     }

--- a/Tests/Helpers/SharedMocks.swift
+++ b/Tests/Helpers/SharedMocks.swift
@@ -141,12 +141,13 @@ class ReachabilityMock: ReachabilityType {
 class ConfigurationServiceMock: ConfigurationServiceType {
     var getConfigDataCallCount = 0
     var simulateRequestFailure = false
+    var mockedError = ConfigurationServiceError.requestError(.unknown)
 
     func getConfigData() -> Result<ConfigData, ConfigurationServiceError> {
         getConfigDataCallCount += 1
 
         guard !simulateRequestFailure else {
-            return .failure(.requestError(.unknown))
+            return .failure(mockedError)
         }
 
         return .success(ConfigData(enabled: true, endpoints: .empty))

--- a/Tests/MessageMixerServiceSpec.swift
+++ b/Tests/MessageMixerServiceSpec.swift
@@ -119,7 +119,7 @@ class MessageMixerServiceSpec: QuickSpec {
                     httpSession.responseError = NSError(domain: "config.error.test", code: 1, userInfo: nil)
                 }
 
-                it("will return ConfigurationServiceError containig RequestError") {
+                it("will return ConfigurationServiceError containing .requestError") {
                     waitUntil { done in
                         requestQueue.async {
                             let result = service.ping()
@@ -134,6 +134,36 @@ class MessageMixerServiceSpec: QuickSpec {
                             done()
                         }
                     }
+                }
+            }
+
+            context("when request fails with a status code equals to 429") {
+                let originalHttpResponse: HTTPURLResponse? = httpSession?.httpResponse
+
+                it("will return ConfigurationServiceError containig .tooManyRequestsError") {
+                    httpSession.httpResponse = HTTPURLResponse(url: URL(string: "https://ping.url")!,
+                                                               statusCode: 429,
+                                                               httpVersion: nil,
+                                                               headerFields: nil)
+
+                    waitUntil { done in
+                        requestQueue.async {
+                            let result = service.ping()
+                            let error = result.getError()
+                            expect(error).toNot(beNil())
+
+                            guard case .tooManyRequestsError = error else {
+                                fail("Unexpected error type \(String(describing: error)). Expected .tooManyRequestsError")
+                                done()
+                                return
+                            }
+                            done()
+                        }
+                    }
+                }
+
+                afterEach {
+                    httpSession.httpResponse = originalHttpResponse
                 }
             }
 


### PR DESCRIPTION
# Description
Retry logic when a 429 error is received for ping and getConfigData.
The initial value for retry is 60 seconds, then this value is exponentially increased + a random value is added.

## Tests
I tested getConfigData and Ping requests by mocking them on Charles Proxy and by returning 429 error:
HTTP/1.1 429

## Links
Add links to github/jira issues, design documents and other relevant resources (e.g. previous discussions, platform/tool documentation etc.)

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data **before every commit**, including API endpoints and keys
- [x] I ran `fastlane ci` without errors
