### PR TITLE
fix: fix isOptedOut persistence, reset campaigns queue on user change, fix tests (SDKCF-3656)

### DIFF
--- a/RInAppMessaging/Classes/InAppMessagingModule.swift
+++ b/RInAppMessaging/Classes/InAppMessagingModule.swift
@@ -85,10 +85,20 @@ internal class InAppMessagingModule: AnalyticsBroadcaster,
         guard isEnabled else {
             return
         }
+
+        let diff: [IAMPreference.Field]?
+        if let preference = preference {
+            diff = preference.diff(preferenceRepository.preference)
+        } else {
+            diff = preferenceRepository.preference == nil ? [] : nil
+        }
         preferenceRepository.setPreference(preference)
 
         guard isInitialized else {
             return
+        }
+        if diff?.isEmpty != true && diff != [.accessToken] {
+            readyCampaignDispatcher.resetQueue()
         }
         campaignRepository.loadCachedData()
         campaignsListManager.refreshList()

--- a/RInAppMessaging/Classes/Models/Responses/PingResponse.swift
+++ b/RInAppMessaging/Classes/Models/Responses/PingResponse.swift
@@ -15,6 +15,7 @@ internal struct Campaign: Codable, Hashable {
     private enum CodingKeys: String, CodingKey {
         case data = "campaignData"
         case impressionsLeft // Cache coding only
+        case isOptedOut // Cache coding only
     }
 
     let data: CampaignData
@@ -38,6 +39,7 @@ internal struct Campaign: Codable, Hashable {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         let data = try container.decode(CampaignData.self, forKey: .data)
         impressionsLeft = (try? container.decode(Int.self, forKey: .impressionsLeft)) ?? data.maxImpressions
+        isOptedOut = (try? container.decode(Bool.self, forKey: .isOptedOut)) ?? false
         self.data = data
     }
 
@@ -45,6 +47,7 @@ internal struct Campaign: Codable, Hashable {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(data, forKey: .data)
         try container.encode(impressionsLeft, forKey: .impressionsLeft)
+        try container.encode(isOptedOut, forKey: .isOptedOut)
     }
 
     init(data: CampaignData) {

--- a/RInAppMessaging/Classes/Protocols/TaskSchedulable.swift
+++ b/RInAppMessaging/Classes/Protocols/TaskSchedulable.swift
@@ -9,10 +9,19 @@ internal protocol TaskSchedulable: AnyObject {
     /// - Parameter task: A block of code to run after the delay.
     /// - Parameter wallDeadline: Set `true` to use wall time (gettimeofday) instead of absolute time to ensure execution after returning from background
     func scheduleTask(milliseconds: Int, wallDeadline: Bool, _ task: @escaping () -> Void)
+
+    /// Schedules a task to be ran after a certain delay. Keeps reference of the `DispatchWorkItem`
+    /// so that the work can be cancelled at any time. `wallDeadline` is set to false.
+    /// - Parameter milliseconds: Delay before running the task in milliseconds.
+    /// - Parameter task: A block of code to run after the delay.
+    func scheduleTask(milliseconds: Int, _ task: @escaping () -> Void)
 }
 
 /// Default implementation.
 extension TaskSchedulable {
+    func scheduleTask(milliseconds: Int, _ task: @escaping () -> Void) {
+        scheduleTask(milliseconds: milliseconds, wallDeadline: false, task)
+    }
     func scheduleTask(milliseconds: Int, wallDeadline: Bool, _ task: @escaping () -> Void) {
         DispatchQueue.main.async {
             self.scheduledTask?.cancel()

--- a/RInAppMessaging/Classes/Repositories/CampaignRepository.swift
+++ b/RInAppMessaging/Classes/Repositories/CampaignRepository.swift
@@ -110,10 +110,8 @@ internal class CampaignRepository: CampaignRepositoryType {
     }
 
     func loadCachedData() {
-        guard let cachedData = userDataCache.getUserData(identifiers: preferenceRepository.getUserIdentifiers())?.campaignData else {
-            return
-        }
-        campaigns.set(value: cachedData)
+        let cachedData = userDataCache.getUserData(identifiers: preferenceRepository.getUserIdentifiers())?.campaignData
+        campaigns.set(value: cachedData ?? [])
     }
 
     private func findCampaign(withID id: String) -> Campaign? {

--- a/Tests/CampaignRepositorySpec.swift
+++ b/Tests/CampaignRepositorySpec.swift
@@ -160,6 +160,25 @@ class CampaignRepositorySpec: QuickSpec {
                     expect(userDataCache.cachedCampaignData?.first?.impressionsLeft).to(equal(testCampaign.impressionsLeft + 1))
                 }
             }
+
+            context("when loadCache is called") {
+
+                it("will populate campaign list from cache data") {
+                    userDataCache.userDataMock = UserDataCacheContainer(campaignData: [testCampaign])
+                    expect(campaignRepository.list).to(beEmpty())
+                    campaignRepository.loadCachedData()
+                    expect(campaignRepository.list).to(haveCount(1))
+                }
+
+                it("will clear campaign list if there is no cache data (user change)") {
+                    userDataCache.userDataMock = UserDataCacheContainer(campaignData: [testCampaign])
+                    campaignRepository.loadCachedData()
+                    expect(campaignRepository.list).to(haveCount(1))
+                    userDataCache.userDataMock = nil
+                    campaignRepository.loadCachedData()
+                    expect(campaignRepository.list).to(beEmpty())
+                }
+            }
         }
     }
 }

--- a/Tests/ConfigurationSpec.swift
+++ b/Tests/ConfigurationSpec.swift
@@ -48,6 +48,7 @@ class ConfigurationSpec: QuickSpec {
                     }
 
                     expect(RInAppMessaging.initializedModule).toEventually(beNil())
+                    expect(RInAppMessaging.dependencyManager).to(beNil())
                 }
 
                 it("will not call ping") {

--- a/Tests/Helpers/SharedMocks.swift
+++ b/Tests/Helpers/SharedMocks.swift
@@ -64,9 +64,9 @@ class CampaignRepositoryMock: CampaignRepositoryType {
 
 class CampaignDispatcherMock: CampaignDispatcherType {
     weak var delegate: CampaignDispatcherDelegate?
-    private(set) var wasDispatchCalled = false
-    private(set) var addedCampaigns = [Campaign]()
-    private(set) var wasResetQueueCalled = false
+    var wasDispatchCalled = false
+    var addedCampaigns = [Campaign]()
+    var wasResetQueueCalled = false
 
     func addToQueue(campaign: Campaign) {
         addedCampaigns.append(campaign)

--- a/Tests/InAppMessagingModuleSpec.swift
+++ b/Tests/InAppMessagingModuleSpec.swift
@@ -247,6 +247,34 @@ class InAppMessagingModuleSpec: QuickSpec {
                                 iamModule.registerPreference(IAMPreference())
                                 expect(campaignRepository.wasLoadCachedDataCalled).to(beTrue())
                             }
+
+                            it("will reset dispatch queue if new preference has different ids") {
+                                iamModule.registerPreference(IAMPreferenceBuilder().setUserId("user").build())
+                                readyCampaignDispatcher.wasResetQueueCalled = false
+                                iamModule.registerPreference(IAMPreferenceBuilder().setUserId("user2").build())
+                                expect(readyCampaignDispatcher.wasResetQueueCalled).to(beTrue())
+                            }
+
+                            it("will reset dispatch queue if previous preference was nil") {
+                                iamModule.registerPreference(nil)
+                                readyCampaignDispatcher.wasResetQueueCalled = false
+                                iamModule.registerPreference(IAMPreferenceBuilder().setUserId("user2").build())
+                                expect(readyCampaignDispatcher.wasResetQueueCalled).to(beTrue())
+                            }
+
+                            it("will not reset dispatch queue if new preference has the same id") {
+                                iamModule.registerPreference(IAMPreferenceBuilder().setUserId("user").build())
+                                readyCampaignDispatcher.wasResetQueueCalled = false
+                                iamModule.registerPreference(IAMPreferenceBuilder().setUserId("user").build())
+                                expect(readyCampaignDispatcher.wasResetQueueCalled).to(beFalse())
+                            }
+
+                            it("will not reset dispatch queue if just accessToken was added/modified") {
+                                iamModule.registerPreference(IAMPreferenceBuilder().setUserId("user").setAccessToken("token1").build())
+                                readyCampaignDispatcher.wasResetQueueCalled = false
+                                iamModule.registerPreference(IAMPreferenceBuilder().setUserId("user").setAccessToken("token2").build())
+                                expect(readyCampaignDispatcher.wasResetQueueCalled).to(beFalse())
+                            }
                         }
 
                         context("and module is not initialized") {
@@ -265,6 +293,13 @@ class InAppMessagingModuleSpec: QuickSpec {
                             it("will not reload campaigns repository cache") {
                                 iamModule.registerPreference(IAMPreference())
                                 expect(campaignRepository.wasLoadCachedDataCalled).to(beFalse())
+                            }
+
+                            it("will not reset dispatch queue even if new preference has different ids") {
+                                iamModule.registerPreference(IAMPreferenceBuilder().setUserId("user").build())
+                                readyCampaignDispatcher.wasResetQueueCalled = false
+                                iamModule.registerPreference(IAMPreferenceBuilder().setUserId("user2").build())
+                                expect(readyCampaignDispatcher.wasResetQueueCalled).to(beFalse())
                             }
                         }
                     }

--- a/Tests/PublicAPISpec.swift
+++ b/Tests/PublicAPISpec.swift
@@ -228,11 +228,11 @@ class PublicAPISpec: QuickSpec {
                         return false
                     }))
 
+                    RInAppMessaging.deinitializeModule()
                     reinitializeSDK()
-                    campaignsListManager.refreshList()
                     expect(campaignRepository.list).to(haveCount(1))
                     expect(campaignRepository.list.first?.impressionsLeft).to(equal(1))
-                    RInAppMessaging.logEvent(LoginSuccessfulEvent())
+                    generateAndDisplayLoginCampaigns(count: 1, addContexts: false)
 
                     expect(UIApplication.shared.keyWindow?.subviews).toEventually(containElementSatisfying({
                         if let view = $0 as? BaseView {
@@ -244,12 +244,13 @@ class PublicAPISpec: QuickSpec {
                 }
 
                 it("will not show a message if impressionsLeft was 0 in the last session") {
-                    messageMixerService.mockedResponse = PingResponse(
+                    let mockedResponse = PingResponse(
                         nextPingMilliseconds: Int.max,
                         currentPingMilliseconds: 0,
                         data: [TestHelpers.generateCampaign(id: "test", test: false, delay: 100, maxImpressions: 1,
                                                             triggers: [Trigger(type: .event, eventType: .loginSuccessful,
                                                                                eventName: "e1", attributes: [])])])
+                    messageMixerService.mockedResponse = mockedResponse
                     campaignsListManager.refreshList()
                     RInAppMessaging.logEvent(LoginSuccessfulEvent())
 
@@ -261,7 +262,9 @@ class PublicAPISpec: QuickSpec {
                         return false
                     }))
 
+                    RInAppMessaging.deinitializeModule()
                     reinitializeSDK()
+                    messageMixerService.mockedResponse = mockedResponse
                     campaignsListManager.refreshList()
                     expect(campaignRepository.list).to(haveCount(1))
                     RInAppMessaging.logEvent(LoginSuccessfulEvent())
@@ -282,10 +285,10 @@ class PublicAPISpec: QuickSpec {
                         return false
                     }))
 
+                    RInAppMessaging.deinitializeModule()
                     reinitializeSDK()
-                    campaignsListManager.refreshList()
                     expect(campaignRepository.list).to(haveCount(1))
-                    RInAppMessaging.logEvent(LoginSuccessfulEvent())
+                    generateAndDisplayLoginCampaigns(count: 1, addContexts: false)
 
                     expect(UIApplication.shared.keyWindow?.subviews)
                         .toAfterTimeout(allPass({ !($0 is BaseView) }))

--- a/Tests/ReadyCampaignDispatcherSpec.swift
+++ b/Tests/ReadyCampaignDispatcherSpec.swift
@@ -236,6 +236,13 @@ class ReadyCampaignDispatcherSpec: QuickSpec {
                         expect(router.lastDisplayedCampaign).toEventually(equal(testCampaigns[2]))
                         expect(router.displayedCampaignsCount).to(equal(2))
                     }
+
+                    it("will stop scheduled dispatch") {
+                        expect(dispatcher.scheduledTask).toEventuallyNot(beNil()) // wait
+                        dispatcher.resetQueue()
+                        expect(dispatcher.scheduledTask?.isCancelled).to(beTrue())
+                        expect(router.displayedCampaignsCount).toAfterTimeout(equal(1))
+                    }
                 }
             }
 


### PR DESCRIPTION
# Description

- Fix for unit tests that didn't detect the issue with opt-out
- isOptedOut flag is persisted now
- improvements for user preference update logic

## Links
SDKCF-3656

# Checklist
- [X] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [X] I wrote/updated tests for new/changed code
- [X] I removed all sensitive data **before every commit**, including API endpoints and keys
- [ ] I ran `fastlane ci` without errors
