### PR TITLE
fix: fix a case when logged in user got outdated cache data (SDKCF-3919)

### DIFF
--- a/RInAppMessaging/Classes/InAppMessagingModule.swift
+++ b/RInAppMessaging/Classes/InAppMessagingModule.swift
@@ -108,7 +108,7 @@ internal class InAppMessagingModule: AnalyticsBroadcaster,
             campaignRepository.clearLastUserData()
             eventMatcher.clearNonPersistentEvents()
         }
-        campaignRepository.loadCachedData(syncWithLastUserData: true)
+        campaignRepository.loadCachedData(syncWithLastUserData: false)
         campaignsListManager.refreshList()
     }
 

--- a/Tests/InAppMessagingModuleSpec.swift
+++ b/Tests/InAppMessagingModuleSpec.swift
@@ -322,10 +322,10 @@ class InAppMessagingModuleSpec: QuickSpec {
                                 expect(campaignRepository.wasLoadCachedDataCalled).to(beTrue())
                             }
 
-                            it("will reload campaigns repository cache with syncWithLastUserData set to true") {
+                            it("will reload campaigns repository cache with syncWithLastUserData set to false") {
                                 iamModule.registerPreference(aUser)
                                 expect(campaignRepository.wasLoadCachedDataCalled).to(beTrue())
-                                expect(campaignRepository.loadCachedDataParameters).to(equal((true)))
+                                expect(campaignRepository.loadCachedDataParameters).to(equal((false)))
                             }
 
                             it("will clear last user data when user logs out or changes to another user") {


### PR DESCRIPTION
# Description
Fixes an unwanted behaviour caused by previous commit's change

## Links
SDKCF-3919

# Checklist
- [X] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [X] I wrote/updated tests for new/changed code
- [X] I removed all sensitive data **before every commit**, including API endpoints and keys
- [ ] I ran `fastlane ci` without errors
