### PR TITLE
fix: fix `flushEventBuffer` logic, fix impressionLeft counter race condition (SDKCF-3821)

### DIFF
--- a/RInAppMessaging/Classes/CampaignTriggerAgent.swift
+++ b/RInAppMessaging/Classes/CampaignTriggerAgent.swift
@@ -22,7 +22,7 @@ internal struct CampaignTriggerAgent: CampaignTriggerAgentType {
             validator.validate { (campaign, triggeredEvents) in
                 do {
                     try eventMatcher.removeSetOfMatchedEvents(triggeredEvents, for: campaign)
-                    dispatcher.addToQueue(campaign: campaign)
+                    dispatcher.addToQueue(campaignID: campaign.id)
                 } catch {
                     // Campaign is not ready to be displayed
                 }

--- a/RInAppMessaging/Classes/InAppMessagingModule.swift
+++ b/RInAppMessaging/Classes/InAppMessagingModule.swift
@@ -121,10 +121,10 @@ internal class InAppMessagingModule: AnalyticsBroadcaster,
 
     private func flushEventBuffer(discardEvents: Bool) {
         if !discardEvents {
-            eventBuffer.forEach {
-                eventMatcher.matchAndStore(event: $0)
+            eventBuffer.forEach { event in
+                self.eventMatcher.matchAndStore(event: event)
+                self.campaignTriggerAgent.validateAndTriggerCampaigns()
             }
-            campaignTriggerAgent.validateAndTriggerCampaigns()
         }
         eventBuffer.removeAll()
     }

--- a/RInAppMessaging/Classes/Utilities/CommonUtility.swift
+++ b/RInAppMessaging/Classes/Utilities/CommonUtility.swift
@@ -27,6 +27,14 @@ internal struct CommonUtility {
         resourcesToLock.forEach { $0.unlock() }
     }
 
+    static func lock(resourcesIn object: Lockable) {
+        object.resourcesToLock.forEach { $0.lock() }
+    }
+
+    static func unlock(resourcesIn object: Lockable) {
+        object.resourcesToLock.forEach { $0.unlock() }
+    }
+
     /// Converts a `Trigger` object from `Button` object to a `CustomEvent`.
     /// - Parameter trigger: The trigger object to parse out.
     /// - Returns: The event object created the trigger object.

--- a/Tests/CampaignTriggerAgentSpec.swift
+++ b/Tests/CampaignTriggerAgentSpec.swift
@@ -32,7 +32,7 @@ class CampaignTriggerAgentSpec: QuickSpec {
                     campaignsValidator.campaignsToTrigger = [testCampaign]
                     campaignTriggerAgent.validateAndTriggerCampaigns()
 
-                    expect(campaignDispatcher.addedCampaigns).to(elementsEqual([testCampaign]))
+                    expect(campaignDispatcher.addedCampaignIDs).to(elementsEqual([testCampaign.id]))
                 }
 
                 it("will not dispatch campaign when events coulnd't be triggered") {
@@ -40,7 +40,7 @@ class CampaignTriggerAgentSpec: QuickSpec {
                     campaignsValidator.campaignsToTrigger = [testCampaign]
                     campaignTriggerAgent.validateAndTriggerCampaigns()
 
-                    expect(campaignDispatcher.addedCampaigns).to(beEmpty())
+                    expect(campaignDispatcher.addedCampaignIDs).to(beEmpty())
                 }
             }
 
@@ -55,7 +55,7 @@ class CampaignTriggerAgentSpec: QuickSpec {
                 campaignsValidator.campaignsToTrigger = [testCampaign]
                 campaignTriggerAgent.validateAndTriggerCampaigns()
 
-                expect(campaignDispatcher.addedCampaigns).to(beEmpty())
+                expect(campaignDispatcher.addedCampaignIDs).to(beEmpty())
             }
         }
     }

--- a/Tests/Helpers/SharedMocks.swift
+++ b/Tests/Helpers/SharedMocks.swift
@@ -82,11 +82,11 @@ class CampaignRepositoryMock: CampaignRepositoryType {
 class CampaignDispatcherMock: CampaignDispatcherType {
     weak var delegate: CampaignDispatcherDelegate?
     var wasDispatchCalled = false
-    var addedCampaigns = [Campaign]()
+    var addedCampaignIDs = [String]()
     var wasResetQueueCalled = false
 
-    func addToQueue(campaign: Campaign) {
-        addedCampaigns.append(campaign)
+    func addToQueue(campaignID: String) {
+        addedCampaignIDs.append(campaignID)
     }
     func dispatchAllIfNeeded() {
         wasDispatchCalled = true

--- a/Tests/Helpers/TestHelpers.swift
+++ b/Tests/Helpers/TestHelpers.swift
@@ -114,6 +114,7 @@ struct TestHelpers {
         static func withGeneratedCampaigns(count: Int,
                                            test: Bool,
                                            delay: Int,
+                                           maxImpressions: Int = 2,
                                            addContexts: Bool = false,
                                            triggers: [Trigger]? = nil) -> PingResponse {
             var campaigns = [Campaign]()
@@ -125,7 +126,7 @@ struct TestHelpers {
                         id: "testCampaignId\(i)",
                         test: test,
                         delay: delay,
-                        maxImpressions: 2,
+                        maxImpressions: maxImpressions,
                         title: title,
                         triggers: triggers))
                 }

--- a/Tests/InAppMessagingModuleSpec.swift
+++ b/Tests/InAppMessagingModuleSpec.swift
@@ -205,7 +205,7 @@ class InAppMessagingModuleSpec: QuickSpec {
                         expect(campaignsValidator.wasValidateCalled).to(beTrue())
                     }
 
-                    it("will not log all buferred events when module is disabled") {
+                    it("will not log buferred events when module is disabled") {
                         configurationManager.rolloutPercentage = 0
                         iamModule.logEvent(AppStartEvent())
                         iamModule.logEvent(LoginSuccessfulEvent())
@@ -241,7 +241,7 @@ class InAppMessagingModuleSpec: QuickSpec {
                                                  TestHelpers.generateCampaign(id: "2")]
                                 campaignsValidator.campaignsToTrigger = campaigns
                                 iamModule.logEvent(PurchaseSuccessfulEvent())
-                                expect(readyCampaignDispatcher.addedCampaigns).to(equal(campaigns))
+                                expect(readyCampaignDispatcher.addedCampaignIDs).to(equal(campaigns.map({ $0.id })))
                             }
 
                             it("will call dispatchAllIfNeeded") {

--- a/Tests/PublicAPISpec.swift
+++ b/Tests/PublicAPISpec.swift
@@ -140,12 +140,11 @@ class PublicAPISpec: QuickSpec {
                     configurationManager.simulateRetryDelay = 1.0
                     messageMixerService.delay = 1.0
                     messageMixerService.mockedResponse = TestHelpers.MockResponse.withGeneratedCampaigns(
-                        count: 1, test: false, delay: 100, addContexts: false,
+                        count: 1, test: false, delay: 100, maxImpressions: 2, addContexts: false,
                         triggers: [Trigger(type: .event,
                                            eventType: .loginSuccessful,
                                            eventName: "e1",
                                            attributes: [])])
-                    // maxImpressions = 2
                 })
                 RInAppMessaging.logEvent(LoginSuccessfulEvent())
                 RInAppMessaging.logEvent(LoginSuccessfulEvent())

--- a/Tests/PublicAPISpec.swift
+++ b/Tests/PublicAPISpec.swift
@@ -128,8 +128,13 @@ class PublicAPISpec: QuickSpec {
                                                                pollInterval: .milliseconds(500))
             }
 
-            // it will properly schedule campaigns when events are logged one after another AND
-            it("will display campaigns for matching events that were logged during config retry delay") {
+            // This test checks if events logged after getConfig() failure (bufferedEvents)
+            // are re-logged properly when retried getConfig request succeeds.
+            // If buffered events can fill the set of campaign triggers, for example 3 times,
+            // then that campaign should be displayed 3 times.
+            // This test also checks if campaigns are queued properly (respecting impressionsLeft value)
+            // when multiple events are logged in very short time.
+            it("will display campaigns after first ping call for matching events that were logged after getConfig request failure") {
                 RInAppMessaging.deinitializeModule()
                 reinitializeSDK(onDependencyResolved: {
                     configurationManager.simulateRetryDelay = 1.0
@@ -140,6 +145,7 @@ class PublicAPISpec: QuickSpec {
                                            eventType: .loginSuccessful,
                                            eventName: "e1",
                                            attributes: [])])
+                    // maxImpressions = 2
                 })
                 RInAppMessaging.logEvent(LoginSuccessfulEvent())
                 RInAppMessaging.logEvent(LoginSuccessfulEvent())

--- a/Tests/PublicAPISpec.swift
+++ b/Tests/PublicAPISpec.swift
@@ -131,10 +131,10 @@ class PublicAPISpec: QuickSpec {
             // This test checks if events logged after getConfig() failure (bufferedEvents)
             // are re-logged properly when retried getConfig request succeeds.
             // If buffered events can fill the set of campaign triggers, for example 3 times,
-            // then that campaign should be displayed 3 times.
+            // then that campaign should be displayed 3 times if maxImpression allows it.
             // This test also checks if campaigns are queued properly (respecting impressionsLeft value)
             // when multiple events are logged in very short time.
-            it("will display campaigns after first ping call for matching events that were logged after getConfig request failure") {
+            it("will display campaign 2 times after first ping call for matching events that were logged after getConfig request failure") {
                 RInAppMessaging.deinitializeModule()
                 reinitializeSDK(onDependencyResolved: {
                     configurationManager.simulateRetryDelay = 1.0

--- a/Tests/ReadyCampaignDispatcherSpec.swift
+++ b/Tests/ReadyCampaignDispatcherSpec.swift
@@ -279,7 +279,7 @@ class ReadyCampaignDispatcherSpec: QuickSpec {
                     it("will stop scheduled dispatch") {
                         expect(dispatcher.scheduledTask).toEventuallyNot(beNil()) // wait
                         dispatcher.resetQueue()
-                        expect(dispatcher.scheduledTask?.isCancelled).to(beTrue())
+                        expect(dispatcher.scheduledTask?.isCancelled).toEventually(beTrue())
                         expect(router.displayedCampaignsCount).toAfterTimeout(equal(1), timeout: 2)
                     }
                 }


### PR DESCRIPTION
# Description
Fixes a problem when events from `eventBuffer` triggered campaign only once when events allowed to display more times.
Fixes an issue (race condition) when campaigns were validated and added to the queue more times than `maxImpression` allowed

Note: CampaignDispatcher now holds only campaign ID to ensure up-to-date information. The other solution would be to change Campaign model to class type

## Links
SDKCF-3821

# Checklist
- [X] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [X] I wrote/updated tests for new/changed code
- [X] I removed all sensitive data **before every commit**, including API endpoints and keys
- [X] I ran `fastlane ci` without errors
