### PR TITLE
fix: clear event list on user change to prevent unexpected campaign displays (SDKCF-3727)

### DIFF
--- a/RInAppMessaging/Classes/EventMatcher.swift
+++ b/RInAppMessaging/Classes/EventMatcher.swift
@@ -15,6 +15,8 @@ internal protocol EventMatcherType: AnyObject, Lockable {
     /// Function can be used with persistent events - they won't be removed.
     /// - Throws: Can throw EventMatcherError when records of requested events cannot be found
     func removeSetOfMatchedEvents(_ eventsToRemove: Set<Event>, for campaign: Campaign) throws
+
+    func clearNonPersistentEvents()
 }
 
 internal enum EventMatcherError: Error {
@@ -102,6 +104,10 @@ internal class EventMatcher: EventMatcherType {
             events[campaign.id] = campaignEvents
             matchedEvents.set(value: events)
         }
+    }
+
+    func clearNonPersistentEvents() {
+        matchedEvents.set(value: [:])
     }
 
     private func isEventMatchingOneOfTriggers(event: Event, triggers: [Trigger]) -> Bool {

--- a/RInAppMessaging/Classes/InAppMessagingModule.swift
+++ b/RInAppMessaging/Classes/InAppMessagingModule.swift
@@ -97,6 +97,7 @@ internal class InAppMessagingModule: AnalyticsBroadcaster,
         let isLogoutOrUserChange = (preferenceRepository.getUserIdentifiers().isEmpty || diff?.isEmpty == false) && !oldUserIdentifiers.isEmpty
         if isLogoutOrUserChange {
             campaignRepository.resetDataPersistence()
+            eventMatcher.clearNonPersistentEvents()
         }
         campaignRepository.loadCachedData(syncWithLastUserData: false)
         campaignsListManager.refreshList()

--- a/Tests/EventMatcherSpec.swift
+++ b/Tests/EventMatcherSpec.swift
@@ -248,6 +248,27 @@ class EventMatcherSpec: QuickSpec {
                     expect(eventMatcher.containsAllMatchedEvents(for: campaign)).to(beFalse())
                 }
             }
+
+            context("when calling clearNonPersistentEvents") {
+
+                it("will clear all matched non-persistent events") {
+                    campaignRepository.list = [testCampaign]
+                    eventMatcher.matchAndStore(event: LoginSuccessfulEvent())
+                    expect(eventMatcher.matchedEvents(for: testCampaign)).toNot(beEmpty())
+
+                    eventMatcher.clearNonPersistentEvents()
+                    expect(eventMatcher.matchedEvents(for: testCampaign)).to(beEmpty())
+                }
+
+                it("will not clear persistent events") {
+                    campaignRepository.list = [testCampaign]
+                    eventMatcher.matchAndStore(event: AppStartEvent())
+                    expect(eventMatcher.matchedEvents(for: testCampaign)).toNot(beEmpty())
+
+                    eventMatcher.clearNonPersistentEvents()
+                    expect(eventMatcher.matchedEvents(for: testCampaign)).toNot(beEmpty())
+                }
+            }
         }
     }
 }

--- a/Tests/Helpers/SharedMocks.swift
+++ b/Tests/Helpers/SharedMocks.swift
@@ -101,6 +101,7 @@ class EventMatcherMock: EventMatcherType {
     var simulateMatchingSuccess = true
     var simulateMatcherError: EventMatcherError?
     var resourcesToLock: [LockableResource] = []
+    var wasClearNonPersistentEventsCalled = false
 
     func matchAndStore(event: Event) {
         loggedEvents.append(event)
@@ -119,6 +120,10 @@ class EventMatcherMock: EventMatcherType {
         if !simulateMatchingSuccess {
             throw EventMatcherError.couldntFindRequestedSetOfEvents
         }
+    }
+
+    func clearNonPersistentEvents() {
+        wasClearNonPersistentEventsCalled = true
     }
 }
 

--- a/Tests/InAppMessagingModuleSpec.swift
+++ b/Tests/InAppMessagingModuleSpec.swift
@@ -278,6 +278,29 @@ class InAppMessagingModuleSpec: QuickSpec {
                                         expect(campaignRepository.wasResetDataPersistenceCalled).to(beFalse())
                                     }
                             }
+
+                            it("will clear event list when user logs out or changes to another user") {
+                                [(aUser, nil), (aUser, IAMPreference()),
+                                 (aUser, IAMPreferenceBuilder().setUserId("userB").build())]
+                                    .forEach { prefA, prefB in
+                                        iamModule.registerPreference(prefA)
+                                        eventMatcher.wasClearNonPersistentEventsCalled = false // reset
+                                        iamModule.registerPreference(prefB)
+                                        expect(eventMatcher.wasClearNonPersistentEventsCalled).to(beTrue())
+                                    }
+                            }
+
+                            it("will not clear event list when user did not log out or change to another user") {
+                                [(nil, aUser), (IAMPreference(), aUser),
+                                 (nil, nil), (nil, IAMPreference()),
+                                 (IAMPreference(), nil), (IAMPreference(), IAMPreference())]
+                                    .forEach { prefA, prefB in
+                                        iamModule.registerPreference(prefA)
+                                        eventMatcher.wasClearNonPersistentEventsCalled = false // reset
+                                        iamModule.registerPreference(prefB)
+                                        expect(eventMatcher.wasClearNonPersistentEventsCalled).to(beFalse())
+                                    }
+                            }
                         }
 
                         context("and module is not initialized") {


### PR DESCRIPTION
# Description
This fixes a situation when userA logs multiple events for given campaign that has a matching trigger and the display limit was reached, so when userB logs in with fresh impression counter, all stacked events from previous user make the campaign display immediately (even multiple times until userB's impression limit is reached)

## Links
SDKCF-3727

# Checklist
- [X] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [X] I wrote/updated tests for new/changed code
- [X] I removed all sensitive data **before every commit**, including API endpoints and keys
- [X] I ran `fastlane ci` without errors
