### PR TITLE
SDKCF-3652: Get config new endpoint

### DIFF
--- a/RInAppMessaging/Classes/Models/Requests/GetConfigRequest.swift
+++ b/RInAppMessaging/Classes/Models/Requests/GetConfigRequest.swift
@@ -1,7 +1,27 @@
 internal struct GetConfigRequest: Codable {
+    private enum CodingKeys: String, CodingKey {
+        case locale
+        case appVersion
+        case platform
+        case appId
+        case sdkVersion
+    }
+
     let locale: String
     let appVersion: String
     let platform: Platform
     let appId: String
     let sdkVersion: String
+}
+
+extension GetConfigRequest {
+    var toQueryItems: [URLQueryItem] {
+        var queryItems = [URLQueryItem]()
+        queryItems.append(URLQueryItem(name: CodingKeys.platform.rawValue, value: "\(platform.rawValue)"))
+        queryItems.append(URLQueryItem(name: CodingKeys.appId.rawValue, value: appId))
+        queryItems.append(URLQueryItem(name: CodingKeys.appVersion.rawValue, value: appVersion))
+        queryItems.append(URLQueryItem(name: CodingKeys.sdkVersion.rawValue, value: sdkVersion))
+        queryItems.append(URLQueryItem(name: CodingKeys.locale.rawValue, value: locale))
+        return queryItems
+    }
 }

--- a/RInAppMessaging/Classes/Models/Responses/GetConfigResponse.swift
+++ b/RInAppMessaging/Classes/Models/Responses/GetConfigResponse.swift
@@ -3,8 +3,15 @@ internal struct GetConfigResponse: Decodable {
 }
 
 internal struct ConfigData: Decodable {
-    let enabled: Bool
+    let rolloutPercentage: Int
     let endpoints: EndpointURL?
+}
+
+extension ConfigData {
+    // Temporary property - It has to be removed in the ticket SDKCF-3663
+    var enabled: Bool {
+        rolloutPercentage > 0
+    }
 }
 
 internal struct EndpointURL: Decodable, Equatable {

--- a/Tests/ConfigurationRepositorySpec.swift
+++ b/Tests/ConfigurationRepositorySpec.swift
@@ -27,18 +27,18 @@ class ConfigurationRepositorySpec: QuickSpec {
                 let endpoints = EndpointURL(ping: URL(string: "ping")!,
                                             displayPermission: URL(string: "displayPermission")!,
                                             impression: URL(string: "impression")!)
-                let config = ConfigData(enabled: true, endpoints: endpoints)
+                let config = ConfigData(rolloutPercentage: 100, endpoints: endpoints)
                 configurationRepository.saveConfiguration(config)
 
                 expect(configurationRepository.getEndpoints()).to(equal(endpoints))
             }
 
             it("will properly save enabled flag") {
-                let enabled = true
-                let config = ConfigData(enabled: enabled, endpoints: .empty)
+                let rolloutPercentage = 100
+                let config = ConfigData(rolloutPercentage: rolloutPercentage, endpoints: .empty)
                 configurationRepository.saveConfiguration(config)
 
-                expect(configurationRepository.getIsEnabledStatus()).to(equal(enabled))
+                expect(configurationRepository.getIsEnabledStatus()).to(beTrue())
             }
         }
     }

--- a/Tests/ConfigurationServiceSpec.swift
+++ b/Tests/ConfigurationServiceSpec.swift
@@ -33,7 +33,8 @@ class ConfigurationServiceSpec: QuickSpec {
                         done()
                     }
                 }
-                expect(httpSession.sentRequest?.url).to(equal(configURL))
+                expect(httpSession.sentRequest?.url?.scheme).to(equal(configURL.scheme))
+                expect(httpSession.sentRequest?.url?.host).to(equal(configURL.host))
             }
 
             context("when request succeeds") {
@@ -188,7 +189,7 @@ class ConfigurationServiceSpec: QuickSpec {
                         }
                     }
 
-                    let request = httpSession.decodeSentData(modelType: GetConfigRequest.self)
+                    let request = httpSession.decodeQueryItems(modelType: GetConfigRequest.self)
 
                     expect(request).toNot(beNil())
                     expect(request?.locale).to(equal(Locale.current.normalizedIdentifier))
@@ -208,7 +209,7 @@ class ConfigurationServiceSpec: QuickSpec {
                                 expect(error).toNot(beNil())
 
                                 guard case .requestError(let requestError) = error,
-                                      case .bodyEncodingError(let encodingError) = requestError,
+                                      case .urlBuildingError(let encodingError) = requestError,
                                       case .missingMetadata = encodingError as? RequestError else {
                                     fail("Unexpected error type \(String(describing: error)). Expected .requestError(.missingMetadata)")
                                     done()

--- a/Tests/ConfigurationSpec.swift
+++ b/Tests/ConfigurationSpec.swift
@@ -35,7 +35,7 @@ class ConfigurationSpec: QuickSpec {
             context("when configuration returned false") {
 
                 beforeEach {
-                    configurationManager.isConfigEnabled = false
+                    configurationManager.rolloutPercentage = 0
                 }
 
                 it("will disable module") {
@@ -60,7 +60,7 @@ class ConfigurationSpec: QuickSpec {
             context("when configuration returned true") {
 
                 it("will call ping") {
-                    configurationManager.isConfigEnabled = true
+                    configurationManager.rolloutPercentage = 100
                     RInAppMessaging.configure(dependencyManager: dependencyManager)
 
                     expect(mockMessageMixer.wasPingCalled).toEventually(beTrue())

--- a/Tests/DisplayPermissionServiceSpec.swift
+++ b/Tests/DisplayPermissionServiceSpec.swift
@@ -7,7 +7,7 @@ class DisplayPermissionServiceSpec: QuickSpec {
     override func spec() {
 
         let requestQueue = DispatchQueue(label: "iam.test.request")
-        let configData = ConfigData(enabled: true,
+        let configData = ConfigData(rolloutPercentage: 100,
                                     endpoints: EndpointURL(
                                         ping: URL(string: "https://ping.url")!,
                                         displayPermission: URL(string: "https://permission.url")!,
@@ -56,7 +56,7 @@ class DisplayPermissionServiceSpec: QuickSpec {
 
             it("will give permission if url is not available") {
                 configurationRepository.saveConfiguration(
-                    ConfigData(enabled: true,
+                    ConfigData(rolloutPercentage: 100,
                                endpoints: EndpointURL(
                                 ping: URL(string: "https://ping.url")!,
                                 displayPermission: nil,

--- a/Tests/GetConfigResponseSpec.swift
+++ b/Tests/GetConfigResponseSpec.swift
@@ -13,6 +13,7 @@ class GetConfigResponseSpec: QuickSpec {
                     let model = try? JSONDecoder().decode(GetConfigResponse.self, from: Payloads.allFields.utf8Data!)
 
                     expect(model).toNot(beNil())
+                    expect(model?.data.rolloutPercentage).to(equal(0))
                     expect(model?.data.enabled).to(beFalse())
                     expect(model?.data.endpoints?.ping).toNot(beNil())
                     expect(model?.data.endpoints?.impression).toNot(beNil())
@@ -23,6 +24,7 @@ class GetConfigResponseSpec: QuickSpec {
                     let model = try? JSONDecoder().decode(GetConfigResponse.self, from: Payloads.noEndpoints.utf8Data!)
 
                     expect(model).toNot(beNil())
+                    expect(model?.data.rolloutPercentage).to(equal(0))
                     expect(model?.data.enabled).to(beFalse())
                     expect(model?.data.endpoints).to(beNil())
                 }
@@ -31,6 +33,7 @@ class GetConfigResponseSpec: QuickSpec {
                     let model = try? JSONDecoder().decode(GetConfigResponse.self, from: Payloads.emptyEndpoints.utf8Data!)
 
                     expect(model).toNot(beNil())
+                    expect(model?.data.rolloutPercentage).to(equal(0))
                     expect(model?.data.enabled).to(beFalse())
                     expect(model?.data.endpoints?.ping).to(beNil())
                     expect(model?.data.endpoints?.impression).to(beNil())
@@ -41,6 +44,7 @@ class GetConfigResponseSpec: QuickSpec {
                     let model = try? JSONDecoder().decode(GetConfigResponse.self, from: Payloads.noPingEndpoint.utf8Data!)
 
                     expect(model).toNot(beNil())
+                    expect(model?.data.rolloutPercentage).to(equal(0))
                     expect(model?.data.enabled).to(beFalse())
                     expect(model?.data.endpoints?.ping).to(beNil())
                     expect(model?.data.endpoints?.impression).toNot(beNil())
@@ -51,6 +55,7 @@ class GetConfigResponseSpec: QuickSpec {
                     let model = try? JSONDecoder().decode(GetConfigResponse.self, from: Payloads.noImpressionEndpoint.utf8Data!)
 
                     expect(model).toNot(beNil())
+                    expect(model?.data.rolloutPercentage).to(equal(0))
                     expect(model?.data.enabled).to(beFalse())
                     expect(model?.data.endpoints?.ping).toNot(beNil())
                     expect(model?.data.endpoints?.impression).to(beNil())
@@ -61,14 +66,15 @@ class GetConfigResponseSpec: QuickSpec {
                     let model = try? JSONDecoder().decode(GetConfigResponse.self, from: Payloads.noDisplayPermissionEndpoint.utf8Data!)
 
                     expect(model).toNot(beNil())
+                    expect(model?.data.rolloutPercentage).to(equal(0))
                     expect(model?.data.enabled).to(beFalse())
                     expect(model?.data.endpoints?.ping).toNot(beNil())
                     expect(model?.data.endpoints?.impression).toNot(beNil())
                     expect(model?.data.endpoints?.displayPermission).to(beNil())
                 }
 
-                it("will not be correctly created if there is no enabled flag") {
-                    let model = try? JSONDecoder().decode(GetConfigResponse.self, from: Payloads.noEnabled.utf8Data!)
+                it("will not be correctly created if there is no rolloutPercentage flag") {
+                    let model = try? JSONDecoder().decode(GetConfigResponse.self, from: Payloads.noRolloutPercentage.utf8Data!)
 
                     expect(model).to(beNil())
                 }
@@ -86,7 +92,7 @@ class GetConfigResponseSpec: QuickSpec {
         static let allFields = """
         {
           "data": {
-            "enabled": false,
+            "rolloutPercentage": 0,
             "endpoints": {
               "ping": "https://something",
               "impression": "https://something",
@@ -99,7 +105,7 @@ class GetConfigResponseSpec: QuickSpec {
         static let noEndpoints = """
         {
           "data": {
-            "enabled": false
+            "rolloutPercentage": 0
           }
         }
         """
@@ -107,7 +113,7 @@ class GetConfigResponseSpec: QuickSpec {
         static let noPingEndpoint = """
         {
           "data": {
-            "enabled": false,
+            "rolloutPercentage": 0,
             "endpoints": {
               "impression": "https://something",
               "displayPermission": "https://something"
@@ -119,7 +125,7 @@ class GetConfigResponseSpec: QuickSpec {
         static let noImpressionEndpoint = """
         {
           "data": {
-            "enabled": false,
+            "rolloutPercentage": 0,
             "endpoints": {
               "ping": "https://something",
               "displayPermission": "https://something"
@@ -131,7 +137,7 @@ class GetConfigResponseSpec: QuickSpec {
         static let noDisplayPermissionEndpoint = """
         {
           "data": {
-            "enabled": false,
+            "rolloutPercentage": 0,
             "endpoints": {
               "ping": "https://something",
               "impression": "https://something"
@@ -140,7 +146,7 @@ class GetConfigResponseSpec: QuickSpec {
         }
         """
 
-        static let noEnabled = """
+        static let noRolloutPercentage = """
         {
           "data": {
             "endpoints": {
@@ -155,7 +161,7 @@ class GetConfigResponseSpec: QuickSpec {
         static let emptyEndpoints = """
         {
           "data": {
-            "enabled": false,
+            "rolloutPercentage": 0,
             "endpoints": { }
           }
         }

--- a/Tests/ImpressionServiceSpec.swift
+++ b/Tests/ImpressionServiceSpec.swift
@@ -7,7 +7,7 @@ class ImpressionServiceSpec: QuickSpec {
     override func spec() {
 
         let requestQueue = DispatchQueue(label: "iam.test.request")
-        let configData = ConfigData(enabled: true,
+        let configData = ConfigData(rolloutPercentage: 100,
                                     endpoints: EndpointURL(
                                         ping: URL(string: "https://ping.url")!,
                                         displayPermission: nil,
@@ -56,7 +56,7 @@ class ImpressionServiceSpec: QuickSpec {
 
             it("will report an error if url is not available") {
                 configurationRepository.saveConfiguration(
-                    ConfigData(enabled: true,
+                    ConfigData(rolloutPercentage: 100,
                                endpoints: EndpointURL(
                                 ping: URL(string: "https://ping.url")!,
                                 displayPermission: nil,

--- a/Tests/InAppMessagingModuleSpec.swift
+++ b/Tests/InAppMessagingModuleSpec.swift
@@ -72,11 +72,11 @@ class InAppMessagingModuleSpec: QuickSpec {
 
                 context("and module is enabled") {
                     beforeEach {
-                        configurationManager.isConfigEnabled = true
+                        configurationManager.rolloutPercentage = 100
                     }
 
                     it("will call refreshList in CampaignsListManager") {
-                        configurationManager.isConfigEnabled = true
+                        configurationManager.rolloutPercentage = 100
                         iamModule.initialize { }
 
                         expect(campaignsListManager.wasRefreshListCalled).to(beTrue())
@@ -94,7 +94,7 @@ class InAppMessagingModuleSpec: QuickSpec {
 
                 context("and module is disabled") {
                     beforeEach {
-                        configurationManager.isConfigEnabled = false
+                        configurationManager.rolloutPercentage = 0
                     }
 
                     it("will not call refreshList in CampaignsListManager") {
@@ -117,7 +117,7 @@ class InAppMessagingModuleSpec: QuickSpec {
 
                     context("and module is enabled") {
                         beforeEach {
-                            configurationManager.isConfigEnabled = true
+                            configurationManager.rolloutPercentage = 100
                         }
 
                         context("and module is initialized") {
@@ -170,7 +170,7 @@ class InAppMessagingModuleSpec: QuickSpec {
 
                     context("and module is disabled") {
                         beforeEach {
-                            configurationManager.isConfigEnabled = false
+                            configurationManager.rolloutPercentage = 0
                             iamModule.initialize { }
                         }
 
@@ -195,7 +195,7 @@ class InAppMessagingModuleSpec: QuickSpec {
 
                     context("and module is enabled") {
                         beforeEach {
-                            configurationManager.isConfigEnabled = true
+                            configurationManager.rolloutPercentage = 100
                         }
 
                         context("and module is initialized") {
@@ -242,7 +242,7 @@ class InAppMessagingModuleSpec: QuickSpec {
 
                     context("and module is disabled") {
                         beforeEach {
-                            configurationManager.isConfigEnabled = false
+                            configurationManager.rolloutPercentage = 0
                             iamModule.initialize { }
                         }
 

--- a/Tests/MessageMixerServiceSpec.swift
+++ b/Tests/MessageMixerServiceSpec.swift
@@ -7,7 +7,7 @@ class MessageMixerServiceSpec: QuickSpec {
     override func spec() {
 
         let requestQueue = DispatchQueue(label: "iam.test.request")
-        let configData = ConfigData(enabled: true, endpoints: .empty)
+        let configData = ConfigData(rolloutPercentage: 100, endpoints: .empty)
 
         var service: MessageMixerService!
         var preferenceRepository: IAMPreferenceRepository!

--- a/Tests/Payloads/config_success.json
+++ b/Tests/Payloads/config_success.json
@@ -1,6 +1,6 @@
 {
     "data": {
-        "enabled": true,
+        "rolloutPercentage": 100,
         "endpoints": {
             "ping": "https://endpoint.com/ping",
             "impression": "https://endpoint.com/impression",

--- a/Tests/Payloads/config_success_optional.json
+++ b/Tests/Payloads/config_success_optional.json
@@ -1,5 +1,5 @@
 {
     "data": {
-        "enabled": true
+        "rolloutPercentage": 100
     }
 }

--- a/Tests/PublicAPISpec.swift
+++ b/Tests/PublicAPISpec.swift
@@ -19,7 +19,7 @@ class PublicAPISpec: QuickSpec {
             return DependencyManager.Container([
                 DependencyManager.ContainerElement(type: ConfigurationManagerType.self, factory: {
                     let manager = ConfigurationManagerMock()
-                    manager.isConfigEnabled = true
+                    manager.rolloutPercentage = 100
                     return manager
                 }),
                 DependencyManager.ContainerElement(type: MessageMixerServiceType.self, factory: { messageMixerService }),


### PR DESCRIPTION
# Description
- Change Config endpoint call to be a GET with query params instead of: POST + JSON body.
- Add rolloutPercentage property to the ConfigData model. 

## Links
SDKCF-3652

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data **before every commit**, including API endpoints and keys
- [x] I ran `fastlane ci` without errors
