### PR TITLE
ci: remove build status change check from integration tests

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -79,16 +79,7 @@ workflows:
         - cache_paths: |-
             $BITRISE_CACHE_DIR
             $GEM_CACHE_PATH
-    - build-status-change@0:
-        inputs:
-        - access_token: "$BITRISE_ACCESS_TOKEN"
     - slack@3:
-        run_if: |-
-          {{if .IsBuildFailed}}
-          true
-          {{else}}
-          {{enveq "BUILD_STATUS_CHANGED" "true"}}
-          {{end}}
         inputs:
         - channel: ''
         - webhook_url: "$SLACK_CHANNEL_WEBHOOK"
@@ -102,7 +93,7 @@ workflows:
             $BITRISE_APP_TITLE » $BITRISE_TRIGGERED_WORKFLOW_TITLE - #$BITRISE_BUILD_NUMBER *Failure*
             <$BITRISE_BUILD_URL|Open>
         - message: |+
-            $BITRISE_APP_TITLE » $BITRISE_TRIGGERED_WORKFLOW_TITLE - #$BITRISE_BUILD_NUMBER *Back to normal*
+            $BITRISE_APP_TITLE » $BITRISE_TRIGGERED_WORKFLOW_TITLE - #$BITRISE_BUILD_NUMBER *Success*
             <$BITRISE_BUILD_URL|Open>
         - fields: ''
         - buttons: ''


### PR DESCRIPTION
# Description
This change strengthens security by removing the need of BITRISE_ACCESS_TOKEN

# Checklist
- [X] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [ ] I wrote/updated tests for new/changed code
- [X] I removed all sensitive data **before every commit**, including API endpoints and keys
- [ ] I ran `fastlane ci` without errors
