### PR TITLE
feat: add handling for getConfig response status codes 400 and 404 (SDKCF-3884)

### DIFF
--- a/RInAppMessaging.xcodeproj/project.pbxproj
+++ b/RInAppMessaging.xcodeproj/project.pbxproj
@@ -39,6 +39,7 @@
 		459B228224528A7D00D218CE /* DisplayPermissionServiceSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 459B228124528A7D00D218CE /* DisplayPermissionServiceSpec.swift */; };
 		459DE86A24074F720002F451 /* EventMatcherSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 459DE86924074F720002F451 /* EventMatcherSpec.swift */; };
 		459DE86C2407B5750002F451 /* CustomEventSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 459DE86B2407B5750002F451 /* CustomEventSpec.swift */; };
+		45A86D0F2669877F00D0C43F /* HeaderAttributesBuilderSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45A86D0E2669877F00D0C43F /* HeaderAttributesBuilderSpec.swift */; };
 		45ADA53E247CFE9E00A9E2A3 /* ConfigurationRepositorySpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45ADA53D247CFE9E00A9E2A3 /* ConfigurationRepositorySpec.swift */; };
 		45ADA540247D076E00A9E2A3 /* InAppMessagingModuleSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45ADA53F247D076E00A9E2A3 /* InAppMessagingModuleSpec.swift */; };
 		45ADA542247D206B00A9E2A3 /* RouterSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45ADA541247D206B00A9E2A3 /* RouterSpec.swift */; };
@@ -119,6 +120,7 @@
 		459B228124528A7D00D218CE /* DisplayPermissionServiceSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DisplayPermissionServiceSpec.swift; sourceTree = "<group>"; };
 		459DE86924074F720002F451 /* EventMatcherSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventMatcherSpec.swift; sourceTree = "<group>"; };
 		459DE86B2407B5750002F451 /* CustomEventSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomEventSpec.swift; sourceTree = "<group>"; };
+		45A86D0E2669877F00D0C43F /* HeaderAttributesBuilderSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeaderAttributesBuilderSpec.swift; sourceTree = "<group>"; };
 		45ADA53D247CFE9E00A9E2A3 /* ConfigurationRepositorySpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigurationRepositorySpec.swift; sourceTree = "<group>"; };
 		45ADA53F247D076E00A9E2A3 /* InAppMessagingModuleSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InAppMessagingModuleSpec.swift; sourceTree = "<group>"; };
 		45ADA541247D206B00A9E2A3 /* RouterSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouterSpec.swift; sourceTree = "<group>"; };
@@ -289,6 +291,7 @@
 				456FE1E62428513200304872 /* ErrorReportableSpec.swift */,
 				459DE86924074F720002F451 /* EventMatcherSpec.swift */,
 				4538BAE226282DE4009952BE /* GetConfigResponseSpec.swift */,
+				45A86D0E2669877F00D0C43F /* HeaderAttributesBuilderSpec.swift */,
 				45357AF6245AD49E007D8FDC /* HttpRequestableSpec.swift */,
 				4557A8B0257E544C00C9D241 /* IAMPreferenceSpec.swift */,
 				D911DC56211159DE0082B950 /* IdRegistrationSpec.swift */,
@@ -546,6 +549,7 @@
 				456FE1ED2429C4D200304872 /* ViewSpec.swift in Sources */,
 				4595F4F4262DE12C0001F30B /* KeyHasherSpec.swift in Sources */,
 				4534947223C6ABF700189A81 /* SerializationSpec.swift in Sources */,
+				45A86D0F2669877F00D0C43F /* HeaderAttributesBuilderSpec.swift in Sources */,
 				D911DC5821115B410082B950 /* IdRegistrationSpec.swift in Sources */,
 				45EA720525B71FA2001B2049 /* UIApplicationExtensionSpec.swift in Sources */,
 				45AFB308246CFB640080D21B /* LocaleSpec.swift in Sources */,

--- a/RInAppMessaging/Classes/ConfigurationManager.swift
+++ b/RInAppMessaging/Classes/ConfigurationManager.swift
@@ -59,17 +59,22 @@ internal class ConfigurationManager: ConfigurationManagerType, TaskSchedulable {
         case .failure(let error):
             previousState = state
             state = ResponseState.error(error)
-            reportError(description: "Error calling config server. Retrying in \(retryDelayMS)ms", data: error)
+
             switch error {
-            case ConfigurationServiceError.tooManyRequestsError:
+            case .tooManyRequestsError:
+                reportError(description: "Error calling config server. Retrying in \(retryDelayMS)ms", data: error)
                 if case ResponseState.success = previousState {
                     retryDelayMS = Constants.Retry.TooManyRequestsError.initialRetryDelayMS
                 }
                 scheduleTask(milliseconds: Int(retryDelayMS), wallDeadline: true, retryHandler)
                 // Exponential backoff for pinging Configuration server.
                 retryDelayMS.increaseRandomizedBackoff()
+            case .missingOrInvalidSubscriptionId:
+                reportError(description: "Config request error: Missing or invalid Subscription ID. SDK will be disabled.", data: error)
+                completion(ConfigData(rolloutPercentage: 0, endpoints: nil))
 
             default:
+                reportError(description: "Error calling config server. Retrying in \(retryDelayMS)ms", data: error)
                 scheduleTask(milliseconds: Int(retryDelayMS), wallDeadline: true, retryHandler)
                 // Exponential backoff for pinging Configuration server.
                 retryDelayMS.increaseBackOff()

--- a/RInAppMessaging/Classes/ConfigurationManager.swift
+++ b/RInAppMessaging/Classes/ConfigurationManager.swift
@@ -72,6 +72,9 @@ internal class ConfigurationManager: ConfigurationManagerType, TaskSchedulable {
             case .missingOrInvalidSubscriptionId:
                 reportError(description: "Config request error: Missing or invalid Subscription ID. SDK will be disabled.", data: error)
                 completion(ConfigData(rolloutPercentage: 0, endpoints: nil))
+            case .unknownSubscriptionId:
+                reportError(description: "Config request error: Unknown Subscription ID. SDK will be disabled.", data: error)
+                completion(ConfigData(rolloutPercentage: 0, endpoints: nil))
 
             default:
                 reportError(description: "Error calling config server. Retrying in \(retryDelayMS)ms", data: error)

--- a/RInAppMessaging/Classes/Models/Requests/HeaderAttribute.swift
+++ b/RInAppMessaging/Classes/Models/Requests/HeaderAttribute.swift
@@ -1,4 +1,4 @@
-internal struct HeaderAttribute: Codable {
+internal struct HeaderAttribute: Codable, Equatable {
     let key: String
     let value: String
 }

--- a/RInAppMessaging/Classes/Services/ConfigurationService.swift
+++ b/RInAppMessaging/Classes/Services/ConfigurationService.swift
@@ -7,6 +7,7 @@ internal enum ConfigurationServiceError: Error {
     case jsonDecodingError(Error)
     case tooManyRequestsError
     case missingOrInvalidSubscriptionId
+    case unknownSubscriptionId
 }
 
 internal struct ConfigurationService: ConfigurationServiceType, HttpRequestable {
@@ -36,8 +37,10 @@ internal struct ConfigurationService: ConfigurationServiceType, HttpRequestable 
             switch requestError {
             case .httpError(let statusCode, _, _) where statusCode == 429:
                 return .failure(.tooManyRequestsError)
-            case .httpError(let statusCode, _, _) where [404, 400].contains(statusCode):
+            case .httpError(let statusCode, _, _) where statusCode == 400:
                 return .failure(.missingOrInvalidSubscriptionId)
+            case .httpError(let statusCode, _, _) where statusCode == 404:
+                return .failure(.unknownSubscriptionId)
             default:
                 return .failure(.requestError(requestError))
             }

--- a/RInAppMessaging/Classes/Services/DisplayPermissionService.swift
+++ b/RInAppMessaging/Classes/Services/DisplayPermissionService.swift
@@ -92,17 +92,10 @@ extension DisplayPermissionService {
     }
 
     private func buildRequestHeader() -> [HeaderAttribute] {
-        let Keys = Constants.Request.Header.self
-        var additionalHeaders: [HeaderAttribute] = []
+        var builder = HeaderAttributesBuilder()
+        builder.addSubscriptionID(bundleInfo: bundleInfo)
+        builder.addAccessToken(preferenceRepository: preferenceRepository)
 
-        if let subId = bundleInfo.inAppSubscriptionId {
-            additionalHeaders.append(HeaderAttribute(key: Keys.subscriptionID, value: subId))
-        }
-
-        if let accessToken = preferenceRepository.getAccessToken() {
-            additionalHeaders.append(HeaderAttribute(key: Keys.authorization, value: "OAuth2 \(accessToken)"))
-        }
-
-        return additionalHeaders
+        return builder.build()
     }
 }

--- a/RInAppMessaging/Classes/Services/ImpressionService.swift
+++ b/RInAppMessaging/Classes/Services/ImpressionService.swift
@@ -109,21 +109,11 @@ extension ImpressionService {
     }
 
     private func buildRequestHeader() -> [HeaderAttribute] {
-        let Keys = Constants.Request.Header.self
-        var additionalHeaders: [HeaderAttribute] = []
+        var builder = HeaderAttributesBuilder()
+        builder.addSubscriptionID(bundleInfo: bundleInfo)
+        builder.addDeviceID()
+        builder.addAccessToken(preferenceRepository: preferenceRepository)
 
-        if let subId = bundleInfo.inAppSubscriptionId {
-            additionalHeaders.append(HeaderAttribute(key: Keys.subscriptionID, value: subId))
-        }
-
-        if let deviceId = UIDevice.current.identifierForVendor?.uuidString {
-            additionalHeaders.append(HeaderAttribute(key: Keys.deviceID, value: deviceId))
-        }
-
-        if let accessToken = preferenceRepository.getAccessToken() {
-            additionalHeaders.append(HeaderAttribute(key: Keys.authorization, value: "OAuth2 \(accessToken)"))
-        }
-
-        return additionalHeaders
+        return builder.build()
     }
 }

--- a/RInAppMessaging/Classes/Services/MessageMixerService.swift
+++ b/RInAppMessaging/Classes/Services/MessageMixerService.swift
@@ -90,21 +90,11 @@ extension MessageMixerService {
     }
 
     private func buildRequestHeader() -> [HeaderAttribute] {
-        let Keys = Constants.Request.Header.self
-        var additionalHeaders: [HeaderAttribute] = []
+        var builder = HeaderAttributesBuilder()
+        builder.addSubscriptionID(bundleInfo: bundleInfo)
+        builder.addDeviceID()
+        builder.addAccessToken(preferenceRepository: preferenceRepository)
 
-        if let subId = bundleInfo.inAppSubscriptionId {
-            additionalHeaders.append(HeaderAttribute(key: Keys.subscriptionID, value: subId))
-        }
-
-        if let deviceId = UIDevice.current.identifierForVendor?.uuidString {
-            additionalHeaders.append(HeaderAttribute(key: Keys.deviceID, value: deviceId))
-        }
-
-        if let accessToken = preferenceRepository.getAccessToken() {
-            additionalHeaders.append(HeaderAttribute(key: Keys.authorization, value: "OAuth2 \(accessToken)"))
-        }
-
-        return additionalHeaders
+        return builder.build()
     }
 }

--- a/RInAppMessaging/Classes/Utilities/HeaderAttributesBuilder.swift
+++ b/RInAppMessaging/Classes/Utilities/HeaderAttributesBuilder.swift
@@ -1,0 +1,35 @@
+struct HeaderAttributesBuilder {
+    private let Keys = Constants.Request.Header.self
+    private var addedHeaders: [HeaderAttribute] = []
+
+    @discardableResult
+    mutating func addDeviceID() -> Bool {
+        guard let deviceId = UIDevice.current.identifierForVendor?.uuidString else {
+            return false
+        }
+        addedHeaders.append(HeaderAttribute(key: Keys.deviceID, value: deviceId))
+        return true
+    }
+
+    @discardableResult
+    mutating func addSubscriptionID(bundleInfo: BundleInfo.Type) -> Bool {
+        guard let subId = bundleInfo.inAppSubscriptionId, !subId.isEmpty else {
+            return false
+        }
+        addedHeaders.append(HeaderAttribute(key: Keys.subscriptionID, value: subId))
+        return true
+    }
+
+    @discardableResult
+    mutating func addAccessToken(preferenceRepository: IAMPreferenceRepository) -> Bool {
+        guard let accessToken = preferenceRepository.getAccessToken() else {
+            return false
+        }
+        addedHeaders.append(HeaderAttribute(key: Keys.authorization, value: "OAuth2 \(accessToken)"))
+        return true
+    }
+
+    func build() -> [HeaderAttribute] {
+        addedHeaders
+    }
+}

--- a/Tests/ConfigurationManagerSpec.swift
+++ b/Tests/ConfigurationManagerSpec.swift
@@ -97,6 +97,24 @@ class ConfigurationManagerSpec: QuickSpec {
                     configurationManager.fetchAndSaveConfigData(completion: { _ in })
                     expect(configurationManager.scheduledTask).toEventuallyNot(beNil())
                 }
+
+                it("should not retry for .missingOrInvalidSubscriptionId error") {
+                    configurationService.simulateRequestFailure = true
+                    configurationService.mockedError = .missingOrInvalidSubscriptionId
+                    configurationManager.fetchAndSaveConfigData(completion: { _ in })
+                    expect(configurationManager.scheduledTask).toAfterTimeout(beNil())
+                }
+
+                it("should return disable response for .missingOrInvalidSubscriptionId error") {
+                    configurationService.simulateRequestFailure = true
+                    configurationService.mockedError = .missingOrInvalidSubscriptionId
+                    waitUntil { done in
+                        configurationManager.fetchAndSaveConfigData(completion: { config in
+                            expect(config.rolloutPercentage).to(equal(0))
+                            done()
+                        })
+                    }
+                }
             }
         }
     }

--- a/Tests/ConfigurationServiceSpec.swift
+++ b/Tests/ConfigurationServiceSpec.swift
@@ -124,6 +124,72 @@ class ConfigurationServiceSpec: QuickSpec {
                         }
                     }
                 }
+
+                context("and status code is 4xx") {
+
+                    it("will return ConfigurationServiceError containing .tooManyRequestsError for code 429") {
+                        httpSession.httpResponse = HTTPURLResponse(url: configURL,
+                                                                   statusCode: 429,
+                                                                   httpVersion: nil,
+                                                                   headerFields: nil)
+                        waitUntil { done in
+                            requestQueue.async {
+                                let result = service.getConfigData()
+                                let error = result.getError()
+                                expect(error).toNot(beNil())
+
+                                guard case .tooManyRequestsError = error else {
+                                    fail("Unexpected error type \(String(describing: error)). Expected .tooManyRequestsError")
+                                    done()
+                                    return
+                                }
+                                done()
+                            }
+                        }
+                    }
+
+                    it("will return ConfigurationServiceError containing .missingOrInvalidSubscriptionId for code 400") {
+                        httpSession.httpResponse = HTTPURLResponse(url: configURL,
+                                                                   statusCode: 400,
+                                                                   httpVersion: nil,
+                                                                   headerFields: nil)
+                        waitUntil { done in
+                            requestQueue.async {
+                                let result = service.getConfigData()
+                                let error = result.getError()
+                                expect(error).toNot(beNil())
+
+                                guard case .missingOrInvalidSubscriptionId = error else {
+                                    fail("Unexpected error type \(String(describing: error)). Expected .missingOrInvalidSubscriptionId")
+                                    done()
+                                    return
+                                }
+                                done()
+                            }
+                        }
+                    }
+
+                    it("will return ConfigurationServiceError containing .missingOrInvalidSubscriptionId for code 404") {
+                        httpSession.httpResponse = HTTPURLResponse(url: configURL,
+                                                                   statusCode: 404,
+                                                                   httpVersion: nil,
+                                                                   headerFields: nil)
+                        waitUntil { done in
+                            requestQueue.async {
+                                let result = service.getConfigData()
+                                let error = result.getError()
+                                expect(error).toNot(beNil())
+
+                                guard case .missingOrInvalidSubscriptionId = error else {
+                                    fail("Unexpected error type \(String(describing: error)). Expected .missingOrInvalidSubscriptionId")
+                                    done()
+                                    return
+                                }
+                                done()
+                            }
+                        }
+                    }
+                }
             }
 
             context("when request fails") {
@@ -132,6 +198,8 @@ class ConfigurationServiceSpec: QuickSpec {
                 }
 
                 it("will return ConfigurationServiceError containing .requestError") {
+                    httpSession.responseError = NSError(domain: "config.error.test", code: 1, userInfo: nil)
+
                     waitUntil { done in
                         requestQueue.async {
                             let result = service.getConfigData()
@@ -146,36 +214,6 @@ class ConfigurationServiceSpec: QuickSpec {
                             done()
                         }
                     }
-                }
-            }
-
-            context("when request fails with a status code equals to 429") {
-                let originalHttpResponse: HTTPURLResponse? = httpSession?.httpResponse
-
-                it("will return ConfigurationServiceError containing .tooManyRequestsError") {
-                    httpSession.httpResponse = HTTPURLResponse(url: configURL,
-                                                               statusCode: 429,
-                                                               httpVersion: nil,
-                                                               headerFields: nil)
-
-                    waitUntil { done in
-                        requestQueue.async {
-                            let result = service.getConfigData()
-                            let error = result.getError()
-                            expect(error).toNot(beNil())
-
-                            guard case .tooManyRequestsError = error else {
-                                fail("Unexpected error type \(String(describing: error)). Expected .tooManyRequestsError")
-                                done()
-                                return
-                            }
-                            done()
-                        }
-                    }
-                }
-
-                afterEach {
-                    httpSession.httpResponse = originalHttpResponse
                 }
             }
 

--- a/Tests/HeaderAttributesBuilderSpec.swift
+++ b/Tests/HeaderAttributesBuilderSpec.swift
@@ -1,0 +1,84 @@
+import Quick
+import Nimble
+@testable import RInAppMessaging
+
+class HeaderAttributesBuilderSpec: QuickSpec {
+
+    override func spec() {
+
+        describe("HeaderAttributesBuilder") {
+
+            var builder: HeaderAttributesBuilder!
+            let preferenceRepository = IAMPreferenceRepository()
+
+            beforeEach {
+                builder = HeaderAttributesBuilder()
+                BundleInfoMock.reset()
+                preferenceRepository.setPreference(nil)
+            }
+
+            context("when calling addSubscriptionID") {
+
+                it("should return false for empty subscription id") {
+                    BundleInfoMock.inAppSubscriptionIdMock = ""
+                    expect(builder.addSubscriptionID(bundleInfo: BundleInfoMock.self)).to(beFalse())
+                }
+
+                it("should return false for nil subscription id") {
+                    BundleInfoMock.inAppSubscriptionIdMock = nil
+                    expect(builder.addSubscriptionID(bundleInfo: BundleInfoMock.self)).to(beFalse())
+                }
+
+                it("should return true for any subscription id") {
+                    BundleInfoMock.inAppSubscriptionIdMock = "some-id"
+                    expect(builder.addSubscriptionID(bundleInfo: BundleInfoMock.self)).to(beTrue())
+                }
+
+                it("should apped new header attribute") {
+                    BundleInfoMock.inAppSubscriptionIdMock = "some-id"
+                    builder.addSubscriptionID(bundleInfo: BundleInfoMock.self)
+                    expect(builder.build()).to(elementsEqual([HeaderAttribute(key: Constants.Request.Header.subscriptionID, value: "some-id")]))
+                }
+            }
+
+            context("when calling addAccessToken") {
+
+                it("should return false for nil access token") {
+                    preferenceRepository.setPreference(IAMPreferenceBuilder().setAccessToken(nil).build())
+                    expect(builder.addAccessToken(preferenceRepository: preferenceRepository)).to(beFalse())
+                }
+
+                it("should return true for any access token id") {
+                    preferenceRepository.setPreference(IAMPreferenceBuilder().setAccessToken("token").build())
+                    expect(builder.addAccessToken(preferenceRepository: preferenceRepository)).to(beTrue())
+                }
+
+                it("should apped new header attribute") {
+                    preferenceRepository.setPreference(IAMPreferenceBuilder().setAccessToken("token").build())
+                    builder.addAccessToken(preferenceRepository: preferenceRepository)
+                    expect(builder.build()).to(elementsEqual([HeaderAttribute(key: Constants.Request.Header.authorization, value: "OAuth2 token")]))
+                }
+            }
+
+            context("when calling build") {
+
+                it("should return empty array when nothing was set") {
+                    expect(builder.build()).to(beEmpty())
+                }
+
+                it("should return array with all expected types") {
+                    BundleInfoMock.inAppSubscriptionIdMock = "some-id"
+                    preferenceRepository.setPreference(IAMPreferenceBuilder().setAccessToken("token").build())
+
+                    builder.addDeviceID()
+                    builder.addSubscriptionID(bundleInfo: BundleInfoMock.self)
+                    builder.addAccessToken(preferenceRepository: preferenceRepository)
+
+                    expect(builder.build()).to(contain(HeaderAttribute(key: Constants.Request.Header.subscriptionID, value: "some-id")))
+                    expect(builder.build()).to(contain(HeaderAttribute(key: Constants.Request.Header.authorization, value: "OAuth2 token")))
+                    expect(builder.build()).to(containElementSatisfying({ $0.key == Constants.Request.Header.deviceID && !$0.value.isEmpty }))
+                }
+            }
+        }
+    }
+}

--- a/Tests/HeaderAttributesBuilderSpec.swift
+++ b/Tests/HeaderAttributesBuilderSpec.swift
@@ -34,7 +34,7 @@ class HeaderAttributesBuilderSpec: QuickSpec {
                     expect(builder.addSubscriptionID(bundleInfo: BundleInfoMock.self)).to(beTrue())
                 }
 
-                it("should apped new header attribute") {
+                it("should append new header attribute") {
                     BundleInfoMock.inAppSubscriptionIdMock = "some-id"
                     builder.addSubscriptionID(bundleInfo: BundleInfoMock.self)
                     expect(builder.build()).to(elementsEqual([HeaderAttribute(key: Constants.Request.Header.subscriptionID, value: "some-id")]))
@@ -53,7 +53,7 @@ class HeaderAttributesBuilderSpec: QuickSpec {
                     expect(builder.addAccessToken(preferenceRepository: preferenceRepository)).to(beTrue())
                 }
 
-                it("should apped new header attribute") {
+                it("should append new header attribute") {
                     preferenceRepository.setPreference(IAMPreferenceBuilder().setAccessToken("token").build())
                     builder.addAccessToken(preferenceRepository: preferenceRepository)
                     expect(builder.build()).to(elementsEqual([HeaderAttribute(key: Constants.Request.Header.authorization, value: "OAuth2 token")]))

--- a/Tests/ViewPresenterSpec.swift
+++ b/Tests/ViewPresenterSpec.swift
@@ -240,7 +240,7 @@ class ViewPresenterSpec: QuickSpec {
                         expect(view.wasShowAlertCalled).toEventually(beTrue())
                     }
 
-                    // testing positive cases for redirect/deepling URL requires UIApplication.shared.openURL() function to be mocked
+                    // testing positive cases for redirect/deeplink URL requires UIApplication.shared.openURL() function to be mocked
                 }
             }
         }
@@ -396,7 +396,7 @@ class ViewPresenterSpec: QuickSpec {
                     expect(view.wasShowAlertCalled).toEventually(beTrue())
                 }
 
-                // testing positive cases for redirect/deepling URL requires UIApplication.shared.openURL() function to be mocked
+                // testing positive cases for redirect/deeplink URL requires UIApplication.shared.openURL() function to be mocked
             }
 
             context("when didClickExitButton is called") {


### PR DESCRIPTION
# Description
Added handling for getConfig response statuses 400 and 404 which are returned in case of request that contained invalid subscription ID or missing subscription ID. In both cases SDK will be disabled (no retry).
Refactored request header building in Service classes.

## Links
SDKCF-3884

# Checklist
- [X] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [X] I wrote/updated tests for new/changed code
- [X] I removed all sensitive data **before every commit**, including API endpoints and keys
- [X] I ran `fastlane ci` without errors
