### PR TITLE
fix: remove error notification for API properties

### DIFF
--- a/RInAppMessaging/Classes/RInAppMessaging.swift
+++ b/RInAppMessaging/Classes/RInAppMessaging.swift
@@ -32,8 +32,9 @@ import Foundation
     /// - Note: There is a possibility that changing this property will cause campaigns to display incorrectly
     @objc public static var accessibilityCompatibleDisplay = false {
         didSet {
-            notifyIfModuleNotInitialized()
-            dependencyManager?.resolve(type: RouterType.self)?.accessibilityCompatibleDisplay = accessibilityCompatibleDisplay
+            inAppQueue.async {
+                dependencyManager?.resolve(type: RouterType.self)?.accessibilityCompatibleDisplay = accessibilityCompatibleDisplay
+            }
         }
     }
 
@@ -43,10 +44,7 @@ import Foundation
     /// Optional delegate for advanced features
     @objc public static weak var delegate: RInAppMessagingDelegate? {
         didSet {
-            inAppQueue.async {
-                notifyIfModuleNotInitialized()
-                initializedModule?.delegate = delegate
-            }
+            initializedModule?.delegate = delegate
         }
     }
 
@@ -66,7 +64,7 @@ import Foundation
     static func configure(dependencyManager: DependencyManager) {
         self.dependencyManager = dependencyManager
 
-        inAppQueue.async(flags: .barrier) {
+        inAppQueue.async {
             guard initializedModule == nil else {
                 return
             }
@@ -111,7 +109,7 @@ import Foundation
     /// Log the event name passed in and also pass the event name to the view controller to display a matching campaign.
     /// - Parameter event: The Event object to log.
     @objc public static func logEvent(_ event: Event) {
-        inAppQueue.async(flags: .barrier) {
+        inAppQueue.async {
             notifyIfModuleNotInitialized()
             initializedModule?.logEvent(event)
         }
@@ -120,7 +118,7 @@ import Foundation
     /// Register user preference to the IAM SDK.
     /// - Parameter preference: Preferences of the user.
     @objc public static func registerPreference(_ preference: IAMPreference?) {
-        inAppQueue.async(flags: .barrier) {
+        inAppQueue.async {
             notifyIfModuleNotInitialized()
             initializedModule?.registerPreference(preference)
         }
@@ -132,7 +130,7 @@ import Foundation
     /// - Parameter clearQueuedCampaigns: when set to true, it will clear also the list of campaigns that were
     ///                                   triggered and are queued to be displayed.
     @objc public static func closeMessage(clearQueuedCampaigns: Bool = false) {
-        inAppQueue.async(flags: .barrier) {
+        inAppQueue.async {
             notifyIfModuleNotInitialized()
             initializedModule?.closeMessage(clearQueuedCampaigns: clearQueuedCampaigns)
         }

--- a/Tests/PublicAPISpec.swift
+++ b/Tests/PublicAPISpec.swift
@@ -92,12 +92,10 @@ class PublicAPISpec: QuickSpec {
                 let errorDelegate = ErrorDelegate()
                 RInAppMessaging.errorDelegate = errorDelegate
 
-                RInAppMessaging.delegate = delegate // 1st error sent
-                RInAppMessaging.accessibilityCompatibleDisplay = true // 2nd error sent
-                RInAppMessaging.closeMessage(clearQueuedCampaigns: true) // 3rd error sent
-                RInAppMessaging.logEvent(LoginSuccessfulEvent()) // 4th error sent
-                RInAppMessaging.registerPreference(IAMPreferenceBuilder().setUserId("user").build()) // 5th error sent
-                expect(errorDelegate.totalErrorNumber).toEventually(equal(5))
+                RInAppMessaging.closeMessage(clearQueuedCampaigns: true) // 1st error sent
+                RInAppMessaging.logEvent(LoginSuccessfulEvent()) // 2nd error sent
+                RInAppMessaging.registerPreference(IAMPreferenceBuilder().setUserId("user").build()) // 3rd error sent
+                expect(errorDelegate.totalErrorNumber).toEventually(equal(3))
             }
 
             it("won't reinitialize module if config was called more than once") {
@@ -142,9 +140,9 @@ class PublicAPISpec: QuickSpec {
 
             it("will set accessibilityCompatibleDisplay flag in Router") {
                 RInAppMessaging.accessibilityCompatibleDisplay = true
-                expect(router.accessibilityCompatibleDisplay).to(beTrue())
+                expect(router.accessibilityCompatibleDisplay).toAfterTimeout(beTrue())
                 RInAppMessaging.accessibilityCompatibleDisplay = false
-                expect(router.accessibilityCompatibleDisplay).to(beFalse())
+                expect(router.accessibilityCompatibleDisplay).toEventually(beFalse())
             }
 
             it("won't send any events until configuration has finished") {


### PR DESCRIPTION
# Description
`notifyIfModuleNotInitialized()` is not necessary for API properties because their values are passed to the module during configuration. This change also fixes unwanted notifications when those properties are set just after `configure()`.
Added synchronization for `accessibilityCompatibleDisplay` to avoid crashes.
Removed `.barrier` flag from inAppQueue calls because that flag is applicable only to concurrent queues.

# Checklist
- [X] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [X] I wrote/updated tests for new/changed code
- [X] I removed all sensitive data **before every commit**, including API endpoints and keys
- [X] I ran `fastlane ci` without errors
