### PR TITLE
improve: add subscription id in config api header SDKCF-3716

### DIFF
--- a/RInAppMessaging/Classes/Services/ConfigurationService.swift
+++ b/RInAppMessaging/Classes/Services/ConfigurationService.swift
@@ -23,7 +23,8 @@ internal struct ConfigurationService: ConfigurationServiceType, HttpRequestable 
         let response = requestFromServerSync(
             url: configURL,
             httpMethod: .get,
-            addtionalHeaders: nil)
+            addtionalHeaders: buildRequestHeader()
+        )
 
         switch response {
         case .success((let data, _)):
@@ -70,7 +71,21 @@ extension ConfigurationService {
         )
     }
 
-    func buildURLRequest(url: URL) -> Result<URLRequest, Error> {
+    private func buildRequestHeader() -> [HeaderAttribute] {
+        let Keys = Constants.Request.Header.self
+        var additionalHeaders: [HeaderAttribute] = []
+
+        if let subId = bundleInfo.inAppSubscriptionId, !subId.isEmpty {
+            additionalHeaders.append(HeaderAttribute(key: Keys.subscriptionID, value: subId))
+        } else {
+            Logger.debug("Info.plist must contain a valid InAppMessagingAppSubscriptionID")
+            assertionFailure()
+        }
+
+        return additionalHeaders
+    }
+
+   func buildURLRequest(url: URL) -> Result<URLRequest, Error> {
         do {
             let request = try getConfigRequest()
             var urlComponents = URLComponents(url: url, resolvingAgainstBaseURL: true)

--- a/Tests/ConfigurationServiceSpec.swift
+++ b/Tests/ConfigurationServiceSpec.swift
@@ -19,6 +19,10 @@ class ConfigurationServiceSpec: QuickSpec {
 
                 service = ConfigurationService(configURL: configURL,
                                                sessionConfiguration: .default)
+
+                BundleInfoMock.reset()
+                service.bundleInfo = BundleInfoMock.self
+
                 httpSession = URLSessionMock.mock(originalInstance: service.httpSession)
             }
 

--- a/Tests/ConfigurationServiceSpec.swift
+++ b/Tests/ConfigurationServiceSpec.swift
@@ -199,6 +199,20 @@ class ConfigurationServiceSpec: QuickSpec {
                     expect(request?.sdkVersion).to(equal(BundleInfoMock.inAppSdkVersion))
                 }
 
+                it("will send subscription id in header") {
+                    waitUntil { done in
+                        requestQueue.async {
+                            _ = service.getConfigData()
+                            done()
+                        }
+                    }
+
+                    let Keys = Constants.Request.Header.self
+                    let headers = httpSession.sentRequest?.allHTTPHeaderFields
+                    expect(headers).toNot(beEmpty())
+                    expect(headers?[Keys.subscriptionID]).to(equal(BundleInfoMock.inAppSubscriptionId))
+                }
+
                 context("and required data is missing") {
 
                     func makeRequestAndEvaluateError() {


### PR DESCRIPTION
# Description
Add subscription id to Config API request header

## Links
SDKCF-3716

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data **before every commit**, including API endpoints and keys
- [x] I ran `fastlane ci` without errors
