### PR TITLE
improve: hash the key used to access cache (SDKCF-3667)

### DIFF
--- a/RInAppMessaging.xcodeproj/project.pbxproj
+++ b/RInAppMessaging.xcodeproj/project.pbxproj
@@ -31,6 +31,7 @@
 		456FE1E924288C6500304872 /* CampaignTriggerAgentSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 456FE1E824288C6500304872 /* CampaignTriggerAgentSpec.swift */; };
 		456FE1EB2428C51E00304872 /* CommonUtilitySpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 456FE1EA2428C51E00304872 /* CommonUtilitySpec.swift */; };
 		456FE1ED2429C4D200304872 /* ViewSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 456FE1EC2429C4D200304872 /* ViewSpec.swift */; };
+		4595F4F4262DE12C0001F30B /* KeyHasherSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4595F4F3262DE12C0001F30B /* KeyHasherSpec.swift */; };
 		459B227C245289F300D218CE /* ConfigurationServiceSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 459B227B245289F300D218CE /* ConfigurationServiceSpec.swift */; };
 		459B227E24528A5100D218CE /* MessageMixerServiceSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 459B227D24528A5000D218CE /* MessageMixerServiceSpec.swift */; };
 		459B228024528A6900D218CE /* ImpressionServiceSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 459B227F24528A6900D218CE /* ImpressionServiceSpec.swift */; };
@@ -109,6 +110,7 @@
 		456FE1E824288C6500304872 /* CampaignTriggerAgentSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CampaignTriggerAgentSpec.swift; sourceTree = "<group>"; };
 		456FE1EA2428C51E00304872 /* CommonUtilitySpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommonUtilitySpec.swift; sourceTree = "<group>"; };
 		456FE1EC2429C4D200304872 /* ViewSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewSpec.swift; sourceTree = "<group>"; };
+		4595F4F3262DE12C0001F30B /* KeyHasherSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyHasherSpec.swift; sourceTree = "<group>"; };
 		459B227B245289F300D218CE /* ConfigurationServiceSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigurationServiceSpec.swift; sourceTree = "<group>"; };
 		459B227D24528A5000D218CE /* MessageMixerServiceSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MessageMixerServiceSpec.swift; sourceTree = "<group>"; };
 		459B227F24528A6900D218CE /* ImpressionServiceSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImpressionServiceSpec.swift; sourceTree = "<group>"; };
@@ -289,6 +291,7 @@
 				D911DC56211159DE0082B950 /* IdRegistrationSpec.swift */,
 				459B227F24528A6900D218CE /* ImpressionServiceSpec.swift */,
 				45ADA53F247D076E00A9E2A3 /* InAppMessagingModuleSpec.swift */,
+				4595F4F3262DE12C0001F30B /* KeyHasherSpec.swift */,
 				45AFB307246CFB640080D21B /* LocaleSpec.swift */,
 				45563B0824064D98004EAFD3 /* LockableSpec.swift */,
 				4516601C23CD740300310181 /* MainContainerSpec.swift */,
@@ -537,6 +540,7 @@
 				459B227C245289F300D218CE /* ConfigurationServiceSpec.swift in Sources */,
 				45DA01AD23D5831900A27CC6 /* ConfigurationManagerSpec.swift in Sources */,
 				456FE1ED2429C4D200304872 /* ViewSpec.swift in Sources */,
+				4595F4F4262DE12C0001F30B /* KeyHasherSpec.swift in Sources */,
 				4534947223C6ABF700189A81 /* SerializationSpec.swift in Sources */,
 				D911DC5821115B410082B950 /* IdRegistrationSpec.swift in Sources */,
 				45EA720525B71FA2001B2049 /* UIApplicationExtensionSpec.swift in Sources */,

--- a/RInAppMessaging/Classes/UserDataCache.swift
+++ b/RInAppMessaging/Classes/UserDataCache.swift
@@ -79,9 +79,9 @@ internal class UserDataCache: UserDataCacheable {
         identifiers.map({ $0.identifier }).sorted().forEach {
             hasher.combine($0)
         }
-        hasher.encryprtionMethod = .md5
+        hasher.encryptionMethod = .md5
         let salt = hasher.generateHash()
-        hasher.encryprtionMethod = .sha256
+        hasher.encryptionMethod = .sha256
         hasher.salt = salt
 
         return hasher.generateHash()

--- a/RInAppMessaging/Classes/UserDataCache.swift
+++ b/RInAppMessaging/Classes/UserDataCache.swift
@@ -20,7 +20,7 @@ internal struct UserDataCacheContainer: Codable, Equatable {
 
 internal class UserDataCache: UserDataCacheable {
 
-    private typealias CacheContainers = [Set<UserIdentifier>: UserDataCacheContainer]
+    private typealias CacheContainers = [String: UserDataCacheContainer]
 
     private let userDefaults: UserDefaults
     private var cachedContainers: CacheContainers
@@ -74,7 +74,16 @@ internal class UserDataCache: UserDataCacheable {
         }
     }
 
-    private func userKey(from identifiers: [UserIdentifier]) -> Set<UserIdentifier> {
-        Set<UserIdentifier>(identifiers)
+    private func userKey(from identifiers: [UserIdentifier]) -> String {
+        var hasher = KeyHasher()
+        identifiers.map({ $0.identifier }).sorted().forEach {
+            hasher.combine($0)
+        }
+        hasher.encryprtionMethod = .md5
+        let salt = hasher.generateHash()
+        hasher.encryprtionMethod = .sha256
+        hasher.salt = salt
+
+        return hasher.generateHash()
     }
 }

--- a/RInAppMessaging/Classes/Utilities/KeyHasher.swift
+++ b/RInAppMessaging/Classes/Utilities/KeyHasher.swift
@@ -1,0 +1,79 @@
+import CommonCrypto
+import CryptoKit
+
+/// Tool for creating a salted hash from given string values using selected KeyHasher.Encryption method
+internal struct KeyHasher {
+
+    enum Encryption: String {
+        case md5
+        case sha256
+    }
+
+    var encryprtionMethod = Encryption.sha256
+    var salt: String?
+
+    private var data = [String]()
+
+    mutating func combine(_ value: String) {
+        data.append(value)
+    }
+
+    mutating func generateHash() -> String {
+        var dataString = data.joined(separator: ".")
+        if let salt = salt, !salt.isEmpty {
+            dataString.append(salt)
+        }
+
+        switch encryprtionMethod {
+        case .sha256:
+            return sha256(string: dataString)
+        case .md5:
+            return md5(string: dataString)
+        }
+    }
+
+    // MARK: Hashing functions
+
+    private func md5(string: String) -> String {
+        let stringData = Data(string.utf8)
+
+        if #available(iOS 13.0, *) {
+            let hash = Insecure.MD5.hash(data: stringData)
+            return hash.hexString
+        } else {
+            var hash = [UInt8](repeating: 0, count: Int(CC_MD5_DIGEST_LENGTH))
+            data.withUnsafeBytes {
+                _ = CC_MD5($0.baseAddress, CC_LONG(data.count), &hash)
+            }
+            return Data(hash).hexString
+        }
+    }
+
+    private func sha256(string: String) -> String {
+        let stringData = Data(string.utf8)
+
+        if #available(iOS 13.0, *) {
+            let hash = SHA256.hash(data: stringData)
+            return hash.hexString
+        } else {
+            var hash = [UInt8](repeating: 0, count: Int(CC_SHA256_DIGEST_LENGTH))
+            data.withUnsafeBytes {
+                _ = CC_SHA256($0.baseAddress, CC_LONG(data.count), &hash)
+            }
+            return Data(hash).hexString
+        }
+    }
+}
+
+@available(iOS 13.0, *)
+extension Digest {
+    var hexString: String {
+        map { String(format: "%02hhx", $0) }.joined()
+    }
+}
+
+extension Data {
+    var hexString: String {
+        map { String(format: "%02hhx", $0) }.joined()
+    }
+}

--- a/RInAppMessaging/Classes/Utilities/KeyHasher.swift
+++ b/RInAppMessaging/Classes/Utilities/KeyHasher.swift
@@ -1,5 +1,4 @@
 import CommonCrypto
-import CryptoKit
 
 /// Tool for creating a salted hash from given string values using selected KeyHasher.Encryption method
 internal struct KeyHasher {
@@ -9,7 +8,7 @@ internal struct KeyHasher {
         case sha256
     }
 
-    var encryprtionMethod = Encryption.sha256
+    var encryptionMethod = Encryption.sha256
     var salt: String?
 
     private var data = [String]()
@@ -24,7 +23,7 @@ internal struct KeyHasher {
             dataString.append(salt)
         }
 
-        switch encryprtionMethod {
+        switch encryptionMethod {
         case .sha256:
             return sha256(string: dataString)
         case .md5:
@@ -37,38 +36,21 @@ internal struct KeyHasher {
     private func md5(string: String) -> String {
         let stringData = Data(string.utf8)
 
-        if #available(iOS 13.0, *) {
-            let hash = Insecure.MD5.hash(data: stringData)
-            return hash.hexString
-        } else {
-            var hash = [UInt8](repeating: 0, count: Int(CC_MD5_DIGEST_LENGTH))
-            data.withUnsafeBytes {
-                _ = CC_MD5($0.baseAddress, CC_LONG(data.count), &hash)
-            }
-            return Data(hash).hexString
+        var hash = [UInt8](repeating: 0, count: Int(CC_MD5_DIGEST_LENGTH))
+        stringData.withUnsafeBytes {
+            _ = CC_MD5($0.baseAddress, CC_LONG(stringData.count), &hash)
         }
+        return Data(hash).hexString
     }
 
     private func sha256(string: String) -> String {
         let stringData = Data(string.utf8)
 
-        if #available(iOS 13.0, *) {
-            let hash = SHA256.hash(data: stringData)
-            return hash.hexString
-        } else {
-            var hash = [UInt8](repeating: 0, count: Int(CC_SHA256_DIGEST_LENGTH))
-            data.withUnsafeBytes {
-                _ = CC_SHA256($0.baseAddress, CC_LONG(data.count), &hash)
-            }
-            return Data(hash).hexString
+        var hash = [UInt8](repeating: 0, count: Int(CC_SHA256_DIGEST_LENGTH))
+        stringData.withUnsafeBytes {
+            _ = CC_SHA256($0.baseAddress, CC_LONG(stringData.count), &hash)
         }
-    }
-}
-
-@available(iOS 13.0, *)
-extension Digest {
-    var hexString: String {
-        map { String(format: "%02hhx", $0) }.joined()
+        return Data(hash).hexString
     }
 }
 

--- a/Tests/KeyHasherSpec.swift
+++ b/Tests/KeyHasherSpec.swift
@@ -1,0 +1,126 @@
+import Quick
+import Nimble
+@testable import RInAppMessaging
+
+class KeyHasherSpec: QuickSpec {
+
+    override func spec() {
+        // Be sure to run those tests for ios version >=13.0 and <13.0
+        describe("KeyHasher") {
+
+            var hasher: KeyHasher!
+
+            beforeEach {
+                hasher = KeyHasher()
+            }
+
+            [KeyHasher.Encryption.md5, KeyHasher.Encryption.sha256].forEach { encryption in
+                context("when using \(encryption) encryption method") {
+
+                    beforeEach {
+                        hasher.encryprtionMethod = encryption
+                    }
+
+                    it("will generate a valid hash for empty data") {
+                        expect(hasher.generateHash()).toNot(beEmpty())
+                    }
+
+                    it("will generate a valid hash for empty value") {
+                        hasher.combine("")
+                        expect(hasher.generateHash()).toNot(beEmpty())
+                    }
+
+                    it("will generate a valid hash for single added value") {
+                        hasher.combine("some value")
+                        expect(hasher.generateHash()).toNot(beEmpty())
+                    }
+
+                    it("will generate a valid hash for multiple added values") {
+                        hasher.combine("some value")
+                        hasher.combine("another value")
+                        hasher.combine("some other value")
+                        expect(hasher.generateHash()).toNot(beEmpty())
+                    }
+
+                    it("will generate the same hash for the same values") {
+                        hasher.combine("some value")
+                        let resultA = hasher.generateHash()
+
+                        var anotherHasher = KeyHasher()
+                        anotherHasher.encryprtionMethod = hasher.encryprtionMethod
+                        anotherHasher.combine("some value")
+                        let resultB = anotherHasher.generateHash()
+
+                        expect(resultA).to(equal(resultB))
+                    }
+
+                    it("will generate different hash for different values") {
+                        hasher.combine("some value")
+                        let resultA = hasher.generateHash()
+
+                        var anotherHasher = KeyHasher()
+                        anotherHasher.encryprtionMethod = hasher.encryprtionMethod
+                        anotherHasher.combine("another value")
+                        let resultB = anotherHasher.generateHash()
+
+                        expect(resultA).toNot(equal(resultB))
+                    }
+
+                    context("with added salt") {
+
+                        beforeEach {
+                            hasher.salt = "salt"
+                        }
+
+                        it("will generate a valid hash for empty data") {
+                            expect(hasher.generateHash()).toNot(beEmpty())
+                        }
+
+                        it("will generate a valid hash for empty value") {
+                            hasher.combine("")
+                            expect(hasher.generateHash()).toNot(beEmpty())
+                        }
+
+                        it("will generate a valid hash for single added value") {
+                            hasher.combine("some value")
+                            expect(hasher.generateHash()).toNot(beEmpty())
+                        }
+
+                        it("will generate a valid hash for multiple added values") {
+                            hasher.combine("some value")
+                            hasher.combine("another value")
+                            hasher.combine("some other value")
+                            expect(hasher.generateHash()).toNot(beEmpty())
+                        }
+
+                        it("will generate the same hash for the same values") {
+                            hasher.combine("some value")
+                            let resultA = hasher.generateHash()
+
+                            var anotherHasher = KeyHasher()
+                            anotherHasher.encryprtionMethod = hasher.encryprtionMethod
+                            anotherHasher.salt = hasher.salt
+                            anotherHasher.combine("some value")
+                            let resultB = anotherHasher.generateHash()
+
+                            expect(resultA).to(equal(resultB))
+                        }
+
+                        it("will generate different hash for different values") {
+                            hasher.combine("some value")
+                            let resultA = hasher.generateHash()
+
+                            var anotherHasher = KeyHasher()
+                            anotherHasher.encryprtionMethod = hasher.encryprtionMethod
+                            anotherHasher.salt = hasher.salt
+                            anotherHasher.combine("another value")
+                            let resultB = anotherHasher.generateHash()
+
+                            expect(resultA).toNot(equal(resultB))
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Tests/KeyHasherSpec.swift
+++ b/Tests/KeyHasherSpec.swift
@@ -30,6 +30,12 @@ class KeyHasherSpec: QuickSpec {
                         expect(hasher.generateHash()).toNot(beEmpty())
                     }
 
+                    it("will generate a valid hash for a very long value") {
+                        let longString = Array(repeating: "123abc!@#", count: 100).joined()
+                        hasher.combine(longString)
+                        expect(hasher.generateHash()).toNot(beEmpty())
+                    }
+
                     it("will generate a valid hash for single added value") {
                         hasher.combine("some value")
                         expect(hasher.generateHash()).toNot(beEmpty())

--- a/Tests/KeyHasherSpec.swift
+++ b/Tests/KeyHasherSpec.swift
@@ -5,7 +5,7 @@ import Nimble
 class KeyHasherSpec: QuickSpec {
 
     override func spec() {
-        // Be sure to run those tests for ios version >=13.0 and <13.0
+
         describe("KeyHasher") {
 
             var hasher: KeyHasher!
@@ -18,7 +18,7 @@ class KeyHasherSpec: QuickSpec {
                 context("when using \(encryption) encryption method") {
 
                     beforeEach {
-                        hasher.encryprtionMethod = encryption
+                        hasher.encryptionMethod = encryption
                     }
 
                     it("will generate a valid hash for empty data") {
@@ -47,7 +47,7 @@ class KeyHasherSpec: QuickSpec {
                         let resultA = hasher.generateHash()
 
                         var anotherHasher = KeyHasher()
-                        anotherHasher.encryprtionMethod = hasher.encryprtionMethod
+                        anotherHasher.encryptionMethod = hasher.encryptionMethod
                         anotherHasher.combine("some value")
                         let resultB = anotherHasher.generateHash()
 
@@ -59,7 +59,7 @@ class KeyHasherSpec: QuickSpec {
                         let resultA = hasher.generateHash()
 
                         var anotherHasher = KeyHasher()
-                        anotherHasher.encryprtionMethod = hasher.encryprtionMethod
+                        anotherHasher.encryptionMethod = hasher.encryptionMethod
                         anotherHasher.combine("another value")
                         let resultB = anotherHasher.generateHash()
 
@@ -98,7 +98,7 @@ class KeyHasherSpec: QuickSpec {
                             let resultA = hasher.generateHash()
 
                             var anotherHasher = KeyHasher()
-                            anotherHasher.encryprtionMethod = hasher.encryprtionMethod
+                            anotherHasher.encryptionMethod = hasher.encryptionMethod
                             anotherHasher.salt = hasher.salt
                             anotherHasher.combine("some value")
                             let resultB = anotherHasher.generateHash()
@@ -111,7 +111,7 @@ class KeyHasherSpec: QuickSpec {
                             let resultA = hasher.generateHash()
 
                             var anotherHasher = KeyHasher()
-                            anotherHasher.encryprtionMethod = hasher.encryprtionMethod
+                            anotherHasher.encryptionMethod = hasher.encryptionMethod
                             anotherHasher.salt = hasher.salt
                             anotherHasher.combine("another value")
                             let resultB = anotherHasher.generateHash()

--- a/Tests/UserDataCacheSpec.swift
+++ b/Tests/UserDataCacheSpec.swift
@@ -74,7 +74,7 @@ class UserDataCacheSpec: QuickSpec {
                 expect(userContainer?.campaignData).to(equal(campaigns))
             }
 
-            it("will not return data from anonymous user container") {
+            it("will not return registered user data from anonymous user container") {
                 let previousUserCache = UserDataCache(userDefaults: userDefaults)
                 let campaigns = TestHelpers.MockResponse.withGeneratedCampaigns(count: 2, test: false, delay: 0).data
                 previousUserCache.cacheCampaignData(campaigns, userIdentifiers: [])


### PR DESCRIPTION
# Description
This hashing method was easiest to implement.
We can discuss alternative approach if this one is not secure enough.

## Links
SDKCF-3667

# Checklist
- [X] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [X] I wrote/updated tests for new/changed code
- [X] I removed all sensitive data **before every commit**, including API endpoints and keys
- [X] I ran `fastlane ci` without errors
