### PR TITLE
fix: fix a situation when incrementImpressionsLeft was called twice when calling `closeMessage` API

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,7 +1,7 @@
 PODS:
-  - Nimble (9.0.0)
-  - Quick (3.1.2)
-  - RInAppMessaging (3.0.0)
+  - Nimble (9.2.0)
+  - Quick (4.0.0)
+  - RInAppMessaging (4.0.0-pp)
   - SwiftLint (0.43.1)
 
 DEPENDENCIES:
@@ -21,9 +21,9 @@ EXTERNAL SOURCES:
     :path: "."
 
 SPEC CHECKSUMS:
-  Nimble: 3b4ec3fd40f1dc178058e0981107721c615643d8
-  Quick: 60f0ea3b8e0cfc0df3259a5c06a238ad8b3c46e0
-  RInAppMessaging: c71ee2432ac1e0031e575dd56909e972626f79a4
+  Nimble: 4f4a345c80b503b3ea13606a4f98405974ee4d0b
+  Quick: 6473349e43b9271a8d43839d9ba1c442ed1b7ac4
+  RInAppMessaging: 5e99dc996b6a1afd16b7841d877f5d60d4f131f0
   SwiftLint: 99f82d07b837b942dd563c668de129a03fc3fb52
 
 PODFILE CHECKSUM: 8a6dcd4c28e5723bd520363ede4f5fec5524dcd0

--- a/RInAppMessaging/Classes/InAppMessagingModule.swift
+++ b/RInAppMessaging/Classes/InAppMessagingModule.swift
@@ -107,9 +107,7 @@ internal class InAppMessagingModule: AnalyticsBroadcaster,
         if clearQueuedCampaigns {
             readyCampaignDispatcher.resetQueue()
         }
-        if let campaign = router.discardDisplayedCampaign() {
-            campaignRepository.incrementImpressionsLeftInCampaign(id: campaign.id)
-        }
+        router.discardDisplayedCampaign()
     }
 }
 

--- a/RInAppMessaging/Classes/Services/ConfigurationService.swift
+++ b/RInAppMessaging/Classes/Services/ConfigurationService.swift
@@ -57,10 +57,10 @@ internal struct ConfigurationService: ConfigurationServiceType, HttpRequestable 
 extension ConfigurationService {
     private func getConfigRequest() throws -> GetConfigRequest {
         guard let appVersion = bundleInfo.appVersion,
-            let appId = bundleInfo.applicationId,
-            let sdkVersion = bundleInfo.inAppSdkVersion else {
-                Logger.debug("failed creating a request body")
-                throw RequestError.missingMetadata
+              let appId = bundleInfo.applicationId,
+              let sdkVersion = bundleInfo.inAppSdkVersion else {
+            Logger.debug("failed creating a request body")
+            throw RequestError.missingMetadata
         }
         return GetConfigRequest(
             locale: Locale.current.normalizedIdentifier,
@@ -85,7 +85,7 @@ extension ConfigurationService {
         return additionalHeaders
     }
 
-   func buildURLRequest(url: URL) -> Result<URLRequest, Error> {
+    func buildURLRequest(url: URL) -> Result<URLRequest, Error> {
         do {
             let request = try getConfigRequest()
             var urlComponents = URLComponents(url: url, resolvingAgainstBaseURL: true)

--- a/Tests/CampaignsListManagerSpec.swift
+++ b/Tests/CampaignsListManagerSpec.swift
@@ -99,6 +99,7 @@ class CampaignsListManagerSpec: QuickSpec {
 
                     it("will schedule next ping call") {
                         manager.refreshList()
+                        expect(messageMixerService.wasPingCalled).toEventually(beTrue()) // wait
                         messageMixerService.wasPingCalled = false
                         expect(messageMixerService.wasPingCalled).toEventually(beTrue())
                     }

--- a/Tests/InAppMessagingModuleSpec.swift
+++ b/Tests/InAppMessagingModuleSpec.swift
@@ -361,14 +361,6 @@ class InAppMessagingModuleSpec: QuickSpec {
                         expect(router.wasDiscardCampaignCalled).to(beTrue())
                     }
 
-                    it("will increment impressionsLeft in closed campaign") {
-                        let campaign = TestHelpers.generateCampaign(id: "test")
-                        router.lastDisplayedCampaign = campaign
-
-                        iamModule.closeMessage(clearQueuedCampaigns: false)
-                        expect(campaignRepository.wasIncrementImpressionsCalled).to(beTrue())
-                    }
-
                     it("will reset queued campaigns list if `clearQueuedCampaigns` is true") {
                         iamModule.closeMessage(clearQueuedCampaigns: true)
                         expect(readyCampaignDispatcher.wasResetQueueCalled).to(beTrue())

--- a/Tests/PublicAPISpec.swift
+++ b/Tests/PublicAPISpec.swift
@@ -141,6 +141,14 @@ class PublicAPISpec: QuickSpec {
                         $0 is BaseView
                     }))
                 }
+
+                it("will restore/increment impressionsLeft in closed campaign") {
+                    generateAndDisplayLoginCampaigns(count: 1, addContexts: false)
+
+                    expect(campaignRepository.list.first?.impressionsLeft).toEventually(equal(1))
+                    RInAppMessaging.closeMessage()
+                    expect(campaignRepository.list.first?.impressionsLeft).toEventually(equal(2))
+                }
             }
 
             context("delegate") {

--- a/Tests/ReadyCampaignDispatcherSpec.swift
+++ b/Tests/ReadyCampaignDispatcherSpec.swift
@@ -115,7 +115,7 @@ class ReadyCampaignDispatcherSpec: QuickSpec {
                                 let campaign = TestHelpers.generateCampaign(id: "test", title: "[ctx] title")
                                 dispatcher.addToQueue(campaign: campaign)
                                 dispatcher.dispatchAllIfNeeded()
-                                expect(campaignRepository.wasIncrementImpressionsCalled).toAfterTimeout(beFalse())
+                                expect(campaignRepository.incrementImpressionsCalls).toAfterTimeout(equal(0))
                             }
                         }
 
@@ -163,7 +163,7 @@ class ReadyCampaignDispatcherSpec: QuickSpec {
                                 let campaign = TestHelpers.generateCampaign(id: "test", title: "[ctx] title")
                                 dispatcher.addToQueue(campaign: campaign)
                                 dispatcher.dispatchAllIfNeeded()
-                                expect(campaignRepository.wasIncrementImpressionsCalled).toEventually(beTrue())
+                                expect(campaignRepository.incrementImpressionsCalls).toAfterTimeout(equal(1))
                             }
                         }
                     }
@@ -278,7 +278,7 @@ class ReadyCampaignDispatcherSpec: QuickSpec {
                     let campaign = TestHelpers.generateCampaign(id: "test")
                     dispatcher.addToQueue(campaign: campaign)
                     dispatcher.dispatchAllIfNeeded()
-                    expect(campaignRepository.wasDecrementImpressionsCalled).toEventually(beTrue())
+                    expect(campaignRepository.decrementImpressionsCalls).toAfterTimeout(equal(1))
                 }
 
                 it("will restore impressions left value if contexts were rejected") {
@@ -286,7 +286,7 @@ class ReadyCampaignDispatcherSpec: QuickSpec {
                     let campaign = TestHelpers.generateCampaign(id: "test", title: "[ctx] title")
                     dispatcher.addToQueue(campaign: campaign)
                     dispatcher.dispatchAllIfNeeded()
-                    expect(campaignRepository.wasIncrementImpressionsCalled).toEventually(beTrue())
+                    expect(campaignRepository.incrementImpressionsCalls).toAfterTimeout(equal(1))
                 }
 
                 it("will not increment impressions left value if contexts were approved") {
@@ -294,7 +294,7 @@ class ReadyCampaignDispatcherSpec: QuickSpec {
                     let campaign = TestHelpers.generateCampaign(id: "test", title: "[ctx] title")
                     dispatcher.addToQueue(campaign: campaign)
                     dispatcher.dispatchAllIfNeeded()
-                    expect(campaignRepository.wasIncrementImpressionsCalled).toAfterTimeout(beFalse())
+                    expect(campaignRepository.incrementImpressionsCalls).toAfterTimeout(equal(0))
                 }
 
                 it("will dispatch remaining campaigns") {

--- a/Tests/RouterSpec.swift
+++ b/Tests/RouterSpec.swift
@@ -122,8 +122,7 @@ class RouterSpec: QuickSpec {
                     router.displayCampaign(campaign, confirmation: true, completion: { _ in })
                     expect(UIApplication.shared.keyWindow?.subviews)
                         .toEventually(containElementSatisfying({ $0 is BaseView }))
-                    let closedCampaignView = router.discardDisplayedCampaign()
-                    expect(closedCampaignView).toNot(beNil())
+                    router.discardDisplayedCampaign()
                     expect(UIApplication.shared.keyWindow?.subviews)
                         .toEventuallyNot(containElementSatisfying({ $0 is BaseView }))
                 }
@@ -137,7 +136,7 @@ class RouterSpec: QuickSpec {
                     })
                     expect(UIApplication.shared.keyWindow?.subviews)
                         .toEventually(containElementSatisfying({ $0 is BaseView }))
-                    _ = router.discardDisplayedCampaign()
+                    router.discardDisplayedCampaign()
                     expect(completionCalled).toEventually(beTrue())
                 }
             }


### PR DESCRIPTION
# Description
`closeMessage` sends onDismiss call with cancelled flag and that already makes completion handler in Router to call `incrementImpressionsLeftInCampaign`

# Checklist
- [X] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [X] I wrote/updated tests for new/changed code
- [X] I removed all sensitive data **before every commit**, including API endpoints and keys
- [X] I ran `fastlane ci` without errors
