### PR TITLE
improve: handle transition of anonymous user -> logged-in user (SDKCF-3710)

### DIFF
--- a/RInAppMessaging/Classes/CampaignDispatcher.swift
+++ b/RInAppMessaging/Classes/CampaignDispatcher.swift
@@ -91,14 +91,13 @@ internal class CampaignDispatcher: CampaignDispatcherType, TaskSchedulable {
             }
             let shouldShow = delegate.shouldShowCampaignMessage(title: campaignTitle,
                                                                 contexts: contexts)
-            if !shouldShow {
-                campaignRepository.incrementImpressionsLeftInCampaign(id: campaign.id)
-            }
             return shouldShow
 
         }(), completion: { cancelled in
             self.dispatchQueue.async {
-
+                if cancelled {
+                    self.campaignRepository.incrementImpressionsLeftInCampaign(id: campaign.id)
+                }
                 guard !self.queuedCampaigns.isEmpty else {
                     self.isDispatching = false
                     return

--- a/RInAppMessaging/Classes/InAppMessagingModule.swift
+++ b/RInAppMessaging/Classes/InAppMessagingModule.swift
@@ -92,15 +92,17 @@ internal class InAppMessagingModule: AnalyticsBroadcaster,
         } else {
             diff = preferenceRepository.preference == nil ? [] : nil
         }
+        let isFirstUser = preferenceRepository.getUserIdentifiers().isEmpty && diff?.isEmpty == false
         preferenceRepository.setPreference(preference)
 
         guard isInitialized else {
             return
         }
         if diff?.isEmpty != true && diff != [.accessToken] {
+            // reset only if identifiers changed
             readyCampaignDispatcher.resetQueue()
         }
-        campaignRepository.loadCachedData()
+        campaignRepository.loadCachedData(syncWithDefaultUserData: isFirstUser)
         campaignsListManager.refreshList()
     }
 

--- a/Tests/CampaignRepositorySpec.swift
+++ b/Tests/CampaignRepositorySpec.swift
@@ -9,6 +9,7 @@ class CampaignRepositorySpec: QuickSpec {
 
             var campaignRepository: CampaignRepository!
             var userDataCache: UserDataCacheMock!
+            var preferenceRepository: IAMPreferenceRepository!
             var firstPersistedCampaign: Campaign? {
                 return campaignRepository.list.first
             }
@@ -24,11 +25,12 @@ class CampaignRepositorySpec: QuickSpec {
 
             beforeEach {
                 userDataCache = UserDataCacheMock()
-                campaignRepository = CampaignRepository(userDataCache: userDataCache, preferenceRepository: IAMPreferenceRepository())
+                preferenceRepository = IAMPreferenceRepository()
+                campaignRepository = CampaignRepository(userDataCache: userDataCache, preferenceRepository: preferenceRepository)
             }
 
-            it("will load cache data during initialization") {
-                userDataCache.userDataMock = UserDataCacheContainer(campaignData: [testCampaign])
+            it("will load default user cache data during initialization") {
+                userDataCache.defaultUserDataMock = UserDataCacheContainer(campaignData: [testCampaign])
                 campaignRepository = CampaignRepository(userDataCache: userDataCache, preferenceRepository: IAMPreferenceRepository())
                 expect(campaignRepository.list).to(equal([testCampaign]))
             }
@@ -93,9 +95,18 @@ class CampaignRepositorySpec: QuickSpec {
                     expect(firstPersistedCampaign?.impressionsLeft).to(equal(4))
                 }
 
-                it("will save updated list to the cache") {
+                it("will save updated list to the cache (anonymous user)") {
                     campaignRepository.syncWith(list: [testCampaign], timestampMilliseconds: 0)
                     expect(userDataCache.cachedCampaignData).to(equal([testCampaign]))
+                }
+
+                it("will save updated list to the cache (logged-in user)") {
+                    preferenceRepository.setPreference(IAMPreferenceBuilder().setUserId("user").build())
+                    campaignRepository.syncWith(list: [testCampaign], timestampMilliseconds: 0)
+                    let userCache = userDataCache.cachedData[preferenceRepository.getUserIdentifiers()]
+                    let defaultUserCache = userDataCache.cachedData[[]]
+                    expect(userCache?.campaignData).to(equal([testCampaign]))
+                    expect(defaultUserCache?.campaignData).to(equal(userCache?.campaignData))
                 }
             }
 
@@ -109,10 +120,20 @@ class CampaignRepositorySpec: QuickSpec {
                     expect(firstPersistedCampaign?.isOptedOut).to(beTrue())
                 }
 
-                it("will save updated list to the cache") {
+                it("will save updated list to the cache (anonymous user)") {
                     campaignRepository.syncWith(list: [testCampaign], timestampMilliseconds: 0)
                     campaignRepository.optOutCampaign(testCampaign)
                     expect(userDataCache.cachedCampaignData?.first?.isOptedOut).to(beTrue())
+                }
+
+                it("will save updated list to the cache (logged-in user)") {
+                    preferenceRepository.setPreference(IAMPreferenceBuilder().setUserId("user").build())
+                    campaignRepository.syncWith(list: [testCampaign], timestampMilliseconds: 0)
+                    campaignRepository.optOutCampaign(testCampaign)
+                    let userCache = userDataCache.cachedData[preferenceRepository.getUserIdentifiers()]
+                    let defaultUserCache = userDataCache.cachedData[[]]
+                    expect(userCache?.campaignData?.first?.isOptedOut).to(beTrue())
+                    expect(defaultUserCache?.campaignData).to(equal(userCache?.campaignData))
                 }
             }
 
@@ -137,10 +158,20 @@ class CampaignRepositorySpec: QuickSpec {
                     expect(firstPersistedCampaign?.impressionsLeft).to(equal(0))
                 }
 
-                it("will save updated list to the cache") {
+                it("will save updated list to the cache (anonymous user)") {
                     campaignRepository.syncWith(list: [testCampaign], timestampMilliseconds: 0)
                     campaignRepository.decrementImpressionsLeftInCampaign(id: testCampaign.id)
                     expect(userDataCache.cachedCampaignData?.first?.impressionsLeft).to(equal(testCampaign.impressionsLeft - 1))
+                }
+
+                it("will save updated list to the cache (logged-in user)") {
+                    preferenceRepository.setPreference(IAMPreferenceBuilder().setUserId("user").build())
+                    campaignRepository.syncWith(list: [testCampaign], timestampMilliseconds: 0)
+                    campaignRepository.decrementImpressionsLeftInCampaign(id: testCampaign.id)
+                    let userCache = userDataCache.cachedData[preferenceRepository.getUserIdentifiers()]
+                    let defaultUserCache = userDataCache.cachedData[[]]
+                    expect(userCache?.campaignData?.first?.impressionsLeft).to(equal(testCampaign.impressionsLeft - 1))
+                    expect(defaultUserCache?.campaignData).to(equal(userCache?.campaignData))
                 }
             }
 
@@ -154,29 +185,127 @@ class CampaignRepositorySpec: QuickSpec {
                     expect(firstPersistedCampaign?.impressionsLeft).to(equal(4))
                 }
 
-                it("will save updated list to the cache") {
+                it("will save updated list to the cache (anonymous user)") {
                     campaignRepository.syncWith(list: [testCampaign], timestampMilliseconds: 0)
                     campaignRepository.incrementImpressionsLeftInCampaign(id: testCampaign.id)
                     expect(userDataCache.cachedCampaignData?.first?.impressionsLeft).to(equal(testCampaign.impressionsLeft + 1))
                 }
+
+                it("will save updated list to the cache (logged-in user)") {
+                    preferenceRepository.setPreference(IAMPreferenceBuilder().setUserId("user").build())
+                    campaignRepository.syncWith(list: [testCampaign], timestampMilliseconds: 0)
+                    campaignRepository.incrementImpressionsLeftInCampaign(id: testCampaign.id)
+                    let userCache = userDataCache.cachedData[preferenceRepository.getUserIdentifiers()]
+                    let defaultUserCache = userDataCache.cachedData[[]]
+                    expect(userCache?.campaignData?.first?.impressionsLeft).to(equal(testCampaign.impressionsLeft + 1))
+                    expect(defaultUserCache?.campaignData).to(equal(userCache?.campaignData))
+                }
             }
 
             context("when loadCache is called") {
+                context("and no user is logged in (default user cache)") {
 
-                it("will populate campaign list from cache data") {
-                    userDataCache.userDataMock = UserDataCacheContainer(campaignData: [testCampaign])
-                    expect(campaignRepository.list).to(beEmpty())
-                    campaignRepository.loadCachedData()
-                    expect(campaignRepository.list).to(haveCount(1))
+                    beforeEach {
+                        userDataCache.defaultUserDataMock = UserDataCacheContainer(campaignData: [testCampaign])
+                        userDataCache.userDataMock = nil
+                        preferenceRepository.setPreference(nil)
+                    }
+
+                    context("and syncWithDefaultUserData set to false") {
+
+                        it("will populate campaign list from cache data") {
+                            expect(campaignRepository.list).to(beEmpty())
+                            campaignRepository.loadCachedData(syncWithDefaultUserData: false)
+                            expect(campaignRepository.list).to(haveCount(1))
+                        }
+
+                        it("will clear old campaign list if there is no cache data") {
+                            campaignRepository.loadCachedData(syncWithDefaultUserData: false)
+                            expect(campaignRepository.list).to(haveCount(1))
+                            userDataCache.defaultUserDataMock = nil
+                            campaignRepository.loadCachedData(syncWithDefaultUserData: false)
+                            expect(campaignRepository.list).to(beEmpty())
+                        }
+                    }
+
+                    context("and syncWithDefaultUserData set to true") {
+
+                        it("will populate campaign list from cache data") {
+                            userDataCache.userDataMock = UserDataCacheContainer(campaignData: [testCampaign])
+                            expect(campaignRepository.list).to(beEmpty())
+                            campaignRepository.loadCachedData(syncWithDefaultUserData: true)
+                            expect(campaignRepository.list).to(haveCount(1))
+                        }
+                    }
                 }
 
-                it("will clear campaign list if there is no cache data (user change)") {
-                    userDataCache.userDataMock = UserDataCacheContainer(campaignData: [testCampaign])
-                    campaignRepository.loadCachedData()
-                    expect(campaignRepository.list).to(haveCount(1))
-                    userDataCache.userDataMock = nil
-                    campaignRepository.loadCachedData()
-                    expect(campaignRepository.list).to(beEmpty())
+                context("and user is logged in") {
+                    let modifiedTestCampaign = TestHelpers.generateCampaign(id: "testImpressions",
+                                                                            test: false,
+                                                                            delay: 0,
+                                                                            maxImpressions: 0)
+                    let otherTestCampaign = TestHelpers.generateCampaign(id: "test2",
+                                                                         test: false,
+                                                                         delay: 0,
+                                                                         maxImpressions: 3)
+
+                    beforeEach {
+                        preferenceRepository.setPreference(IAMPreferenceBuilder().setUserId("user").build())
+                    }
+
+                    context("and syncWithDefaultUserData set to false") {
+
+                        beforeEach {
+                            userDataCache.defaultUserDataMock = UserDataCacheContainer(campaignData: [modifiedTestCampaign, otherTestCampaign])
+                            userDataCache.userDataMock = nil
+                        }
+
+                        it("will not populate campaign list from cache data") {
+                            expect(campaignRepository.list).to(beEmpty())
+                            campaignRepository.loadCachedData(syncWithDefaultUserData: false)
+                            expect(campaignRepository.list).to(beEmpty())
+                        }
+
+                        it("will clear old campaign list if there is no cache data") {
+                            userDataCache.userDataMock = UserDataCacheContainer(campaignData: [testCampaign])
+                            campaignRepository.loadCachedData(syncWithDefaultUserData: false)
+                            expect(campaignRepository.list).to(haveCount(1))
+                            userDataCache.userDataMock = nil
+                            campaignRepository.loadCachedData(syncWithDefaultUserData: false)
+                            expect(campaignRepository.list).to(beEmpty())
+                        }
+                    }
+
+                    context("and syncWithDefaultUserData set to true") {
+
+                        it("will populate campaign list from cache data if default user cache is empty") {
+                            userDataCache.defaultUserDataMock = nil
+                            userDataCache.userDataMock = UserDataCacheContainer(campaignData: [testCampaign])
+                            campaignRepository.loadCachedData(syncWithDefaultUserData: true)
+                            expect(campaignRepository.list).to(elementsEqual([testCampaign]))
+                        }
+
+                        it("will populate campaign list from default cache data if user cache is empty") {
+                            userDataCache.defaultUserDataMock = UserDataCacheContainer(campaignData: [testCampaign])
+                            userDataCache.userDataMock = nil
+                            campaignRepository.loadCachedData(syncWithDefaultUserData: true)
+                            expect(campaignRepository.list).to(elementsEqual([testCampaign]))
+                        }
+
+                        it("will populate campaign list from cache data and add new campaings from default user cache") {
+                            userDataCache.defaultUserDataMock = UserDataCacheContainer(campaignData: [otherTestCampaign])
+                            userDataCache.userDataMock = UserDataCacheContainer(campaignData: [testCampaign])
+                            campaignRepository.loadCachedData(syncWithDefaultUserData: true)
+                            expect(campaignRepository.list).to(equal([testCampaign, otherTestCampaign]))
+                        }
+
+                        it("will populate campaign list from cache data and update campaings from default user cache") {
+                            userDataCache.defaultUserDataMock = UserDataCacheContainer(campaignData: [modifiedTestCampaign])
+                            userDataCache.userDataMock = UserDataCacheContainer(campaignData: [testCampaign])
+                            campaignRepository.loadCachedData(syncWithDefaultUserData: true)
+                            expect(campaignRepository.list).to(elementsEqual([modifiedTestCampaign]))
+                        }
+                    }
                 }
             }
         }

--- a/Tests/Helpers/SharedMocks.swift
+++ b/Tests/Helpers/SharedMocks.swift
@@ -22,6 +22,7 @@ class CampaignRepositoryMock: CampaignRepositoryType {
     private(set) var wasOptOutCalled = false
     private(set) var lastSyncCampaigns = [Campaign]()
     private(set) var wasLoadCachedDataCalled = false
+    private(set) var loadCachedDataParameters: (Bool)?
 
     func decrementImpressionsLeftInCampaign(id: String) -> Campaign? {
         wasDecrementImpressionsCalled = true
@@ -50,8 +51,18 @@ class CampaignRepositoryMock: CampaignRepositoryType {
         lastSyncCampaigns = list
     }
 
-    func loadCachedData() {
+    func loadCachedData(syncWithDefaultUserData: Bool) {
         wasLoadCachedDataCalled = true
+        loadCachedDataParameters = (syncWithDefaultUserData)
+    }
+
+    func resetFlags() {
+        wasDecrementImpressionsCalled = false
+        wasIncrementImpressionsCalled = false
+        wasOptOutCalled = false
+        lastSyncCampaigns = [Campaign]()
+        wasLoadCachedDataCalled = false
+        loadCachedDataParameters = nil
     }
 
     private func indexAndCampaign(forID id: String) -> (Int, Campaign)? {
@@ -369,19 +380,23 @@ class RouterMock: RouterType {
 
 class UserDataCacheMock: UserDataCacheable {
     var userDataMock: UserDataCacheContainer?
+    var defaultUserDataMock: UserDataCacheContainer?
     var cachedCampaignData: [Campaign]?
     var cachedDisplayPermissionData: (DisplayPermissionResponse, String)?
+    var cachedData = [[UserIdentifier]: UserDataCacheContainer]()
 
     func getUserData(identifiers: [UserIdentifier]) -> UserDataCacheContainer? {
-        return userDataMock
+        identifiers.isEmpty ? defaultUserDataMock : userDataMock
     }
 
     func cacheCampaignData(_ data: [Campaign], userIdentifiers: [UserIdentifier]) {
         cachedCampaignData = data
+        cachedData[userIdentifiers] = UserDataCacheContainer(campaignData: data)
     }
 
     func cacheDisplayPermissionData(_ data: DisplayPermissionResponse, campaignID: String, userIdentifiers: [UserIdentifier]) {
         cachedDisplayPermissionData = (data, campaignID)
+        cachedData[userIdentifiers] = UserDataCacheContainer(displayPermissionData: [campaignID: data])
     }
 }
 


### PR DESCRIPTION
# Description
- Added syncing of anonymous cache and logged-in user cache.
(anon cache is used before logged-in user data reaches the SDK)
- Fixed impression counter update when campaign display is cancelled (onVerify() and closeMessage() API)

## Links
SDKCF-3710

# Checklist
- [X] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [X] I wrote/updated tests for new/changed code
- [X] I removed all sensitive data **before every commit**, including API endpoints and keys
- [X] I ran `fastlane ci` without errors
