### PR TITLE
ci: remove branch validation in `deploy` workflow, move docs step to separate workflow

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -27,17 +27,12 @@ workflows:
     before_run:
     - _setup
     steps:
-    - script@1:
-        title: Verify branch
+    - brew-install@0:
+        title: Install svn for deploy_ghpages
         inputs:
-        - content: |-
-            #!/usr/bin/env bash
-            set -ex
-
-            if [[ "${BITRISE_GIT_BRANCH}" != "master" ]]; then
-              echo " [!] Deployments are allowed only on 'master' branch"
-              exit 1
-            fi
+        - cache_enabled: 'yes'
+        - upgrade: 'no'
+        - packages: svn
     - script@1:
         title: Lint and push Cocoapods trunk
         inputs:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -26,13 +26,9 @@ workflows:
   deploy:
     before_run:
     - _setup
+    after_run:
+    - _deploy_docs_worker    
     steps:
-    - brew-install@0:
-        title: Install svn for deploy_ghpages
-        inputs:
-        - cache_enabled: 'yes'
-        - upgrade: 'no'
-        - packages: svn
     - script@1:
         title: Lint and push Cocoapods trunk
         inputs:
@@ -42,6 +38,20 @@ workflows:
 
             bundle exec pod spec lint --allow-warnings
             bundle exec pod trunk push --allow-warnings --verbose
+
+  deploy_docs:
+    before_run:
+    - _setup
+    - _deploy_docs_worker
+
+  _deploy_docs_worker:
+    steps:
+    - brew-install@0:
+        title: Install svn
+        inputs:
+        - cache_enabled: 'yes'
+        - upgrade: 'no'
+        - packages: svn
     - fastlane@2:
         title: Generate and deploy Docs to Github Pages
         inputs:


### PR DESCRIPTION
# Description
svn install is needed for macOS 11+
Added `deploy_docs` workflow

# Checklist
- [X] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [ ] I wrote/updated tests for new/changed code
- [X] I removed all sensitive data **before every commit**, including API endpoints and keys
- [ ] I ran `fastlane ci` without errors
