### PR TITLE
SDKCF-3977 avoid Campaign display if image fetch fails

### DIFF
--- a/RInAppMessaging/Classes/CampaignDispatcher.swift
+++ b/RInAppMessaging/Classes/CampaignDispatcher.swift
@@ -43,7 +43,7 @@ internal class CampaignDispatcher: CampaignDispatcherType, TaskSchedulable {
             memoryCapacity: 512_000,
             // response must be <= 5% in order to be cached
             diskCapacity: 400_000_000, // allocation: 5MB * 4 images / 5%
-            diskPath: "RInAppMessaging") 
+            diskPath: "RInAppMessaging")
         httpSession = URLSession(configuration: sessionConfig)
     }
 

--- a/RInAppMessaging/Classes/CampaignDispatcher.swift
+++ b/RInAppMessaging/Classes/CampaignDispatcher.swift
@@ -145,7 +145,6 @@ internal class CampaignDispatcher: CampaignDispatcherType, TaskSchedulable {
     private func data(from url: URL, completion: @escaping (Data?) -> Void) {
         let sessionConfig = URLSessionConfiguration.default
         sessionConfig.timeoutIntervalForRequest = 5 // seconds
-        sessionConfig.timeoutIntervalForResource = 5
         URLSession(configuration: sessionConfig).dataTask(with: url) { (data, _, error) in
             guard error != nil else {
                 completion(nil)

--- a/RInAppMessaging/Classes/CampaignDispatcher.swift
+++ b/RInAppMessaging/Classes/CampaignDispatcher.swift
@@ -42,7 +42,7 @@ internal class CampaignDispatcher: CampaignDispatcherType, TaskSchedulable {
         sessionConfig.urlCache = URLCache(
             memoryCapacity: 512_000,
             diskCapacity: 8_000_000_000, // 100_000_000(5MB) * 4 images / 0.05 capacity
-            diskPath: "IAM.CampaignDisplay") // non-iCloud cache path
+            diskPath: "RInAppMessaging") // non-iCloud cache path
         httpSession = URLSession(configuration: sessionConfig)
     }
 

--- a/RInAppMessaging/Classes/CampaignDispatcher.swift
+++ b/RInAppMessaging/Classes/CampaignDispatcher.swift
@@ -27,7 +27,7 @@ internal class CampaignDispatcher: CampaignDispatcherType, TaskSchedulable {
 
     weak var delegate: CampaignDispatcherDelegate?
     var scheduledTask: DispatchWorkItem?
-    var httpSession: URLSession
+    private(set) var httpSession: URLSession
 
     init(router: RouterType,
          permissionService: DisplayPermissionServiceType,

--- a/RInAppMessaging/Classes/CampaignDispatcher.swift
+++ b/RInAppMessaging/Classes/CampaignDispatcher.swift
@@ -41,8 +41,9 @@ internal class CampaignDispatcher: CampaignDispatcherType, TaskSchedulable {
         sessionConfig.timeoutIntervalForRequest = Constants.CampaignMessage.imageResourceRequestTimeoutSeconds
         sessionConfig.urlCache = URLCache(
             memoryCapacity: 512_000,
-            diskCapacity: 8_000_000_000, // 100_000_000(5MB) * 4 images / 0.05 capacity
-            diskPath: "RInAppMessaging") // non-iCloud cache path
+            // response must be <= 5% in order to be cached
+            diskCapacity: 8_000_000_000, // allocation: 5MB * 4 images / 5%
+            diskPath: "RInAppMessaging") 
         httpSession = URLSession(configuration: sessionConfig)
     }
 

--- a/RInAppMessaging/Classes/CampaignDispatcher.swift
+++ b/RInAppMessaging/Classes/CampaignDispatcher.swift
@@ -42,7 +42,7 @@ internal class CampaignDispatcher: CampaignDispatcherType, TaskSchedulable {
         sessionConfig.urlCache = URLCache(
             memoryCapacity: 512_000,
             // response must be <= 5% in order to be cached
-            diskCapacity: 8_000_000_000, // allocation: 5MB * 4 images / 5%
+            diskCapacity: 400_000_000, // allocation: 5MB * 4 images / 5%
             diskPath: "RInAppMessaging") 
         httpSession = URLSession(configuration: sessionConfig)
     }

--- a/RInAppMessaging/Classes/CampaignDispatcher.swift
+++ b/RInAppMessaging/Classes/CampaignDispatcher.swift
@@ -94,14 +94,16 @@ internal class CampaignDispatcher: CampaignDispatcherType, TaskSchedulable {
             return
         }
 
-        // fetch image from url and display if successful
+        // fetch from imageUrl, display if successful, skip on error
         if let resImgUrlString = campaign.data.messagePayload.resource.imageUrl, let resImgUrl = URL(string: resImgUrlString) {
             data(from: resImgUrl) { imgBlob in
-                guard let imgBlob = imgBlob else {
-                    self.dispatchNext()
-                    return
+                self.dispatchQueue.async {
+                    guard let imgBlob = imgBlob else {
+                        self.dispatchNext()
+                        return
+                    }
+                    self.displayCampaign(campaign, imageBlob: imgBlob)
                 }
-                self.displayCampaign(campaign, imageBlob: imgBlob)
             }
         } else {
             // If no image expected, just display the message.

--- a/RInAppMessaging/Classes/CampaignDispatcher.swift
+++ b/RInAppMessaging/Classes/CampaignDispatcher.swift
@@ -39,6 +39,10 @@ internal class CampaignDispatcher: CampaignDispatcherType, TaskSchedulable {
 
         let sessionConfig = URLSessionConfiguration.default
         sessionConfig.timeoutIntervalForRequest = Constants.CampaignMessage.imageResourceRequestTimeoutSeconds
+        sessionConfig.urlCache = URLCache(
+            memoryCapacity: 512_000,
+            diskCapacity: 8_000_000_000, // 100_000_000(5MB) * 4 images / 0.05 capacity
+            diskPath: "IAM.CampaignDisplay") // non-iCloud cache path
         httpSession = URLSession(configuration: sessionConfig)
     }
 

--- a/RInAppMessaging/Classes/Constants.swift
+++ b/RInAppMessaging/Classes/Constants.swift
@@ -2,6 +2,7 @@ internal enum Constants {
 
     enum CampaignMessage {
         static let defaultIntervalBetweenDisplaysInMS = 3000
+        static let imageResourceRequestTimeoutSeconds: TimeInterval = 5
     }
 
     enum Request {

--- a/RInAppMessaging/Classes/Router.swift
+++ b/RInAppMessaging/Classes/Router.swift
@@ -6,10 +6,12 @@ internal protocol RouterType: AnyObject {
     /// Contains logic to display the correct view type and create
     /// a view controller to present a single campaign.
     /// - Parameter campaign: The campaign object to display.
+    /// - Parameter associatedImageData: Campaign-associated image as Data
     /// - Parameter confirmation: A handler called just before displaying.
     /// - Parameter completion: Completion handler called once displaying has finished.
     /// - Parameter cancelled: true when message display was cancelled
     func displayCampaign(_ campaign: Campaign,
+                         associatedImageData: Data?,
                          confirmation: @escaping @autoclosure () -> Bool,
                          completion: @escaping (_ cancelled: Bool) -> Void)
 
@@ -43,6 +45,7 @@ internal class Router: RouterType {
     }
 
     func displayCampaign(_ campaign: Campaign,
+                         associatedImageData: Data?,
                          confirmation: @escaping @autoclosure () -> Bool,
                          completion: @escaping (_ cancelled: Bool) -> Void) {
 
@@ -69,14 +72,18 @@ internal class Router: RouterType {
                     break
                 }
                 presenter.campaign = campaign
-                presenter.loadResources()
+                if let associatedImageData = associatedImageData {
+                    presenter.associatedImage = UIImage(data: associatedImageData)
+                }
                 viewConstructor = { ModalView(presenter: presenter) }
             case .full:
                 guard let presenter = getPresenter(type: FullViewPresenterType.self) else {
                     break
                 }
                 presenter.campaign = campaign
-                presenter.loadResources()
+                if let associatedImageData = associatedImageData {
+                    presenter.associatedImage = UIImage(data: associatedImageData)
+                }
                 viewConstructor = { FullScreenView(presenter: presenter) }
             case .slide:
                 guard let presenter = getPresenter(type: SlideUpViewPresenterType.self) else {

--- a/RInAppMessaging/Classes/Views/Presenters/BaseViewPresenter.swift
+++ b/RInAppMessaging/Classes/Views/Presenters/BaseViewPresenter.swift
@@ -19,16 +19,7 @@ internal class BaseViewPresenter: BaseViewPresenterType {
 
     var campaign: Campaign!
     var impressions: [Impression] = []
-    lazy var associatedImage: UIImage? = {
-        guard let imageURLString = campaign.data.messagePayload.resource.imageUrl,
-            let encodedImageURLString = imageURLString.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed),
-            let encodedImageURL = URL(string: encodedImageURLString),
-            let imageData = try? Data(contentsOf: encodedImageURL) else {
-
-            return nil
-        }
-        return UIImage(data: imageData)
-    }()
+    var associatedImage: UIImage?
 
     init(campaignRepository: CampaignRepositoryType,
          impressionService: ImpressionServiceType,

--- a/RInAppMessaging/Classes/Views/Presenters/BaseViewPresenter.swift
+++ b/RInAppMessaging/Classes/Views/Presenters/BaseViewPresenter.swift
@@ -8,7 +8,6 @@ internal protocol BaseViewPresenterType: ImpressionTrackable {
     func viewDidInitialize()
     func handleButtonTrigger(_ trigger: Trigger?)
     func optOutCampaign()
-    func loadResources()
 }
 
 internal class BaseViewPresenter: BaseViewPresenterType {
@@ -60,11 +59,6 @@ internal class BaseViewPresenter: BaseViewPresenterType {
 
     func optOutCampaign() {
         campaign = campaignRepository.optOutCampaign(campaign)
-    }
-
-    func loadResources() {
-        // load image from imageUrl data
-        _ = associatedImage
     }
 
     func showURLError(view: BaseView) {

--- a/Tests/Helpers/SharedMocks.swift
+++ b/Tests/Helpers/SharedMocks.swift
@@ -382,6 +382,7 @@ class RouterMock: RouterType {
     var displayTime = TimeInterval(0.1)
 
     func displayCampaign(_ campaign: Campaign,
+                         associatedImageData: Data?,
                          confirmation: @escaping @autoclosure () -> Bool,
                          completion: @escaping (_ cancelled: Bool) -> Void) {
         guard confirmation() else {

--- a/Tests/Helpers/TestHelpers.swift
+++ b/Tests/Helpers/TestHelpers.swift
@@ -70,6 +70,7 @@ struct TestHelpers {
                                  title: String = "testTitle",
                                  type: CampaignDisplayType = .modal,
                                  isTest: Bool = false,
+                                 hasImage: Bool = false,
                                  content: Content? = nil,
                                  buttons: [Button]? = nil) -> Campaign {
         return Campaign(
@@ -91,7 +92,7 @@ struct TestHelpers {
                     frameColor: "color5",
                     resource: Resource(
                         assetsUrl: nil,
-                        imageUrl: nil,
+                        imageUrl: hasImage ? "https://www.example.com/cat.jpg" : nil,
                         cropType: .fill),
                     messageSettings: MessageSettings(
                         displaySettings: DisplaySettings(

--- a/Tests/ReadyCampaignDispatcherSpec.swift
+++ b/Tests/ReadyCampaignDispatcherSpec.swift
@@ -11,6 +11,7 @@ class ReadyCampaignDispatcherSpec: QuickSpec {
             var campaignRepository: CampaignRepositoryMock!
             var delegate: Delegate!
             var router: RouterMock!
+            var httpSession: URLSessionMock!
 
             beforeEach {
                 permissionService = PermissionServiceMock()
@@ -22,17 +23,20 @@ class ReadyCampaignDispatcherSpec: QuickSpec {
                                                 campaignRepository: campaignRepository)
                 dispatcher.delegate = delegate
 
-                dispatcher.httpSession = URLSessionMock.mock(originalInstance: .shared)
-                // swiftlint:disable:next force_cast
-                let httpSession = dispatcher.httpSession as! URLSessionMock
+                URLSessionMock.startMockingURLSession()
+                httpSession = URLSessionMock.mock(originalInstance: dispatcher.httpSession)
 
-                // simulated data response for imageUrl
+                // simulated success response for imageUrl
                 httpSession.httpResponse = HTTPURLResponse(url: URL(string: "https://example.com/cat.jpg")!,
                                                            statusCode: 200,
                                                            httpVersion: nil,
                                                            headerFields: nil)
                 httpSession.responseData = Data()
                 httpSession.responseError = nil
+            }
+
+            afterEach {
+                URLSessionMock.stopMockingURLSession()
             }
 
             context("before dispatching") {
@@ -202,8 +206,6 @@ class ReadyCampaignDispatcherSpec: QuickSpec {
 
                     context("httpSession errors on loading imageUrl") {
                         beforeEach {
-                            // swiftlint:disable:next force_cast
-                            let httpSession = dispatcher.httpSession as! URLSessionMock
                             httpSession.httpResponse = HTTPURLResponse(url: URL(string: "https://example.com/cat.jpg")!,
                                                                        statusCode: 500,
                                                                        httpVersion: nil,

--- a/Tests/ReadyCampaignDispatcherSpec.swift
+++ b/Tests/ReadyCampaignDispatcherSpec.swift
@@ -32,6 +32,7 @@ class ReadyCampaignDispatcherSpec: QuickSpec {
                                                            httpVersion: nil,
                                                            headerFields: nil)
                 httpSession.responseData = Data()
+                httpSession.responseError = nil
             }
 
             context("before dispatching") {
@@ -189,6 +190,14 @@ class ReadyCampaignDispatcherSpec: QuickSpec {
                                 expect(campaignRepository.incrementImpressionsCalls).toAfterTimeout(equal(1))
                             }
                         }
+                    }
+
+                    it("will display campaign when imageUrl is defined") {
+                        let campaign = TestHelpers.generateCampaign(id: "test", title: "title", type: .modal, isTest: false, hasImage: true)
+                        campaignRepository.list = [campaign]
+                        dispatcher.addToQueue(campaignID: campaign.id)
+                        dispatcher.dispatchAllIfNeeded()
+                        expect(router.lastDisplayedCampaign).toAfterTimeout(equal(campaign))
                     }
 
                     context("httpSession errors on loading imageUrl") {

--- a/Tests/RouterSpec.swift
+++ b/Tests/RouterSpec.swift
@@ -39,7 +39,7 @@ class RouterSpec: QuickSpec {
 
                     it("will not show campaign message") {
                         let campaign = TestHelpers.generateCampaign(id: "test", type: .modal)
-                        router.displayCampaign(campaign, confirmation: false, completion: { _ in })
+                        router.displayCampaign(campaign, associatedImageData: nil, confirmation: false, completion: { _ in })
                         expect(UIApplication.shared.keyWindow?.subviews)
                             .toAfterTimeout(allPass({ !($0 is BaseView )}))
                     }
@@ -49,35 +49,35 @@ class RouterSpec: QuickSpec {
 
                     it("will show ModalView for modal campaign type") {
                         let campaign = TestHelpers.generateCampaign(id: "test", type: .modal)
-                        router.displayCampaign(campaign, confirmation: true, completion: { _ in })
+                        router.displayCampaign(campaign, associatedImageData: nil, confirmation: true, completion: { _ in })
                         expect(UIApplication.shared.keyWindow?.subviews)
                             .toEventually(containElementSatisfying({ $0 is ModalView }))
                     }
 
                     it("will show FullScreenView for full campaign type") {
                         let campaign = TestHelpers.generateCampaign(id: "test", type: .full)
-                        router.displayCampaign(campaign, confirmation: true, completion: { _ in })
+                        router.displayCampaign(campaign, associatedImageData: nil, confirmation: true, completion: { _ in })
                         expect(UIApplication.shared.keyWindow?.subviews)
                             .toEventually(containElementSatisfying({ $0 is FullScreenView }))
                     }
 
                     it("will show SlideUpView for slide campaign type") {
                         let campaign = TestHelpers.generateCampaign(id: "test", type: .slide)
-                        router.displayCampaign(campaign, confirmation: true, completion: { _ in })
+                        router.displayCampaign(campaign, associatedImageData: nil, confirmation: true, completion: { _ in })
                         expect(UIApplication.shared.keyWindow?.subviews)
                             .toEventually(containElementSatisfying({ $0 is SlideUpView }))
                     }
 
                     it("will not show any view for invalid campaign type") {
                         let campaign = TestHelpers.generateCampaign(id: "test", type: .invalid)
-                        router.displayCampaign(campaign, confirmation: true, completion: { _ in })
+                        router.displayCampaign(campaign, associatedImageData: nil, confirmation: true, completion: { _ in })
                         expect(UIApplication.shared.keyWindow?.subviews)
                             .toAfterTimeout(allPass({ !($0 is BaseView )}))
                     }
 
                     it("will not show any view for html campaign type") {
                         let campaign = TestHelpers.generateCampaign(id: "test", type: .html)
-                        router.displayCampaign(campaign, confirmation: true, completion: { _ in })
+                        router.displayCampaign(campaign, associatedImageData: nil, confirmation: true, completion: { _ in })
                         expect(UIApplication.shared.keyWindow?.subviews)
                             .toAfterTimeout(allPass({ !($0 is BaseView )}))
                     }
@@ -85,10 +85,10 @@ class RouterSpec: QuickSpec {
                     it("will not show any view when another one is still displayed") {
                         let campaign1 = TestHelpers.generateCampaign(id: "test", type: .modal)
                         let campaign2 = TestHelpers.generateCampaign(id: "test", type: .full)
-                        router.displayCampaign(campaign1, confirmation: true, completion: { _ in })
+                        router.displayCampaign(campaign1, associatedImageData: nil, confirmation: true, completion: { _ in })
                         expect(UIApplication.shared.keyWindow?.subviews)
                             .toEventually(containElementSatisfying({ $0 is ModalView })) // wait
-                        router.displayCampaign(campaign2, confirmation: true, completion: { _ in })
+                        router.displayCampaign(campaign2, associatedImageData: nil, confirmation: true, completion: { _ in })
                         expect(UIApplication.shared.keyWindow?.subviews)
                             .toAfterTimeoutNot(containElementSatisfying({ $0 is FullScreenView }))
                         expect(UIApplication.shared.keyWindow?.subviews)
@@ -98,7 +98,7 @@ class RouterSpec: QuickSpec {
                     it("will add a view to the UIWindow's view when `accessibilityCompatible` is false") {
                         router.accessibilityCompatibleDisplay = false
                         let campaign = TestHelpers.generateCampaign(id: "test", type: .modal)
-                        router.displayCampaign(campaign, confirmation: true, completion: { _ in })
+                        router.displayCampaign(campaign, associatedImageData: nil, confirmation: true, completion: { _ in })
                         expect(UIApplication.shared.keyWindow?.subviews).toEventually(containElementSatisfying({ $0 is BaseView }))
                     }
 
@@ -108,7 +108,7 @@ class RouterSpec: QuickSpec {
                         UIApplication.shared.keyWindow?.addSubview(rootView)
 
                         let campaign = TestHelpers.generateCampaign(id: "test", type: .modal)
-                        router.displayCampaign(campaign, confirmation: true, completion: { _ in })
+                        router.displayCampaign(campaign, associatedImageData: nil, confirmation: true, completion: { _ in })
                         expect(rootView.subviews).toEventually(containElementSatisfying({ $0 is BaseView }))
                         rootView.removeFromSuperview()
                     }
@@ -119,7 +119,7 @@ class RouterSpec: QuickSpec {
 
                 it("will remove displayed campaign view") {
                     let campaign = TestHelpers.generateCampaign(id: "test", type: .modal)
-                    router.displayCampaign(campaign, confirmation: true, completion: { _ in })
+                    router.displayCampaign(campaign, associatedImageData: nil, confirmation: true, completion: { _ in })
                     expect(UIApplication.shared.keyWindow?.subviews)
                         .toEventually(containElementSatisfying({ $0 is BaseView }))
                     router.discardDisplayedCampaign()
@@ -130,7 +130,7 @@ class RouterSpec: QuickSpec {
                 it("will call onDismiss/completion callback with cancelled flag") {
                     let campaign = TestHelpers.generateCampaign(id: "test", type: .modal)
                     var completionCalled = false
-                    router.displayCampaign(campaign, confirmation: true, completion: { cancelled in
+                    router.displayCampaign(campaign, associatedImageData: nil, confirmation: true, completion: { cancelled in
                         completionCalled = true
                         expect(cancelled).to(beTrue())
                     })


### PR DESCRIPTION
# Description

Match Android behaviour by not displaying the Campaign if its associated `imageUrl` is not nil and fails to download.

Used `URLSession` over `Data(contentsOf:)` since the latter has a unsettable and long default timeout. 

## Links

* SDKCF-3977
* Behaviour reference: [android-inappmessaging DisplayMessageJobIntentService.kt:48-52](https://github.com/rakutentech/android-inappmessaging/blob/73df94dac6f81783c09488a10ff00871432def4b/inappmessaging/src/main/java/com/rakuten/tech/mobile/inappmessaging/runtime/service/DisplayMessageJobIntentService.kt#L49-L52)

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data **before every commit**, including API endpoints and keys
- [x] I ran `fastlane ci` without errors
