### PR TITLE
SDKCF-3740: UserDataCache fix

### DIFF
--- a/RInAppMessaging/Classes/UserDataCache.swift
+++ b/RInAppMessaging/Classes/UserDataCache.swift
@@ -24,7 +24,7 @@ internal class UserDataCache: UserDataCacheable {
     private typealias CacheContainers = [String: UserDataCacheContainer]
 
     private let userDefaults: UserDefaults
-    private var cachedContainers: CacheContainers
+    @AtomicGetSet private var cachedContainers: CacheContainers
     private let persistedDataKey = "IAM_user_cache"
     private let isTestEnvironment = Bundle.tests != nil
 


### PR DESCRIPTION
# Description
UserDataCache is a shared instance in the DependencyManager.
If 2 threads modify UserDataCache.cachedContainers, it crashes.
Using AtomicGetSet solves this crash:
`@AtomicGetSet private var cachedContainers: CacheContainers`

## Links
Add links to github/jira issues, design documents and other relevant resources (e.g. previous discussions, platform/tool documentation etc.)

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data **before every commit**, including API endpoints and keys
- [x] I ran `fastlane ci` without errors
