### PR TITLE
improve: add `mutate` function to `AtomicGetSet` property wrapper

### DIFF
--- a/RInAppMessaging.xcodeproj/project.pbxproj
+++ b/RInAppMessaging.xcodeproj/project.pbxproj
@@ -31,6 +31,7 @@
 		456FE1E924288C6500304872 /* CampaignTriggerAgentSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 456FE1E824288C6500304872 /* CampaignTriggerAgentSpec.swift */; };
 		456FE1EB2428C51E00304872 /* CommonUtilitySpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 456FE1EA2428C51E00304872 /* CommonUtilitySpec.swift */; };
 		456FE1ED2429C4D200304872 /* ViewSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 456FE1EC2429C4D200304872 /* ViewSpec.swift */; };
+		457524022637342300C47300 /* AtomicWrapperSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 457524012637342300C47300 /* AtomicWrapperSpec.swift */; };
 		4595F4F4262DE12C0001F30B /* KeyHasherSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4595F4F3262DE12C0001F30B /* KeyHasherSpec.swift */; };
 		459B227C245289F300D218CE /* ConfigurationServiceSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 459B227B245289F300D218CE /* ConfigurationServiceSpec.swift */; };
 		459B227E24528A5100D218CE /* MessageMixerServiceSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 459B227D24528A5000D218CE /* MessageMixerServiceSpec.swift */; };
@@ -110,6 +111,7 @@
 		456FE1E824288C6500304872 /* CampaignTriggerAgentSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CampaignTriggerAgentSpec.swift; sourceTree = "<group>"; };
 		456FE1EA2428C51E00304872 /* CommonUtilitySpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommonUtilitySpec.swift; sourceTree = "<group>"; };
 		456FE1EC2429C4D200304872 /* ViewSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewSpec.swift; sourceTree = "<group>"; };
+		457524012637342300C47300 /* AtomicWrapperSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AtomicWrapperSpec.swift; sourceTree = "<group>"; };
 		4595F4F3262DE12C0001F30B /* KeyHasherSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyHasherSpec.swift; sourceTree = "<group>"; };
 		459B227B245289F300D218CE /* ConfigurationServiceSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigurationServiceSpec.swift; sourceTree = "<group>"; };
 		459B227D24528A5000D218CE /* MessageMixerServiceSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MessageMixerServiceSpec.swift; sourceTree = "<group>"; };
@@ -269,6 +271,7 @@
 			children = (
 				45B572F625AE2163005A80F7 /* Helpers */,
 				45357AE32457EB49007D8FDC /* Payloads */,
+				457524012637342300C47300 /* AtomicWrapperSpec.swift */,
 				C9827557262C423C00476505 /* BackoffSpec.swift */,
 				45563B0624064D78004EAFD3 /* CampaignRepositorySpec.swift */,
 				45BDFD022421D311004DEA0C /* CampaignsListManagerSpec.swift */,
@@ -521,6 +524,7 @@
 				456FE1E72428513200304872 /* ErrorReportableSpec.swift in Sources */,
 				4538BCF6262AE8FA009952BE /* UserDataCacheSpec.swift in Sources */,
 				45BDFD052421EE7B004DEA0C /* SharedMocks.swift in Sources */,
+				457524022637342300C47300 /* AtomicWrapperSpec.swift in Sources */,
 				459B228024528A6900D218CE /* ImpressionServiceSpec.swift in Sources */,
 				4557A8B1257E544C00C9D241 /* IAMPreferenceSpec.swift in Sources */,
 				451E93A2248E3D3D00545D6B /* NimbleExtensions.swift in Sources */,

--- a/RInAppMessaging/Classes/Protocols/Lockable.swift
+++ b/RInAppMessaging/Classes/Protocols/Lockable.swift
@@ -12,9 +12,6 @@ internal protocol LockableResource {
     func unlock()
 }
 
-// The following rule is disabled to ensure thread safety
-// swiftlint:disable shorthand_operator
-
 /// Object-wrapper that conforms to LockableResource protocol.
 /// Used to control getter and setter of given resource.
 /// When lock() has been called on some thread, only that thread will be able to access the resource.
@@ -45,14 +42,14 @@ internal class LockableObject<T>: LockableResource {
         if shouldWait {
             dispatchGroup.wait()
         }
-        lockCount = lockCount + 1
+        _lockCount.mutate { $0 += 1 }
         lockingThread = Thread.current
         dispatchGroup.enter()
     }
 
     func unlock() {
         if lockCount > 0 {
-            lockCount = lockCount - 1
+            _lockCount.mutate { $0 -= 1 }
             dispatchGroup.leave()
         } else {
             lockingThread = nil

--- a/RInAppMessaging/Classes/Utilities/AtomicWrapper.swift
+++ b/RInAppMessaging/Classes/Utilities/AtomicWrapper.swift
@@ -2,7 +2,7 @@
 /// Mutating functions, subscript, incrementation etc. are not synchronized by default -
 /// use `mutate` function to ensure operation atomicity.
 @propertyWrapper
-class AtomicGetSet<Value> {
+struct AtomicGetSet<Value> {
     private let queue = PropertyQueueGenerator.spawnQueue(domain: "IAM.AtomicProperty")
     private var value: Value
 
@@ -19,7 +19,7 @@ class AtomicGetSet<Value> {
         }
     }
 
-    func mutate(_ mutation: (inout Value) -> Void) {
+    mutating func mutate(_ mutation: (inout Value) -> Void) {
         queue.sync {
             mutation(&value)
         }

--- a/RInAppMessaging/Classes/Utilities/AtomicWrapper.swift
+++ b/RInAppMessaging/Classes/Utilities/AtomicWrapper.swift
@@ -1,7 +1,8 @@
 /// This wrapper ensures synchronized access to the value only for getter and setter.
-/// Mutating functions, subscript, incrementation etc. are not synchronized.
+/// Mutating functions, subscript, incrementation etc. are not synchronized by default -
+/// use `mutate` function to ensure operation atomicity.
 @propertyWrapper
-struct AtomicGetSet<Value> {
+class AtomicGetSet<Value> {
     private let queue = PropertyQueueGenerator.spawnQueue(domain: "IAM.AtomicProperty")
     private var value: Value
 
@@ -15,6 +16,12 @@ struct AtomicGetSet<Value> {
         }
         set {
             queue.sync { value = newValue }
+        }
+    }
+
+    func mutate(_ mutation: (inout Value) -> Void) {
+        queue.sync {
+            mutation(&value)
         }
     }
 }

--- a/Tests/AtomicWrapperSpec.swift
+++ b/Tests/AtomicWrapperSpec.swift
@@ -77,6 +77,27 @@ class AtomicWrapperSpec: QuickSpec {
                 dispatchGroup.wait()
             }
 
+            it("will not crash when one thread writes and the other reads the same value at the same time") {
+                let dispatchGroup = DispatchGroup()
+                dispatchGroup.enter()
+                dispatchGroup.enter()
+
+                queueA.async {
+                    for _ in (1...1_000_000) {
+                        _ = self.atomicArray
+                    }
+                    dispatchGroup.leave()
+                }
+                queueB.async {
+                    let valueToSet = ["value"]
+                    for _ in (1...1_000_000) {
+                        self.atomicArray = valueToSet
+                    }
+                    dispatchGroup.leave()
+                }
+                dispatchGroup.wait()
+            }
+
             context("when using mutating functions") {
 
                 // The tests below simulate a situation when one thread tries to modify the value

--- a/Tests/AtomicWrapperSpec.swift
+++ b/Tests/AtomicWrapperSpec.swift
@@ -1,0 +1,85 @@
+import Quick
+import Nimble
+@testable import RInAppMessaging
+
+class AtomicWrapperSpec: QuickSpec {
+
+    @AtomicGetSet var atomicArray = [String]()
+
+    override func spec() {
+
+        struct DelayedValue<T> {
+            private let queue = DispatchQueue(label: "DelayedQueue")
+            private let delaySeconds = 0.1
+
+            let value: T
+
+            init(_ value: T) {
+                self.value = value
+            }
+
+            func get() -> T {
+                queue.sync {
+                    usleep(useconds_t(delaySeconds * Double(USEC_PER_SEC)))
+                    return value
+                }
+            }
+        }
+
+        describe("AtomicGetSet property wrapper") {
+
+            let queueA = DispatchQueue(label: "QueueA")
+            let queueB = DispatchQueue(label: "QueueB")
+
+            beforeEach {
+                self.atomicArray = []
+            }
+
+            context("when using mutating functions") {
+
+                it("should ensure atomicity when using `mutate` function") {
+
+                    for _ in (1...100) {
+                        let dispatchGroup = DispatchGroup()
+                        dispatchGroup.enter()
+                        dispatchGroup.enter()
+
+                        queueA.async {
+                            queueB.async {
+                                self._atomicArray.mutate { $0.append("string 2") }
+                                dispatchGroup.leave()
+                            }
+                            self._atomicArray.mutate { $0.append(DelayedValue("string 1").get()) }
+                            dispatchGroup.leave()
+                        }
+                        dispatchGroup.wait()
+                    }
+
+                    let expected = [[String]](repeating: ["string 1", "string 2"], count: 100).flatMap({ $0 })
+                    expect(self.atomicArray).to(elementsEqual(expected))
+                }
+
+                it("should not expect atomic operation without using `mutate` function") {
+                    for _ in (1...100) {
+                        let dispatchGroup = DispatchGroup()
+                        dispatchGroup.enter()
+                        dispatchGroup.enter()
+
+                        queueA.async {
+                            queueB.async {
+                                self.atomicArray.append("string 2")
+                                dispatchGroup.leave()
+                            }
+                            self.atomicArray.append(DelayedValue("string 1").get())
+                            dispatchGroup.leave()
+                        }
+                        dispatchGroup.wait()
+                    }
+
+                    let expected = [[String]](repeating: ["string 1", "string 2"], count: 100).flatMap({ $0 })
+                    expect(self.atomicArray).toNot(elementsEqual(expected))
+                }
+            }
+        }
+    }
+}

--- a/Tests/AtomicWrapperSpec.swift
+++ b/Tests/AtomicWrapperSpec.swift
@@ -61,14 +61,16 @@ class AtomicWrapperSpec: QuickSpec {
                 dispatchGroup.enter()
 
                 queueA.async {
+                    let valueToSet = ["1"]
                     for _ in (1...1_000_000) {
-                        self.atomicArray = ["1"]
+                        self.atomicArray = valueToSet
                     }
                     dispatchGroup.leave()
                 }
                 queueB.async {
+                    let valueToSet = ["2"]
                     for _ in (1...1_000_000) {
-                        self.atomicArray = ["2"]
+                        self.atomicArray = valueToSet
                     }
                     dispatchGroup.leave()
                 }

--- a/Tests/AtomicWrapperSpec.swift
+++ b/Tests/AtomicWrapperSpec.swift
@@ -37,18 +37,25 @@ class AtomicWrapperSpec: QuickSpec {
 
             context("when using mutating functions") {
 
-                it("should ensure atomicity when using `mutate` function") {
+                // The tests below simulate a situation when one thread tries to modify the value
+                // while the other is using mutating function on the same value. The loop was added to ensure effectiveness
 
+                it("should ensure atomicity when using `mutate` functions") {
                     for _ in (1...100) {
                         let dispatchGroup = DispatchGroup()
                         dispatchGroup.enter()
                         dispatchGroup.enter()
 
                         queueA.async {
+                            let queueDispatchCoordinator = DispatchGroup()
+                            queueDispatchCoordinator.enter()
                             queueB.async {
+                                queueDispatchCoordinator.wait()
                                 self._atomicArray.mutate { $0.append("string 2") }
                                 dispatchGroup.leave()
                             }
+
+                            queueDispatchCoordinator.leave()
                             self._atomicArray.mutate { $0.append(DelayedValue("string 1").get()) }
                             dispatchGroup.leave()
                         }
@@ -59,17 +66,46 @@ class AtomicWrapperSpec: QuickSpec {
                     expect(self.atomicArray).to(elementsEqual(expected))
                 }
 
-                it("should not expect atomic operation without using `mutate` function") {
+                it("should ensure atomicity when using `mutate` function and setter") {
                     for _ in (1...100) {
                         let dispatchGroup = DispatchGroup()
                         dispatchGroup.enter()
                         dispatchGroup.enter()
 
                         queueA.async {
+                            let queueDispatchCoordinator = DispatchGroup()
+                            queueDispatchCoordinator.enter()
                             queueB.async {
+                                queueDispatchCoordinator.wait()
+                                self.atomicArray = ["string 2"]
+                                dispatchGroup.leave()
+                            }
+
+                            queueDispatchCoordinator.leave()
+                            self._atomicArray.mutate { $0.append(DelayedValue("string 1").get()) }
+                            dispatchGroup.leave()
+                        }
+                        dispatchGroup.wait()
+                        expect(self.atomicArray).to(elementsEqual(["string 2"]))
+                    }
+                }
+
+                it("should not expect atomic operation without using `mutate` functions") {
+                    for _ in (1...100) {
+                        let dispatchGroup = DispatchGroup()
+                        dispatchGroup.enter()
+                        dispatchGroup.enter()
+
+                        queueA.async {
+                            let queueDispatchCoordinator = DispatchGroup()
+                            queueDispatchCoordinator.enter()
+                            queueB.async {
+                                queueDispatchCoordinator.wait()
                                 self.atomicArray.append("string 2")
                                 dispatchGroup.leave()
                             }
+
+                            queueDispatchCoordinator.leave()
                             self.atomicArray.append(DelayedValue("string 1").get())
                             dispatchGroup.leave()
                         }
@@ -78,6 +114,30 @@ class AtomicWrapperSpec: QuickSpec {
 
                     let expected = [[String]](repeating: ["string 1", "string 2"], count: 100).flatMap({ $0 })
                     expect(self.atomicArray).toNot(elementsEqual(expected))
+                }
+
+                it("should not expect atomic operation without using `mutate` function and setter") {
+                    for _ in (1...100) {
+                        let dispatchGroup = DispatchGroup()
+                        dispatchGroup.enter()
+                        dispatchGroup.enter()
+
+                        queueA.async {
+                            let queueDispatchCoordinator = DispatchGroup()
+                            queueDispatchCoordinator.enter()
+                            queueB.async {
+                                queueDispatchCoordinator.wait()
+                                self.atomicArray = ["string 2"]
+                                dispatchGroup.leave()
+                            }
+
+                            queueDispatchCoordinator.leave()
+                            self.atomicArray.append(DelayedValue("string 1").get())
+                            dispatchGroup.leave()
+                        }
+                        dispatchGroup.wait()
+                        expect(self.atomicArray).to(elementsEqual(["string 2", "string 1"]))
+                    }
                 }
             }
         }

--- a/Tests/ReadyCampaignDispatcherSpec.swift
+++ b/Tests/ReadyCampaignDispatcherSpec.swift
@@ -264,7 +264,7 @@ class ReadyCampaignDispatcherSpec: QuickSpec {
                         expect(dispatcher.scheduledTask).toEventuallyNot(beNil()) // wait
                         dispatcher.resetQueue()
                         expect(dispatcher.scheduledTask?.isCancelled).to(beTrue())
-                        expect(router.displayedCampaignsCount).toAfterTimeout(equal(1))
+                        expect(router.displayedCampaignsCount).toAfterTimeout(equal(1), timeout: 2)
                     }
                 }
             }

--- a/Tests/ViewSpec.swift
+++ b/Tests/ViewSpec.swift
@@ -145,7 +145,7 @@ class ViewSpec: QuickSpec {
             it("will prevent execution of javascript code in web view using `evaluateJavaScript()`") {
                 let webView = view.createWebView(withHtmlString: "<body>Text</body>", andFrame: .zero)
 
-                waitUntil(timeout: .seconds(5)) { done in
+                waitUntil(timeout: .seconds(6)) { done in
                     webView.evaluateJavaScript("document.body.innerHTML") { (_, error) in
                         expect((error as NSError?)?.code).to(equal(4))
                         expect((error as NSError?)?.domain).to(equal("WKErrorDomain"))

--- a/Tests/ViewSpec.swift
+++ b/Tests/ViewSpec.swift
@@ -145,7 +145,7 @@ class ViewSpec: QuickSpec {
             it("will prevent execution of javascript code in web view using `evaluateJavaScript()`") {
                 let webView = view.createWebView(withHtmlString: "<body>Text</body>", andFrame: .zero)
 
-                waitUntil(timeout: .seconds(6)) { done in
+                waitUntil(timeout: .seconds(10)) { done in
                     webView.evaluateJavaScript("document.body.innerHTML") { (_, error) in
                         expect((error as NSError?)?.code).to(equal(4))
                         expect((error as NSError?)?.domain).to(equal("WKErrorDomain"))


### PR DESCRIPTION
# Description
Added `mutate` method for struct properties wrapped in `@AtomicGetSet`.
Examples:
```swift
intVar.mutate { $0+=1 }
arrayVar.mutate { $0.append("newValue") }
dictVar.mutate { $0["key"] = "value" }
```

# Checklist
- [X] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [ ] I wrote/updated tests for new/changed code
- [X] I removed all sensitive data **before every commit**, including API endpoints and keys
- [X] I ran `fastlane ci` without errors
