### PR TITLE
SDKCF-3646: logEvent crash fix - shared queue

### DIFF
--- a/RInAppMessaging/Classes/DependencyManager/MainContainer.swift
+++ b/RInAppMessaging/Classes/DependencyManager/MainContainer.swift
@@ -33,14 +33,11 @@ internal enum MainContainerFactory {
             ContainerElement(type: ConfigurationRepositoryType.self, factory: {
                 ConfigurationRepository()
             }),
-            ContainerElement(type: DispatchQueue.self, factory: {
-                DispatchQueue(label: "IAM.Main", qos: .utility, attributes: [])
-            }),
             ContainerElement(type: ConfigurationManagerType.self, factory: {
                 ConfigurationManager(reachability: manager.resolve(type: ReachabilityType.self),
                                      configurationService: manager.resolve(type: ConfigurationServiceType.self)!,
                                      configurationRepository: manager.resolve(type: ConfigurationRepositoryType.self)!,
-                                     resumeQueue: manager.resolve(type: DispatchQueue.self)!)
+                                     resumeQueue: RInAppMessaging.inAppQueue)
             }),
             ContainerElement(type: UserDataCacheable.self, factory: {
                 UserDataCache(userDefaults: UserDefaults.standard)

--- a/RInAppMessaging/Classes/RInAppMessaging.swift
+++ b/RInAppMessaging/Classes/RInAppMessaging.swift
@@ -19,9 +19,7 @@
 
     internal private(set) static var initializedModule: InAppMessagingModule?
     private(set) static var dependencyManager: DependencyManager?
-    private static var inAppQueue: DispatchQueue? {
-        dependencyManager?.resolve(type: DispatchQueue.self)
-    }
+    internal static let inAppQueue = DispatchQueue(label: "IAM.Main", qos: .utility, attributes: [])
 
     private override init() { super.init() }
 
@@ -62,7 +60,7 @@
     static func configure(dependencyManager: DependencyManager) {
         self.dependencyManager = dependencyManager
 
-        inAppQueue?.async(flags: .barrier) {
+        inAppQueue.async(flags: .barrier) {
             guard initializedModule == nil else {
                 return
             }
@@ -107,7 +105,7 @@
     /// Log the event name passed in and also pass the event name to the view controller to display a matching campaign.
     /// - Parameter event: The Event object to log.
     @objc public static func logEvent(_ event: Event) {
-        inAppQueue?.async(flags: .barrier) {
+        inAppQueue.async(flags: .barrier) {
             initializedModule?.logEvent(event)
         }
     }
@@ -115,7 +113,7 @@
     /// Register user preference to the IAM SDK.
     /// - Parameter preference: Preferences of the user.
     @objc public static func registerPreference(_ preference: IAMPreference?) {
-        inAppQueue?.async(flags: .barrier) {
+        inAppQueue.async(flags: .barrier) {
             initializedModule?.registerPreference(preference)
         }
     }
@@ -126,14 +124,14 @@
     /// - Parameter clearQueuedCampaigns: when set to true, it will clear also the list of campaigns that were
     ///                                   triggered and are queued to be displayed.
     @objc public static func closeMessage(clearQueuedCampaigns: Bool = false) {
-        inAppQueue?.async(flags: .barrier) {
+        inAppQueue.async(flags: .barrier) {
             initializedModule?.closeMessage(clearQueuedCampaigns: clearQueuedCampaigns)
         }
     }
 
     /// For testing purposes
     internal static func deinitializeModule() {
-        inAppQueue?.sync {
+        inAppQueue.sync {
             initializedModule = nil
         }
     }


### PR DESCRIPTION
# Description
Originally I added the queue to the container to easily set the resumeQueue to ConfigurationManager.
The crash occurs when the queue is resolved in logEvent method.
It is not the best fix but it should solve this crash.

We can decline this PR if we really want to fix the resolving issue in DependencyManager.

Fixes:
- It is safer to use a static immutable queue without resolving it each time we want to use it. It prevents to have a invalid reference.
- It solves the situation when dependencyManager is deallocated by IAM.Main thread because of config response telling SDK to disable, and at the same time dependencyManager is accessed from main thread during logEvent() to get the queue reference.

## Links
SDKCF-3646

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data **before every commit**, including API endpoints and keys
- [x] I ran `fastlane ci` without errors
