### PR TITLE
fix: fix race condition when accessing CampaignRepository (SDKCF-3919)

### DIFF
--- a/RInAppMessaging/Classes/CampaignDispatcher.swift
+++ b/RInAppMessaging/Classes/CampaignDispatcher.swift
@@ -74,11 +74,6 @@ internal class CampaignDispatcher: CampaignDispatcherType, TaskSchedulable {
             return
         }
 
-        CommonUtility.lock(resourcesIn: campaignRepository)
-        defer {
-            CommonUtility.unlock(resourcesIn: campaignRepository)
-        }
-
         let campaignID = queuedCampaignIDs.removeFirst()
         guard let campaign = campaignRepository.list.first(where: { $0.id == campaignID }) else {
             Logger.debug("Warning: Queued campaign \(campaignID) does not exist in the repository anymore")

--- a/RInAppMessaging/Classes/InAppMessagingModule.swift
+++ b/RInAppMessaging/Classes/InAppMessagingModule.swift
@@ -105,10 +105,10 @@ internal class InAppMessagingModule: AnalyticsBroadcaster,
 
         let isLogoutOrUserChange = (preferenceRepository.getUserIdentifiers().isEmpty || diff?.isEmpty == false) && !oldUserIdentifiers.isEmpty
         if isLogoutOrUserChange {
-            campaignRepository.resetDataPersistence()
+            campaignRepository.clearLastUserData()
             eventMatcher.clearNonPersistentEvents()
         }
-        campaignRepository.loadCachedData(syncWithLastUserData: false)
+        campaignRepository.loadCachedData(syncWithLastUserData: true)
         campaignsListManager.refreshList()
     }
 

--- a/RInAppMessaging/Classes/Repositories/CampaignRepository.swift
+++ b/RInAppMessaging/Classes/Repositories/CampaignRepository.swift
@@ -28,10 +28,11 @@ internal protocol CampaignRepositoryType: AnyObject, Lockable {
     func incrementImpressionsLeftInCampaign(id: String) -> Campaign?
 
     /// Loads campaign data from user cache
+    /// - Parameter syncWithLastUserData: When set to true, loaded data will be synchronized with previously registered user (including anonymous user).
     func loadCachedData(syncWithLastUserData: Bool)
 
     /// Deletes cached data used to sync between users
-    func resetDataPersistence()
+    func clearLastUserData()
 }
 
 /// Repository to store campaigns retrieved from ping request.
@@ -119,18 +120,18 @@ internal class CampaignRepository: CampaignRepositoryType {
     func loadCachedData(syncWithLastUserData: Bool) {
         var cachedData = userDataCache.getUserData(identifiers: preferenceRepository.getUserIdentifiers())?.campaignData ?? []
         if syncWithLastUserData {
-            userDataCache.getUserData(identifiers: CampaignRepository.lastUser)?.campaignData?.forEach({ defaultUserCampaign in
-                if let existingCampaignIndex = cachedData.firstIndex(where: { $0.id == defaultUserCampaign.id }) {
-                    cachedData[existingCampaignIndex] = defaultUserCampaign
+            userDataCache.getUserData(identifiers: CampaignRepository.lastUser)?.campaignData?.forEach({ lastUserCampaign in
+                if let existingCampaignIndex = cachedData.firstIndex(where: { $0.id == lastUserCampaign.id }) {
+                    cachedData[existingCampaignIndex] = lastUserCampaign
                 } else {
-                    cachedData.append(defaultUserCampaign)
+                    cachedData.append(lastUserCampaign)
                 }
             })
         }
         campaigns.set(value: cachedData)
     }
 
-    func resetDataPersistence() {
+    func clearLastUserData() {
         userDataCache.deleteUserData(identifiers: CampaignRepository.lastUser)
     }
 

--- a/Tests/Helpers/SharedMocks.swift
+++ b/Tests/Helpers/SharedMocks.swift
@@ -23,7 +23,7 @@ class CampaignRepositoryMock: CampaignRepositoryType {
     private(set) var lastSyncCampaigns = [Campaign]()
     private(set) var wasLoadCachedDataCalled = false
     private(set) var loadCachedDataParameters: (Bool)?
-    private(set) var wasResetDataPersistenceCalled = false
+    private(set) var wasClearLastUserDataCalled = false
 
     func decrementImpressionsLeftInCampaign(id: String) -> Campaign? {
         decrementImpressionsCalls += 1
@@ -64,11 +64,11 @@ class CampaignRepositoryMock: CampaignRepositoryType {
         lastSyncCampaigns = [Campaign]()
         wasLoadCachedDataCalled = false
         loadCachedDataParameters = nil
-        wasResetDataPersistenceCalled = false
+        wasClearLastUserDataCalled = false
     }
 
-    func resetDataPersistence() {
-        wasResetDataPersistenceCalled = true
+    func clearLastUserData() {
+        wasClearLastUserDataCalled = true
     }
 
     private func indexAndCampaign(forID id: String) -> (Int, Campaign)? {

--- a/Tests/InAppMessagingModuleSpec.swift
+++ b/Tests/InAppMessagingModuleSpec.swift
@@ -322,24 +322,24 @@ class InAppMessagingModuleSpec: QuickSpec {
                                 expect(campaignRepository.wasLoadCachedDataCalled).to(beTrue())
                             }
 
-                            it("will reload campaigns repository cache with syncWithLastUserData set to false") {
+                            it("will reload campaigns repository cache with syncWithLastUserData set to true") {
                                 iamModule.registerPreference(aUser)
                                 expect(campaignRepository.wasLoadCachedDataCalled).to(beTrue())
-                                expect(campaignRepository.loadCachedDataParameters).to(equal((false)))
+                                expect(campaignRepository.loadCachedDataParameters).to(equal((true)))
                             }
 
-                            it("will reset campaigns repository data persistence when user logs out or changes to another user") {
+                            it("will clear last user data when user logs out or changes to another user") {
                                 [(aUser, nil), (aUser, IAMPreference()),
                                  (aUser, IAMPreferenceBuilder().setUserId("userB").build())]
                                     .forEach { prefA, prefB in
                                         iamModule.registerPreference(prefA)
                                         campaignRepository.resetFlags()
                                         iamModule.registerPreference(prefB)
-                                        expect(campaignRepository.wasResetDataPersistenceCalled).to(beTrue())
+                                        expect(campaignRepository.wasClearLastUserDataCalled).to(beTrue())
                                     }
                             }
 
-                            it("will not reset campaigns repository data persistence when user did not log out or change to another user") {
+                            it("will not clear last user data when user did not log out or change to another user") {
                                 [(nil, aUser), (IAMPreference(), aUser),
                                  (nil, nil), (nil, IAMPreference()),
                                  (IAMPreference(), nil), (IAMPreference(), IAMPreference())]
@@ -347,7 +347,7 @@ class InAppMessagingModuleSpec: QuickSpec {
                                         iamModule.registerPreference(prefA)
                                         campaignRepository.resetFlags()
                                         iamModule.registerPreference(prefB)
-                                        expect(campaignRepository.wasResetDataPersistenceCalled).to(beFalse())
+                                        expect(campaignRepository.wasClearLastUserDataCalled).to(beFalse())
                                     }
                             }
 

--- a/Tests/PublicAPISpec.swift
+++ b/Tests/PublicAPISpec.swift
@@ -65,6 +65,9 @@ class PublicAPISpec: QuickSpec {
         afterEach {
             RInAppMessaging.deinitializeModule()
             UserDefaults.standard.removePersistentDomain(forName: "PublicAPISpec")
+            UIApplication.shared.keyWindow?.subviews
+                .filter { $0 is BaseView }
+                .forEach { $0.removeFromSuperview() }
         }
 
         describe("RInAppMessaging") {
@@ -193,11 +196,6 @@ class PublicAPISpec: QuickSpec {
             }
 
             context("delegate") {
-                afterEach {
-                    UIApplication.shared.keyWindow?.subviews
-                        .filter { $0 is BaseView }
-                        .forEach { $0.removeFromSuperview() }
-                }
 
                 it("will not call the method if there are no contexts") {
                     generateAndDisplayLoginCampaigns(count: 1, addContexts: false)


### PR DESCRIPTION
# Description
This fixes an issue when impressionLeft data was not updated (and serialized) properly.
The root cause is still unknown. I will investigate that in separate ticket.

## Links
SDKCF-3919

# Checklist
- [X] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [X] I wrote/updated tests for new/changed code
- [X] I removed all sensitive data **before every commit**, including API endpoints and keys
- [X] I ran `fastlane ci` without errors
