### PR TITLE
SDKCF-3976 campaign display iff display permission request succeeds

### DIFF
--- a/RInAppMessaging/Classes/Services/DisplayPermissionService.swift
+++ b/RInAppMessaging/Classes/Services/DisplayPermissionService.swift
@@ -23,8 +23,8 @@ internal class DisplayPermissionService: DisplayPermissionServiceType, HttpReque
     }
 
     func checkPermission(forCampaign campaign: CampaignData) -> DisplayPermissionResponse {
-        // In case of error allow campaigns to be displayed anyway
-        let fallbackResponse = DisplayPermissionResponse(display: true, performPing: false)
+        // In case of error, disallow campaign display
+        let fallbackResponse = DisplayPermissionResponse(display: false, performPing: false)
         let requestParams = [
             Constants.Request.campaignID: campaign.campaignId
         ]

--- a/Tests/DisplayPermissionServiceSpec.swift
+++ b/Tests/DisplayPermissionServiceSpec.swift
@@ -54,7 +54,7 @@ class DisplayPermissionServiceSpec: QuickSpec {
                 expect(httpSession.sentRequest?.url).to(equal(configData.endpoints?.displayPermission))
             }
 
-            it("will give permission if url is not available") {
+            it("will deny permission if url is not available") {
                 configurationRepository.saveConfiguration(
                     ConfigData(rolloutPercentage: 100,
                                endpoints: EndpointURL(

--- a/Tests/DisplayPermissionServiceSpec.swift
+++ b/Tests/DisplayPermissionServiceSpec.swift
@@ -64,7 +64,7 @@ class DisplayPermissionServiceSpec: QuickSpec {
                 waitUntil { done in
                     requestQueue.async {
                         let result = service.checkPermission(forCampaign: campaign.data)
-                        expect(result.display).to(beTrue())
+                        expect(result.display).to(beFalse())
                         expect(result.performPing).to(beFalse())
                         done()
                     }
@@ -105,7 +105,7 @@ class DisplayPermissionServiceSpec: QuickSpec {
                         waitUntil { done in
                             requestQueue.async {
                                 let response = service.checkPermission(forCampaign: campaign.data)
-                                expect(response.display).to(beTrue())
+                                expect(response.display).to(beFalse())
                                 expect(response.performPing).to(beFalse())
                                 done()
                             }
@@ -123,7 +123,7 @@ class DisplayPermissionServiceSpec: QuickSpec {
                     waitUntil { done in
                         requestQueue.async {
                             let response = service.checkPermission(forCampaign: campaign.data)
-                            expect(response.display).to(beTrue())
+                            expect(response.display).to(beFalse())
                             expect(response.performPing).to(beFalse())
                             done()
                         }

--- a/Tests/Helpers/SharedMocks.swift
+++ b/Tests/Helpers/SharedMocks.swift
@@ -149,6 +149,12 @@ class MessageMixerServiceMock: MessageMixerServiceType {
     }
 }
 
+class DisplayPermissionServiceMock: DisplayPermissionServiceType {
+    func checkPermission(forCampaign campaign: CampaignData) -> DisplayPermissionResponse {
+        DisplayPermissionResponse(display: true, performPing: false)
+    }
+}
+
 class ConfigurationManagerMock: ConfigurationManagerType {
     weak var errorDelegate: ErrorDelegate?
     var rolloutPercentage = 100

--- a/Tests/PublicAPISpec.swift
+++ b/Tests/PublicAPISpec.swift
@@ -19,6 +19,7 @@ class PublicAPISpec: QuickSpec {
 
         func mockContainer() -> DependencyManager.Container {
             return DependencyManager.Container([
+                DependencyManager.ContainerElement(type: DisplayPermissionServiceType.self, factory: { DisplayPermissionServiceMock() }),
                 DependencyManager.ContainerElement(type: ConfigurationManagerType.self, factory: { configurationManager }),
                 DependencyManager.ContainerElement(type: MessageMixerServiceType.self, factory: { messageMixerService }),
                 DependencyManager.ContainerElement(type: EventMatcherType.self, factory: { eventMatcher }),


### PR DESCRIPTION
# Description

Align with Android behaviour to only display campaigns if Display permission request succeeds


## Links

SDKCF-3976

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data **before every commit**, including API endpoints and keys
- [x] I ran `fastlane ci` without errors
