### PR TITLE
improve: remove `canOpenURL` check for redirect and deeplink buttons (SDKCF-3848)

### DIFF
--- a/RInAppMessaging/Classes/Views/BaseView.swift
+++ b/RInAppMessaging/Classes/Views/BaseView.swift
@@ -2,7 +2,7 @@ import class UIKit.UIView
 import func Foundation.NSClassFromString
 
 /// Base protocol for all of IAM's supported campaign views
-internal protocol BaseView: UIView {
+internal protocol BaseView: UIView, AlertPresentable {
 
     static var viewIdentifier: String { get }
     var onDismiss: ((_ cancelled: Bool) -> Void)? { get set }

--- a/RInAppMessaging/Classes/Views/Presenters/BaseViewPresenter.swift
+++ b/RInAppMessaging/Classes/Views/Presenters/BaseViewPresenter.swift
@@ -1,3 +1,5 @@
+import class UIKit.UIAlertAction
+
 internal protocol BaseViewPresenterType: ImpressionTrackable {
     var campaign: Campaign! { get set }
     var impressions: [Impression] { get set }
@@ -63,5 +65,15 @@ internal class BaseViewPresenter: BaseViewPresenterType {
     func loadResources() {
         // load image from imageUrl data
         _ = associatedImage
+    }
+
+    func showURLError(view: BaseView) {
+        view.showAlert(title: "dialog_alert_invalidURI_title".localized,
+                       message: "dialog_alert_invalidURI_message".localized,
+                       style: .alert,
+                       actions: [UIAlertAction(title: "dialog_alert_invalidURI_close".localized,
+                                               style: .default,
+                                               handler: nil)
+        ])
     }
 }

--- a/RInAppMessaging/Classes/Views/Presenters/FullViewPresenter.swift
+++ b/RInAppMessaging/Classes/Views/Presenters/FullViewPresenter.swift
@@ -60,18 +60,17 @@ internal class FullViewPresenter: BaseViewPresenter, FullViewPresenterType {
             guard let uriToOpen = URL(string: unwrappedUri),
                 UIApplication.shared.canOpenURL(uriToOpen) else {
 
-                view?.showAlert(title: "dialog_alert_invalidURI_title".localized,
-                               message: "dialog_alert_invalidURI_message".localized,
-                               style: .alert,
-                               actions: [
-                                UIAlertAction(title: "dialog_alert_invalidURI_close".localized,
-                                              style: .default,
-                                              handler: nil)
-                ])
+                if let view = view {
+                    showURLError(view: view)
+                }
                 return
             }
 
-            UIApplication.shared.open(uriToOpen, options: [:], completionHandler: nil)
+            UIApplication.shared.open(uriToOpen, options: [:], completionHandler: { success in
+                if !success, let view = self.view {
+                    self.showURLError(view: view)
+                }
+            })
         }
 
         // If the button came with a campaign trigger, log it.

--- a/RInAppMessaging/Classes/Views/Presenters/SlideUpViewPresenter.swift
+++ b/RInAppMessaging/Classes/Views/Presenters/SlideUpViewPresenter.swift
@@ -34,21 +34,19 @@ internal class SlideUpViewPresenter: BaseViewPresenter, SlideUpViewPresenterType
 
         if [.redirect, .deeplink].contains(campaignContent?.onClickBehavior.action) {
             guard let uri = campaignContent?.onClickBehavior.uri,
-                let uriToOpen = URL(string: uri),
-                UIApplication.shared.canOpenURL(uriToOpen) else {
+                let uriToOpen = URL(string: uri) else {
 
-                view?.showAlert(title: "dialog_alert_invalidURI_title".localized,
-                                message: "dialog_alert_invalidURI_message".localized,
-                                style: .alert,
-                                actions: [
-                                    UIAlertAction(title: "dialog_alert_invalidURI_close".localized,
-                                                  style: .default,
-                                                  handler: nil)
-                ])
+                if let view = view {
+                    showURLError(view: view)
+                }
                 return
             }
 
-            UIApplication.shared.open(uriToOpen, options: [:], completionHandler: nil)
+            UIApplication.shared.open(uriToOpen, options: [:], completionHandler: { success in
+                if !success, let view = self.view {
+                    self.showURLError(view: view)
+                }
+            })
         }
 
         logImpression(type: .clickContent)

--- a/RInAppMessaging/Classes/Views/Protocols/FullViewType.swift
+++ b/RInAppMessaging/Classes/Views/Protocols/FullViewType.swift
@@ -1,4 +1,4 @@
-internal protocol FullViewType: BaseView, AlertPresentable {
+internal protocol FullViewType: BaseView {
     var isOptOutChecked: Bool { get }
 
     func setup(viewModel: FullViewModel)

--- a/RInAppMessaging/Classes/Views/Protocols/SlideUpViewType.swift
+++ b/RInAppMessaging/Classes/Views/Protocols/SlideUpViewType.swift
@@ -1,3 +1,3 @@
-internal protocol SlideUpViewType: BaseView, AlertPresentable {
+internal protocol SlideUpViewType: BaseView {
     func setup(viewModel: SlideUpViewModel)
 }

--- a/Tests/ViewPresenterSpec.swift
+++ b/Tests/ViewPresenterSpec.swift
@@ -103,6 +103,15 @@ class ViewPresenterSpec: QuickSpec {
                     expect(campaignRepository.wasOptOutCalled).to(beTrue())
                 }
             }
+
+            context("when showURLError is called") {
+
+                it("will call showAlert on passed view") {
+                    let view = FullViewMock()
+                    presenter.showURLError(view: view)
+                    expect(view.wasShowAlertCalled).to(beTrue())
+                }
+            }
         }
 
         describe("SlideUpViewPresenter") {
@@ -352,6 +361,7 @@ private class FullViewMock: UIView, FullViewType {
 
     private(set) var wasSetupCalled = false
     private(set) var wasDismissCalled = false
+    private(set) var wasShowAlertCalled = false
     private(set) var addedButtons = [(ActionButton, viewModel: ActionButtonViewModel)]()
 
     func setup(viewModel: FullViewModel) {
@@ -364,6 +374,10 @@ private class FullViewMock: UIView, FullViewType {
 
     func addButtons(_ buttons: [(ActionButton, viewModel: ActionButtonViewModel)]) {
         addedButtons = buttons
+    }
+
+    func showAlert(title: String, message: String, style: UIAlertController.Style, actions: [UIAlertAction]) {
+        wasShowAlertCalled = true
     }
 
     func animateOnShow(completion: @escaping () -> Void) { completion() }


### PR DESCRIPTION
# Description
In some iOS 14 versions `canOpenURL` returns false for https links when default browser is other than Safari.
With this change, apps don't have to define any schemes in `LSApplicationQueriesSchemes` in order to open URIs added to campaign's button/content.

## Links
SDKCF-3848

# Checklist
- [X] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [X] I wrote/updated tests for new/changed code
- [X] I removed all sensitive data **before every commit**, including API endpoints and keys
- [X] I ran `fastlane ci` without errors
