### PR TITLE
improve: optimize campaign image cache allotment

### DIFF
--- a/RInAppMessaging/Classes/CampaignDispatcher.swift
+++ b/RInAppMessaging/Classes/CampaignDispatcher.swift
@@ -39,11 +39,10 @@ internal class CampaignDispatcher: CampaignDispatcherType, TaskSchedulable {
 
         let sessionConfig = URLSessionConfiguration.default
         sessionConfig.timeoutIntervalForRequest = Constants.CampaignMessage.imageResourceRequestTimeoutSeconds
-        sessionConfig.requestCachePolicy = .returnCacheDataElseLoad
         sessionConfig.urlCache = URLCache(
-            memoryCapacity: 10_000_000,
-            // response must be <= 5% in order to be cached
-            diskCapacity: 40_000_000,
+            // response must be <= 5% of mem/disk cap in order to commited to cache
+            memoryCapacity: 512_000, // default
+            diskCapacity: 101*1024*1024,
             diskPath: "RInAppMessaging")
         httpSession = URLSession(configuration: sessionConfig)
     }

--- a/RInAppMessaging/Classes/CampaignDispatcher.swift
+++ b/RInAppMessaging/Classes/CampaignDispatcher.swift
@@ -41,7 +41,7 @@ internal class CampaignDispatcher: CampaignDispatcherType, TaskSchedulable {
         sessionConfig.timeoutIntervalForRequest = Constants.CampaignMessage.imageResourceRequestTimeoutSeconds
         sessionConfig.urlCache = URLCache(
             // response must be <= 5% of mem/disk cap in order to commited to cache
-            memoryCapacity: 512_000, // default
+            memoryCapacity: URLCache.shared.memoryCapacity,
             diskCapacity: 101*1024*1024,
             diskPath: "RInAppMessaging")
         httpSession = URLSession(configuration: sessionConfig)

--- a/RInAppMessaging/Classes/CampaignDispatcher.swift
+++ b/RInAppMessaging/Classes/CampaignDispatcher.swift
@@ -39,10 +39,11 @@ internal class CampaignDispatcher: CampaignDispatcherType, TaskSchedulable {
 
         let sessionConfig = URLSessionConfiguration.default
         sessionConfig.timeoutIntervalForRequest = Constants.CampaignMessage.imageResourceRequestTimeoutSeconds
+        sessionConfig.requestCachePolicy = .returnCacheDataElseLoad
         sessionConfig.urlCache = URLCache(
-            memoryCapacity: 512_000,
+            memoryCapacity: 10_000_000,
             // response must be <= 5% in order to be cached
-            diskCapacity: 400_000_000, // allocation: 5MB * 4 images / 5%
+            diskCapacity: 40_000_000,
             diskPath: "RInAppMessaging")
         httpSession = URLSession(configuration: sessionConfig)
     }

--- a/RInAppMessaging/Classes/CampaignDispatcher.swift
+++ b/RInAppMessaging/Classes/CampaignDispatcher.swift
@@ -42,7 +42,7 @@ internal class CampaignDispatcher: CampaignDispatcherType, TaskSchedulable {
         sessionConfig.urlCache = URLCache(
             // response must be <= 5% of mem/disk cap in order to committed to cache
             memoryCapacity: URLCache.shared.memoryCapacity,
-            diskCapacity: 100*1024*1024, // fits up to 5MB images
+            diskCapacity: Int(5266467/0.05), // fits up to 5MB images
             diskPath: "RInAppMessaging")
         httpSession = URLSession(configuration: sessionConfig)
     }

--- a/RInAppMessaging/Classes/CampaignDispatcher.swift
+++ b/RInAppMessaging/Classes/CampaignDispatcher.swift
@@ -42,7 +42,7 @@ internal class CampaignDispatcher: CampaignDispatcherType, TaskSchedulable {
         sessionConfig.urlCache = URLCache(
             // response must be <= 5% of mem/disk cap in order to committed to cache
             memoryCapacity: URLCache.shared.memoryCapacity,
-            diskCapacity: Int(5266467/0.05), // fits up to 5MB images
+            diskCapacity: 100*1024*1024, // fits up to 5MB images
             diskPath: "RInAppMessaging")
         httpSession = URLSession(configuration: sessionConfig)
     }

--- a/RInAppMessaging/Classes/CampaignDispatcher.swift
+++ b/RInAppMessaging/Classes/CampaignDispatcher.swift
@@ -42,7 +42,7 @@ internal class CampaignDispatcher: CampaignDispatcherType, TaskSchedulable {
         sessionConfig.urlCache = URLCache(
             // response must be <= 5% of mem/disk cap in order to commited to cache
             memoryCapacity: URLCache.shared.memoryCapacity,
-            diskCapacity: 101*1024*1024,
+            diskCapacity: 101*1024*1024, // to fit up to 5MB images
             diskPath: "RInAppMessaging")
         httpSession = URLSession(configuration: sessionConfig)
     }

--- a/RInAppMessaging/Classes/CampaignDispatcher.swift
+++ b/RInAppMessaging/Classes/CampaignDispatcher.swift
@@ -40,9 +40,9 @@ internal class CampaignDispatcher: CampaignDispatcherType, TaskSchedulable {
         let sessionConfig = URLSessionConfiguration.default
         sessionConfig.timeoutIntervalForRequest = Constants.CampaignMessage.imageResourceRequestTimeoutSeconds
         sessionConfig.urlCache = URLCache(
-            // response must be <= 5% of mem/disk cap in order to commited to cache
+            // response must be <= 5% of mem/disk cap in order to committed to cache
             memoryCapacity: URLCache.shared.memoryCapacity,
-            diskCapacity: 101*1024*1024, // to fit up to 5MB images
+            diskCapacity: 100*1024*1024, // fits up to 5MB images
             diskPath: "RInAppMessaging")
         httpSession = URLSession(configuration: sessionConfig)
     }


### PR DESCRIPTION
# Description

Change image caching policy as [per discussion](https://github.com/rakutentech/ios-inappmessaging/pull/95#discussion_r668648531).

# Discussion

[See empirical test](https://github.com/rakutentech/ios-inappmessaging/pull/98#discussion_r669220444) for our use case

For reference: [JUST EAT](https://tech.justeattakeaway.com/2021/02/01/urlcache-default-size-is-not-enough/) uses 4MB memory & 40MB disk. [PSPDFKit suggested 10MB memory & 1GB disk](https://pspdfkit.com/blog/2020/downloading-large-files-with-urlsession/) (I suppose to be able to score a cache hit on beefy files).

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data **before every commit**, including API endpoints and keys
- [x] I ran `fastlane ci` without errors
