### PR TITLE
improve: increase touch area of campaign's close button "x" (SDKCF-3958)

### DIFF
--- a/RInAppMessaging/Assets/FullView.xib
+++ b/RInAppMessaging/Assets/FullView.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>

--- a/RInAppMessaging/Classes/Extensions/UIView+IAM.swift
+++ b/RInAppMessaging/Classes/Extensions/UIView+IAM.swift
@@ -32,6 +32,18 @@ extension UIView {
 
         return nil
     }
+
+    func isTouchInside(touchPoint point: CGPoint, from: UIView, targetView: UIView?, touchAreaSize: CGFloat) -> Bool {
+        guard let targetView = targetView,
+              let targetViewSuperview = targetView.superview else {
+            return false
+        }
+        let targetViewCenter = convert(targetView.center, from: targetViewSuperview)
+        let targetViewTouchArea = CGRect(origin: targetViewCenter, size: .zero)
+            .insetBy(dx: -touchAreaSize / 2.0, dy: -touchAreaSize / 2.0)
+
+        return targetViewTouchArea.contains(point)
+    }
 }
 
 extension NSLayoutConstraint {

--- a/RInAppMessaging/Classes/Views/FullView.swift
+++ b/RInAppMessaging/Classes/Views/FullView.swift
@@ -22,6 +22,7 @@ internal class FullView: UIView, FullViewType, RichContentBrowsable {
         var exitButtonFontSize: CGFloat = 13 // Size of the exit button.
         var exitButtonSize: CGFloat = 15 // Size of the exit button.
         var exitButtonVerticalOffset: CGFloat = 16 // Position of where the button should be relative to the safe area frame.
+        var exitButtonTouchAreaSize: CGFloat = 44 // Clickable area of exit button used in hitTest
         var dialogViewHorizontalMargin: CGFloat = 20 // The spacing between dialog view and the children elements.
         var dialogViewWidthOffset: CGFloat = 0 // Spacing on the left and right side of subviews.
         var dialogViewWidthMultiplier: CGFloat = 1 // Spacing on the left and right side of subviews.
@@ -107,6 +108,17 @@ internal class FullView: UIView, FullViewType, RichContentBrowsable {
         updateUIConstants()
         exitButtonYPositionConstraint.constant = uiConstants.exitButtonVerticalOffset
         bodyViewOffsetYConstraint.constant = hasImage ? 0 : uiConstants.bodyViewSafeAreaOffsetY
+    }
+
+    override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
+        let exitButtonCenter = convert(exitButton.center, from: exitButton.superview)
+        let exitButtonTouchArea = CGRect(origin: exitButtonCenter, size: .zero)
+            .insetBy(dx: -uiConstants.exitButtonTouchAreaSize / 2.0, dy: -uiConstants.exitButtonTouchAreaSize / 2.0)
+
+        if exitButtonTouchArea.contains(point) {
+            return exitButton
+        }
+        return super.hitTest(point, with: event)
     }
 
     func setup(viewModel: FullViewModel) {

--- a/RInAppMessaging/Classes/Views/FullView.swift
+++ b/RInAppMessaging/Classes/Views/FullView.swift
@@ -111,11 +111,7 @@ internal class FullView: UIView, FullViewType, RichContentBrowsable {
     }
 
     override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
-        let exitButtonCenter = convert(exitButton.center, from: exitButton.superview)
-        let exitButtonTouchArea = CGRect(origin: exitButtonCenter, size: .zero)
-            .insetBy(dx: -uiConstants.exitButtonTouchAreaSize / 2.0, dy: -uiConstants.exitButtonTouchAreaSize / 2.0)
-
-        if exitButtonTouchArea.contains(point) {
+        if isTouchInside(touchPoint: point, from: self, targetView: exitButton, touchAreaSize: uiConstants.exitButtonTouchAreaSize) {
             return exitButton
         }
         return super.hitTest(point, with: event)

--- a/RInAppMessaging/Classes/Views/SlideUpView.swift
+++ b/RInAppMessaging/Classes/Views/SlideUpView.swift
@@ -49,14 +49,7 @@ internal class SlideUpView: UIView, SlideUpViewType {
     }
 
     override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
-        guard let exitButton = exitButton else {
-            return super.hitTest(point, with: event)
-        }
-        let exitButtonCenter = convert(exitButton.center, from: exitButton.superview)
-        let exitButtonTouchArea = CGRect(origin: exitButtonCenter, size: .zero)
-            .insetBy(dx: -UIConstants.exitButtonTouchAreaSize / 2.0, dy: -UIConstants.exitButtonTouchAreaSize / 2.0)
-
-        if exitButtonTouchArea.contains(point) {
+        if isTouchInside(touchPoint: point, from: self, targetView: exitButton, touchAreaSize: UIConstants.exitButtonTouchAreaSize) {
             return exitButton
         }
         return super.hitTest(point, with: event)

--- a/RInAppMessaging/Classes/Views/SlideUpView.swift
+++ b/RInAppMessaging/Classes/Views/SlideUpView.swift
@@ -8,6 +8,7 @@ internal class SlideUpView: UIView, SlideUpViewType {
         static let exitButtonSize: CGFloat = 20
         static let exitButtonTopMargin: CGFloat = 12
         static let exitButtonRightMargin: CGFloat = 16
+        static let exitButtonTouchAreaSize: CGFloat = 44
         static let slideAnimationDuration: TimeInterval = 0.4
         static var messageBodyPadding: UIEdgeInsets {
             let bottomSafeArea = UIApplication.shared.getKeyWindow()?.safeAreaInsets.bottom ?? CGFloat(0)
@@ -30,6 +31,7 @@ internal class SlideUpView: UIView, SlideUpViewType {
 
     private let presenter: SlideUpViewPresenterType
     private let dialogView = UIView()
+    private var exitButton: ExitButton?
     private var slideFromDirection = SlideDirection.bottom
     private var bottomConstraint: NSLayoutConstraint!
     private var leftConstraint: NSLayoutConstraint!
@@ -44,6 +46,20 @@ internal class SlideUpView: UIView, SlideUpViewType {
 
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+
+    override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
+        guard let exitButton = exitButton else {
+            return super.hitTest(point, with: event)
+        }
+        let exitButtonCenter = convert(exitButton.center, from: exitButton.superview)
+        let exitButtonTouchArea = CGRect(origin: exitButtonCenter, size: .zero)
+            .insetBy(dx: -UIConstants.exitButtonTouchAreaSize / 2.0, dy: -UIConstants.exitButtonTouchAreaSize / 2.0)
+
+        if exitButtonTouchArea.contains(point) {
+            return exitButton
+        }
+        return super.hitTest(point, with: event)
     }
 
     func setup(viewModel: SlideUpViewModel) {
@@ -146,6 +162,7 @@ internal class SlideUpView: UIView, SlideUpViewType {
         exitButton.addTarget(self, action: #selector(onExitButtonClick), for: .touchUpInside)
 
         exitButton.translatesAutoresizingMaskIntoConstraints = false
+        self.exitButton = exitButton
         dialogView.addSubview(exitButton)
         NSLayoutConstraint.activate([
             exitButton.trailingAnchor.constraint(equalTo: dialogView.trailingAnchor,


### PR DESCRIPTION
# Description
Maybe it's not a very clean solution to use `hitArea()` method for handling touches but it was the easiest one.
Changing button's drawing rect would result in adding custom drawing code for button's content, and constraint calculation would operate in negative numbers being totally unintuitive.

## Links
SDKCF-3958

# Checklist
- [X] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [ ] I wrote/updated tests for new/changed code
- [X] I removed all sensitive data **before every commit**, including API endpoints and keys
- [ ] I ran `fastlane ci` without errors
