### PR TITLE
improve: defer events that were logged before SDK was initialized (SDKCF-3821)

### DIFF
--- a/RInAppMessaging/Classes/InAppMessagingModule.swift
+++ b/RInAppMessaging/Classes/InAppMessagingModule.swift
@@ -121,12 +121,12 @@ internal class InAppMessagingModule: AnalyticsBroadcaster,
 
     private func flushEventBuffer(void: Bool) {
         if !void {
-            self.eventBuffer.forEach {
-                self.eventMatcher.matchAndStore(event: $0)
+            eventBuffer.forEach {
+                eventMatcher.matchAndStore(event: $0)
             }
             campaignTriggerAgent.validateAndTriggerCampaigns()
         }
-        self.eventBuffer.removeAll()
+        eventBuffer.removeAll()
     }
 }
 

--- a/RInAppMessaging/Classes/InAppMessagingModule.swift
+++ b/RInAppMessaging/Classes/InAppMessagingModule.swift
@@ -64,9 +64,9 @@ internal class InAppMessagingModule: AnalyticsBroadcaster,
 
             if enabled {
                 self.campaignsListManager.refreshList()
-                self.flushEventBuffer(void: false)
+                self.flushEventBuffer(discardEvents: false)
             } else {
-                self.flushEventBuffer(void: true)
+                self.flushEventBuffer(discardEvents: true)
                 deinitHandler()
             }
         }
@@ -119,8 +119,8 @@ internal class InAppMessagingModule: AnalyticsBroadcaster,
         router.discardDisplayedCampaign()
     }
 
-    private func flushEventBuffer(void: Bool) {
-        if !void {
+    private func flushEventBuffer(discardEvents: Bool) {
+        if !discardEvents {
             eventBuffer.forEach {
                 eventMatcher.matchAndStore(event: $0)
             }

--- a/RInAppMessaging/Classes/InAppMessagingModule.swift
+++ b/RInAppMessaging/Classes/InAppMessagingModule.swift
@@ -14,7 +14,8 @@ internal class InAppMessagingModule: AnalyticsBroadcaster,
     private let randomizer: RandomizerType
 
     private var isInitialized = false
-    private var isEnabled = true
+    private(set) var isEnabled = true
+    private var eventBuffer = [Event]()
 
     var aggregatedErrorHandler: ((NSError) -> Void)?
     weak var delegate: RInAppMessagingDelegate?
@@ -54,13 +55,18 @@ internal class InAppMessagingModule: AnalyticsBroadcaster,
         }
 
         configurationManager.fetchAndSaveConfigData { [weak self] config in
-            let enabled = self?.isEnabled(config: config) ?? false
-            self?.isEnabled = enabled
-            self?.isInitialized = true
+            guard let self = self else {
+                return
+            }
+            let enabled = self.isEnabled(config: config)
+            self.isEnabled = enabled
+            self.isInitialized = true
 
             if enabled {
-                self?.campaignsListManager.refreshList()
+                self.campaignsListManager.refreshList()
+                self.flushEventBuffer(void: false)
             } else {
+                self.flushEventBuffer(void: true)
                 deinitHandler()
             }
         }
@@ -71,13 +77,16 @@ internal class InAppMessagingModule: AnalyticsBroadcaster,
             return
         }
 
-        eventMatcher.matchAndStore(event: event)
         sendEventName(Constants.RAnalytics.events, event.analyticsParameters)
 
         guard isInitialized else {
+            // Events that were logged after first getConfig request failed,
+            // are saved to this list to be processed later
+            eventBuffer.append(event)
             return
         }
 
+        eventMatcher.matchAndStore(event: event)
         campaignTriggerAgent.validateAndTriggerCampaigns()
     }
 
@@ -108,6 +117,16 @@ internal class InAppMessagingModule: AnalyticsBroadcaster,
             readyCampaignDispatcher.resetQueue()
         }
         router.discardDisplayedCampaign()
+    }
+
+    private func flushEventBuffer(void: Bool) {
+        if !void {
+            self.eventBuffer.forEach {
+                self.eventMatcher.matchAndStore(event: $0)
+            }
+            campaignTriggerAgent.validateAndTriggerCampaigns()
+        }
+        self.eventBuffer.removeAll()
     }
 }
 


### PR DESCRIPTION
# Description
This improvement ensures the desired order of API calls being executed when getConfig request is processing or was scheduled (retry logic).

## Links
SDKCF-3821

# Checklist
- [X] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [X] I wrote/updated tests for new/changed code
- [X] I removed all sensitive data **before every commit**, including API endpoints and keys
- [X] I ran `fastlane ci` without errors
