### PR TITLE
tests: add a test for calling API methods w/o calling `configure()`

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,7 +1,7 @@
 PODS:
   - Nimble (9.2.0)
   - Quick (4.0.0)
-  - RInAppMessaging (4.0.0-pp)
+  - RInAppMessaging (4.0.1)
   - SwiftLint (0.43.1)
 
 DEPENDENCIES:
@@ -23,7 +23,7 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   Nimble: 4f4a345c80b503b3ea13606a4f98405974ee4d0b
   Quick: 6473349e43b9271a8d43839d9ba1c442ed1b7ac4
-  RInAppMessaging: 5e99dc996b6a1afd16b7841d877f5d60d4f131f0
+  RInAppMessaging: 9e8e3a4e027bb9119bb6aab3dcde92088f8b6674
   SwiftLint: 99f82d07b837b942dd563c668de129a03fc3fb52
 
 PODFILE CHECKSUM: 8a6dcd4c28e5723bd520363ede4f5fec5524dcd0

--- a/Tests/PublicAPISpec.swift
+++ b/Tests/PublicAPISpec.swift
@@ -92,11 +92,11 @@ class PublicAPISpec: QuickSpec {
                 let errorDelegate = ErrorDelegate()
                 RInAppMessaging.errorDelegate = errorDelegate
 
-                RInAppMessaging.delegate = delegate
-                RInAppMessaging.accessibilityCompatibleDisplay = true
-                RInAppMessaging.closeMessage(clearQueuedCampaigns: true)
-                RInAppMessaging.logEvent(LoginSuccessfulEvent())
-                RInAppMessaging.registerPreference(IAMPreferenceBuilder().setUserId("user").build())
+                RInAppMessaging.delegate = delegate // 1st error sent
+                RInAppMessaging.accessibilityCompatibleDisplay = true // 2nd error sent
+                RInAppMessaging.closeMessage(clearQueuedCampaigns: true) // 3rd error sent
+                RInAppMessaging.logEvent(LoginSuccessfulEvent()) // 4th error sent
+                RInAppMessaging.registerPreference(IAMPreferenceBuilder().setUserId("user").build()) // 5th error sent
                 expect(errorDelegate.totalErrorNumber).toEventually(equal(5))
             }
 

--- a/Tests/PublicAPISpec.swift
+++ b/Tests/PublicAPISpec.swift
@@ -72,6 +72,19 @@ class PublicAPISpec: QuickSpec {
 
         describe("RInAppMessaging") {
 
+            it("will not crash if api methods are called prior to configure()") {
+                RInAppMessaging.deinitializeModule()
+                expect(RInAppMessaging.initializedModule).to(beNil())
+
+                let errorDelegate = ErrorDelegate()
+                RInAppMessaging.delegate = delegate
+                RInAppMessaging.errorDelegate = errorDelegate
+                RInAppMessaging.accessibilityCompatibleDisplay = true
+                RInAppMessaging.closeMessage(clearQueuedCampaigns: true)
+                RInAppMessaging.logEvent(LoginSuccessfulEvent())
+                RInAppMessaging.registerPreference(IAMPreferenceBuilder().setUserId("user").build())
+            }
+
             it("won't reinitialize module if config was called more than once") {
                 let expectedModule = RInAppMessaging.initializedModule
                 RInAppMessaging.configure()


### PR DESCRIPTION
# Description
Added a test to check if module won't crash if `configure()` is not called

# Checklist
- [X] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [X] I wrote/updated tests for new/changed code
- [X] I removed all sensitive data **before every commit**, including API endpoints and keys
- [X] I ran `fastlane ci` without errors
