### PR TITLE
fix: fix scroll view horizontal bouncing (SDKCF-4020)

### DIFF
--- a/RInAppMessaging/Assets/FullView.xib
+++ b/RInAppMessaging/Assets/FullView.xib
@@ -17,6 +17,7 @@
                 <outlet property="bodyView" destination="mHs-W6-s9X" id="DFx-Il-UEO"/>
                 <outlet property="bodyViewOffsetYConstraint" destination="LEa-Mv-BCR" id="abv-2p-TYw"/>
                 <outlet property="buttonsContainer" destination="x36-hg-Dgf" id="V6b-Wj-ReC"/>
+                <outlet property="contentScrollView" destination="R2i-po-Za0" id="n9b-nr-Eho"/>
                 <outlet property="contentView" destination="9fo-EW-lL9" id="qtH-MB-9vO"/>
                 <outlet property="contentWidthOffsetConstraint" destination="rmG-89-pbI" id="RLz-RF-qgv"/>
                 <outlet property="controlsView" destination="IpI-Mq-vby" id="8Cg-db-Bxz"/>

--- a/RInAppMessaging/Classes/Views/BaseView.swift
+++ b/RInAppMessaging/Classes/Views/BaseView.swift
@@ -38,7 +38,7 @@ internal extension BaseView {
         parentView.addSubview(self)
         NSLayoutConstraint.activate(constraintsForParent(parentView))
 
-        parentView.layoutIfNeeded()
+        parentView.setNeedsLayout()
         parentView.isUserInteractionEnabled = false
         animateOnShow(completion: {
             parentView.isUserInteractionEnabled = true

--- a/RInAppMessaging/Classes/Views/FullView.swift
+++ b/RInAppMessaging/Classes/Views/FullView.swift
@@ -57,6 +57,7 @@ internal class FullView: UIView, FullViewType, RichContentBrowsable {
     @IBOutlet private weak var optOutView: OptOutMessageView!
     @IBOutlet private weak var optOutAndButtonsSpacer: UIView!
     @IBOutlet private weak var buttonsContainer: UIStackView!
+    @IBOutlet private weak var contentScrollView: UIScrollView!
     @IBOutlet private(set) weak var exitButton: ExitButton! {
         didSet {
             exitButton.invertedColors = hasImage
@@ -108,6 +109,12 @@ internal class FullView: UIView, FullViewType, RichContentBrowsable {
         updateUIConstants()
         exitButtonYPositionConstraint.constant = uiConstants.exitButtonVerticalOffset
         bodyViewOffsetYConstraint.constant = hasImage ? 0 : uiConstants.bodyViewSafeAreaOffsetY
+
+        DispatchQueue.main.async { [self] in
+            // Fixes a problem with content size width being set 0.5pt too much
+            // (landscape iPad), resulting in horizontal scroll bouncing.
+            contentScrollView.contentSize.width = contentScrollView.bounds.width
+        }
     }
 
     override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {


### PR DESCRIPTION
# Description
Campaign view should be scrollable only vertically.
It seems like on iPads in landscape mode, for some reason, scroll view's content size is miscalculated.
That calculation is a result of `parentView.setNeedsLayout()` in `displayView` function in `BaseView`.
The difference is just 0.5pt (e.g. 414.0 -> 414.5) I don't know where that 0.5 comes from but I assume that it's a rounding issue.
The line that sets correct content size is wrapped in `DispatchQueue.main.async` in order to be executed after all other calculations.

## Links
SDKCF-4020

# Checklist
- [X] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [ ] I wrote/updated tests for new/changed code
- [X] I removed all sensitive data **before every commit**, including API endpoints and keys
- [ ] I ran `fastlane ci` without errors
