### PR TITLE
fix: fix user data cache sync (SDKCF-3710)

### DIFF
--- a/RInAppMessaging/Classes/CampaignDispatcher.swift
+++ b/RInAppMessaging/Classes/CampaignDispatcher.swift
@@ -23,7 +23,7 @@ internal class CampaignDispatcher: CampaignDispatcherType, TaskSchedulable {
 
     private let dispatchQueue = DispatchQueue(label: "IAM.Campaign", qos: .userInteractive)
     private var queuedCampaigns = [Campaign]()
-    @AtomicGetSet private(set) var isDispatching = false
+    private(set) var isDispatching = false
 
     weak var delegate: CampaignDispatcherDelegate?
     var scheduledTask: DispatchWorkItem?
@@ -44,9 +44,13 @@ internal class CampaignDispatcher: CampaignDispatcherType, TaskSchedulable {
     }
 
     func resetQueue() {
-        isDispatching = false
-        scheduledTask?.cancel()
         dispatchQueue.async {
+            let isDisplayingCampaign = self.scheduledTask == nil && self.isDispatching
+            if !isDisplayingCampaign {
+                self.isDispatching = false
+                self.scheduledTask?.cancel()
+            }
+
             self.queuedCampaigns.removeAll()
         }
     }

--- a/RInAppMessaging/Classes/Protocols/Lockable.swift
+++ b/RInAppMessaging/Classes/Protocols/Lockable.swift
@@ -12,6 +12,9 @@ internal protocol LockableResource {
     func unlock()
 }
 
+// The following rule is disabled to ensure thread safety
+// swiftlint:disable shorthand_operator
+
 /// Object-wrapper that conforms to LockableResource protocol.
 /// Used to control getter and setter of given resource.
 /// When lock() has been called on some thread, only that thread will be able to access the resource.
@@ -42,15 +45,15 @@ internal class LockableObject<T>: LockableResource {
         if shouldWait {
             dispatchGroup.wait()
         }
-        lockCount += 1
+        lockCount = lockCount + 1
         lockingThread = Thread.current
         dispatchGroup.enter()
     }
 
     func unlock() {
         if lockCount > 0 {
+            lockCount = lockCount - 1
             dispatchGroup.leave()
-            lockCount -= 1
         } else {
             lockingThread = nil
         }

--- a/RInAppMessaging/Classes/RInAppMessaging.swift
+++ b/RInAppMessaging/Classes/RInAppMessaging.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 /// Protocol for optional delagate
 @objc public protocol RInAppMessagingDelegate: AnyObject {
     /// Method called only for campaigns with context just before displaying its message
@@ -133,6 +135,7 @@
     internal static func deinitializeModule() {
         inAppQueue.sync {
             initializedModule = nil
+            dependencyManager = nil
         }
     }
 }

--- a/RInAppMessaging/Classes/UserDataCache.swift
+++ b/RInAppMessaging/Classes/UserDataCache.swift
@@ -2,6 +2,7 @@ internal protocol UserDataCacheable: AnyObject {
     func getUserData(identifiers: [UserIdentifier]) -> UserDataCacheContainer?
     func cacheCampaignData(_ data: [Campaign], userIdentifiers: [UserIdentifier])
     func cacheDisplayPermissionData(_ data: DisplayPermissionResponse, campaignID: String, userIdentifiers: [UserIdentifier])
+    func deleteUserData(identifiers: [UserIdentifier])
 }
 
 internal struct UserDataCacheContainer: Codable, Equatable {
@@ -61,6 +62,12 @@ internal class UserDataCache: UserDataCacheable {
         var currentData = cachedContainers[cacheKey] ?? UserDataCacheContainer()
         currentData.displayPermissionData[campaignID] = data
         cachedContainers[cacheKey] = currentData
+        saveData()
+    }
+
+    func deleteUserData(identifiers: [UserIdentifier]) {
+        let cacheKey = userKey(from: identifiers)
+        cachedContainers[cacheKey] = nil
         saveData()
     }
 

--- a/Tests/CampaignRepositorySpec.swift
+++ b/Tests/CampaignRepositorySpec.swift
@@ -13,6 +13,12 @@ class CampaignRepositorySpec: QuickSpec {
             var firstPersistedCampaign: Campaign? {
                 return campaignRepository.list.first
             }
+            var userCache: UserDataCacheContainer? {
+                userDataCache.cachedData[preferenceRepository.getUserIdentifiers()]
+            }
+            var lastUserCache: UserDataCacheContainer? {
+                userDataCache.cachedData[CampaignRepository.lastUser]
+            }
             let testCampaign = TestHelpers.generateCampaign(id: "testImpressions",
                                                             test: false,
                                                             delay: 0,
@@ -29,8 +35,8 @@ class CampaignRepositorySpec: QuickSpec {
                 campaignRepository = CampaignRepository(userDataCache: userDataCache, preferenceRepository: preferenceRepository)
             }
 
-            it("will load default user cache data during initialization") {
-                userDataCache.defaultUserDataMock = UserDataCacheContainer(campaignData: [testCampaign])
+            it("will load last user cache data during initialization") {
+                userDataCache.lastUserDataMock = UserDataCacheContainer(campaignData: [testCampaign])
                 campaignRepository = CampaignRepository(userDataCache: userDataCache, preferenceRepository: IAMPreferenceRepository())
                 expect(campaignRepository.list).to(equal([testCampaign]))
             }
@@ -98,15 +104,14 @@ class CampaignRepositorySpec: QuickSpec {
                 it("will save updated list to the cache (anonymous user)") {
                     campaignRepository.syncWith(list: [testCampaign], timestampMilliseconds: 0)
                     expect(userDataCache.cachedCampaignData).to(equal([testCampaign]))
+                    expect(lastUserCache?.campaignData).to(equal(userCache?.campaignData))
                 }
 
                 it("will save updated list to the cache (logged-in user)") {
                     preferenceRepository.setPreference(IAMPreferenceBuilder().setUserId("user").build())
                     campaignRepository.syncWith(list: [testCampaign], timestampMilliseconds: 0)
-                    let userCache = userDataCache.cachedData[preferenceRepository.getUserIdentifiers()]
-                    let defaultUserCache = userDataCache.cachedData[[]]
                     expect(userCache?.campaignData).to(equal([testCampaign]))
-                    expect(defaultUserCache?.campaignData).to(equal(userCache?.campaignData))
+                    expect(lastUserCache?.campaignData).to(equal(userCache?.campaignData))
                 }
             }
 
@@ -124,16 +129,15 @@ class CampaignRepositorySpec: QuickSpec {
                     campaignRepository.syncWith(list: [testCampaign], timestampMilliseconds: 0)
                     campaignRepository.optOutCampaign(testCampaign)
                     expect(userDataCache.cachedCampaignData?.first?.isOptedOut).to(beTrue())
+                    expect(lastUserCache?.campaignData).to(equal(userCache?.campaignData))
                 }
 
                 it("will save updated list to the cache (logged-in user)") {
                     preferenceRepository.setPreference(IAMPreferenceBuilder().setUserId("user").build())
                     campaignRepository.syncWith(list: [testCampaign], timestampMilliseconds: 0)
                     campaignRepository.optOutCampaign(testCampaign)
-                    let userCache = userDataCache.cachedData[preferenceRepository.getUserIdentifiers()]
-                    let defaultUserCache = userDataCache.cachedData[[]]
                     expect(userCache?.campaignData?.first?.isOptedOut).to(beTrue())
-                    expect(defaultUserCache?.campaignData).to(equal(userCache?.campaignData))
+                    expect(lastUserCache?.campaignData).to(equal(userCache?.campaignData))
                 }
             }
 
@@ -162,16 +166,15 @@ class CampaignRepositorySpec: QuickSpec {
                     campaignRepository.syncWith(list: [testCampaign], timestampMilliseconds: 0)
                     campaignRepository.decrementImpressionsLeftInCampaign(id: testCampaign.id)
                     expect(userDataCache.cachedCampaignData?.first?.impressionsLeft).to(equal(testCampaign.impressionsLeft - 1))
+                    expect(lastUserCache?.campaignData).to(equal(userCache?.campaignData))
                 }
 
                 it("will save updated list to the cache (logged-in user)") {
                     preferenceRepository.setPreference(IAMPreferenceBuilder().setUserId("user").build())
                     campaignRepository.syncWith(list: [testCampaign], timestampMilliseconds: 0)
                     campaignRepository.decrementImpressionsLeftInCampaign(id: testCampaign.id)
-                    let userCache = userDataCache.cachedData[preferenceRepository.getUserIdentifiers()]
-                    let defaultUserCache = userDataCache.cachedData[[]]
                     expect(userCache?.campaignData?.first?.impressionsLeft).to(equal(testCampaign.impressionsLeft - 1))
-                    expect(defaultUserCache?.campaignData).to(equal(userCache?.campaignData))
+                    expect(lastUserCache?.campaignData).to(equal(userCache?.campaignData))
                 }
             }
 
@@ -189,6 +192,9 @@ class CampaignRepositorySpec: QuickSpec {
                     campaignRepository.syncWith(list: [testCampaign], timestampMilliseconds: 0)
                     campaignRepository.incrementImpressionsLeftInCampaign(id: testCampaign.id)
                     expect(userDataCache.cachedCampaignData?.first?.impressionsLeft).to(equal(testCampaign.impressionsLeft + 1))
+                    let userCache = userDataCache.cachedData[preferenceRepository.getUserIdentifiers()]
+                    let lastUserCache = userDataCache.cachedData[CampaignRepository.lastUser]
+                    expect(lastUserCache?.campaignData).to(equal(userCache?.campaignData))
                 }
 
                 it("will save updated list to the cache (logged-in user)") {
@@ -196,114 +202,87 @@ class CampaignRepositorySpec: QuickSpec {
                     campaignRepository.syncWith(list: [testCampaign], timestampMilliseconds: 0)
                     campaignRepository.incrementImpressionsLeftInCampaign(id: testCampaign.id)
                     let userCache = userDataCache.cachedData[preferenceRepository.getUserIdentifiers()]
-                    let defaultUserCache = userDataCache.cachedData[[]]
+                    let lastUserCache = userDataCache.cachedData[CampaignRepository.lastUser]
                     expect(userCache?.campaignData?.first?.impressionsLeft).to(equal(testCampaign.impressionsLeft + 1))
-                    expect(defaultUserCache?.campaignData).to(equal(userCache?.campaignData))
+                    expect(lastUserCache?.campaignData).to(equal(userCache?.campaignData))
                 }
             }
 
             context("when loadCache is called") {
-                context("and no user is logged in (default user cache)") {
+
+                let modifiedTestCampaign = TestHelpers.generateCampaign(id: "testImpressions",
+                                                                        test: false,
+                                                                        delay: 0,
+                                                                        maxImpressions: 0)
+                let otherTestCampaign = TestHelpers.generateCampaign(id: "test2",
+                                                                     test: false,
+                                                                     delay: 0,
+                                                                     maxImpressions: 3)
+
+                context("and lastUserDataMock is not empty") {
 
                     beforeEach {
-                        userDataCache.defaultUserDataMock = UserDataCacheContainer(campaignData: [testCampaign])
+                        userDataCache.lastUserDataMock = UserDataCacheContainer(campaignData: [testCampaign])
                         userDataCache.userDataMock = nil
-                        preferenceRepository.setPreference(nil)
                     }
 
-                    context("and syncWithDefaultUserData set to false") {
+                    context("and syncWithLastUserData set to false") {
 
-                        it("will populate campaign list from cache data") {
+                        it("will not populate campaign list from cache data") {
                             expect(campaignRepository.list).to(beEmpty())
-                            campaignRepository.loadCachedData(syncWithDefaultUserData: false)
-                            expect(campaignRepository.list).to(haveCount(1))
-                        }
-
-                        it("will clear old campaign list if there is no cache data") {
-                            campaignRepository.loadCachedData(syncWithDefaultUserData: false)
-                            expect(campaignRepository.list).to(haveCount(1))
-                            userDataCache.defaultUserDataMock = nil
-                            campaignRepository.loadCachedData(syncWithDefaultUserData: false)
+                            campaignRepository.loadCachedData(syncWithLastUserData: false)
                             expect(campaignRepository.list).to(beEmpty())
                         }
                     }
 
                     context("and syncWithDefaultUserData set to true") {
 
-                        it("will populate campaign list from cache data") {
+                        it("will populate campaign list from last user cache data") {
                             userDataCache.userDataMock = UserDataCacheContainer(campaignData: [testCampaign])
                             expect(campaignRepository.list).to(beEmpty())
-                            campaignRepository.loadCachedData(syncWithDefaultUserData: true)
+                            campaignRepository.loadCachedData(syncWithLastUserData: true)
                             expect(campaignRepository.list).to(haveCount(1))
+                        }
+
+                        it("will populate campaign list from cache data and add new campaings from last user cache") {
+                            userDataCache.lastUserDataMock = UserDataCacheContainer(campaignData: [otherTestCampaign])
+                            userDataCache.userDataMock = UserDataCacheContainer(campaignData: [testCampaign])
+                            campaignRepository.loadCachedData(syncWithLastUserData: true)
+                            expect(campaignRepository.list).to(equal([testCampaign, otherTestCampaign]))
+                        }
+
+                        it("will populate campaign list from cache data and update campaings from last user cache") {
+                            userDataCache.lastUserDataMock = UserDataCacheContainer(campaignData: [modifiedTestCampaign])
+                            userDataCache.userDataMock = UserDataCacheContainer(campaignData: [testCampaign])
+                            campaignRepository.loadCachedData(syncWithLastUserData: true)
+                            expect(campaignRepository.list).to(elementsEqual([modifiedTestCampaign]))
                         }
                     }
                 }
 
-                context("and user is logged in") {
-                    let modifiedTestCampaign = TestHelpers.generateCampaign(id: "testImpressions",
-                                                                            test: false,
-                                                                            delay: 0,
-                                                                            maxImpressions: 0)
-                    let otherTestCampaign = TestHelpers.generateCampaign(id: "test2",
-                                                                         test: false,
-                                                                         delay: 0,
-                                                                         maxImpressions: 3)
+                context("and lastUserDataMock is empty") {
 
                     beforeEach {
-                        preferenceRepository.setPreference(IAMPreferenceBuilder().setUserId("user").build())
+                        userDataCache.lastUserDataMock = nil
+                        userDataCache.userDataMock = UserDataCacheContainer(campaignData: [testCampaign])
                     }
 
-                    context("and syncWithDefaultUserData set to false") {
+                    context("and syncWithLastUserData set to false") {
 
-                        beforeEach {
-                            userDataCache.defaultUserDataMock = UserDataCacheContainer(campaignData: [modifiedTestCampaign, otherTestCampaign])
-                            userDataCache.userDataMock = nil
-                        }
-
-                        it("will not populate campaign list from cache data") {
+                        it("will populate campaign list from cache data") {
                             expect(campaignRepository.list).to(beEmpty())
-                            campaignRepository.loadCachedData(syncWithDefaultUserData: false)
-                            expect(campaignRepository.list).to(beEmpty())
-                        }
-
-                        it("will clear old campaign list if there is no cache data") {
-                            userDataCache.userDataMock = UserDataCacheContainer(campaignData: [testCampaign])
-                            campaignRepository.loadCachedData(syncWithDefaultUserData: false)
+                            campaignRepository.loadCachedData(syncWithLastUserData: false)
                             expect(campaignRepository.list).to(haveCount(1))
-                            userDataCache.userDataMock = nil
-                            campaignRepository.loadCachedData(syncWithDefaultUserData: false)
-                            expect(campaignRepository.list).to(beEmpty())
                         }
+
                     }
 
                     context("and syncWithDefaultUserData set to true") {
 
-                        it("will populate campaign list from cache data if default user cache is empty") {
-                            userDataCache.defaultUserDataMock = nil
-                            userDataCache.userDataMock = UserDataCacheContainer(campaignData: [testCampaign])
-                            campaignRepository.loadCachedData(syncWithDefaultUserData: true)
-                            expect(campaignRepository.list).to(elementsEqual([testCampaign]))
-                        }
-
-                        it("will populate campaign list from default cache data if user cache is empty") {
-                            userDataCache.defaultUserDataMock = UserDataCacheContainer(campaignData: [testCampaign])
-                            userDataCache.userDataMock = nil
-                            campaignRepository.loadCachedData(syncWithDefaultUserData: true)
-                            expect(campaignRepository.list).to(elementsEqual([testCampaign]))
-                        }
-
-                        it("will populate campaign list from cache data and add new campaings from default user cache") {
-                            userDataCache.defaultUserDataMock = UserDataCacheContainer(campaignData: [otherTestCampaign])
-                            userDataCache.userDataMock = UserDataCacheContainer(campaignData: [testCampaign])
-                            campaignRepository.loadCachedData(syncWithDefaultUserData: true)
-                            expect(campaignRepository.list).to(equal([testCampaign, otherTestCampaign]))
-                        }
-
-                        it("will populate campaign list from cache data and update campaings from default user cache") {
-                            userDataCache.defaultUserDataMock = UserDataCacheContainer(campaignData: [modifiedTestCampaign])
-                            userDataCache.userDataMock = UserDataCacheContainer(campaignData: [testCampaign])
-                            campaignRepository.loadCachedData(syncWithDefaultUserData: true)
-                            expect(campaignRepository.list).to(elementsEqual([modifiedTestCampaign]))
+                        it("will not clear existing campaign list if there is no cache data") {
+                            expect(campaignRepository.list).to(beEmpty())
+                            campaignRepository.loadCachedData(syncWithLastUserData: true)
+                            expect(campaignRepository.list).to(haveCount(1))
                         }
                     }
                 }

--- a/Tests/ReadyCampaignDispatcherSpec.swift
+++ b/Tests/ReadyCampaignDispatcherSpec.swift
@@ -236,8 +236,17 @@ class ReadyCampaignDispatcherSpec: QuickSpec {
                         dispatcher.dispatchAllIfNeeded()
                     }
 
-                    it("will stop dispatching") {
+                    it("will not stop dispatching if campaign is displayed") {
+                        router.displayTime = 2.0
                         expect(dispatcher.isDispatching).toEventually(beTrue())
+                        expect(dispatcher.scheduledTask).toEventually(beNil()) // wait
+                        dispatcher.resetQueue()
+                        expect(dispatcher.isDispatching).toAfterTimeout(beTrue())
+                    }
+
+                    it("will stop dispatching if campaign is not displayed") {
+                        expect(dispatcher.isDispatching).toEventually(beTrue())
+                        expect(dispatcher.scheduledTask).toEventuallyNot(beNil()) // wait
                         dispatcher.resetQueue()
                         expect(dispatcher.isDispatching).toEventually(beFalse())
                     }
@@ -247,7 +256,7 @@ class ReadyCampaignDispatcherSpec: QuickSpec {
                         dispatcher.resetQueue()
                         dispatcher.addToQueue(campaign: testCampaigns[2])
                         dispatcher.dispatchAllIfNeeded()
-                        expect(router.lastDisplayedCampaign).toEventually(equal(testCampaigns[2]))
+                        expect(router.lastDisplayedCampaign).toEventually(equal(testCampaigns[2]), timeout: .seconds(2))
                         expect(router.displayedCampaignsCount).to(equal(2))
                     }
 
@@ -293,7 +302,7 @@ class ReadyCampaignDispatcherSpec: QuickSpec {
                         dispatcher.addToQueue(campaign: $0)
                     }
                     dispatcher.dispatchAllIfNeeded()
-                    expect(router.displayedCampaignsCount).toEventually(equal(10))
+                    expect(router.displayedCampaignsCount).toEventually(equal(10), timeout: .seconds(2))
                 }
 
                 it("will schedule next dispatch after a delay defined in campaign data") {


### PR DESCRIPTION
# Description
Anonymous user has now its own independent cache.
Last user cache is used only after app launch and before previously logged in user data is registered (and there was no logout  in previous app session)

## Links
SDKCF-3710

# Checklist
- [X] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [X] I wrote/updated tests for new/changed code
- [X] I removed all sensitive data **before every commit**, including API endpoints and keys
- [X] I ran `fastlane ci` without errors
