### PR TITLE
fix: integral image geometry SDKCF-4022

### DIFF
--- a/RInAppMessaging.xcodeproj/project.pbxproj
+++ b/RInAppMessaging.xcodeproj/project.pbxproj
@@ -55,6 +55,7 @@
 		45DA01AD23D5831900A27CC6 /* ConfigurationManagerSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45DA01AC23D5831900A27CC6 /* ConfigurationManagerSpec.swift */; };
 		45EA720525B71FA2001B2049 /* UIApplicationExtensionSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45EA720425B71FA2001B2049 /* UIApplicationExtensionSpec.swift */; };
 		45EA720D25B72002001B2049 /* UIViewExtensionSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45EA720C25B72002001B2049 /* UIViewExtensionSpec.swift */; };
+		4B8F47C326B29ECA0029FA2E /* CoreGraphicsExtensionSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B8F47C226B29ECA0029FA2E /* CoreGraphicsExtensionSpec.swift */; };
 		607FACD61AFB9204008FA782 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 607FACD51AFB9204008FA782 /* AppDelegate.swift */; };
 		607FACD81AFB9204008FA782 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 607FACD71AFB9204008FA782 /* ViewController.swift */; };
 		607FACDB1AFB9204008FA782 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 607FACD91AFB9204008FA782 /* Main.storyboard */; };
@@ -138,6 +139,7 @@
 		45DA01AC23D5831900A27CC6 /* ConfigurationManagerSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigurationManagerSpec.swift; sourceTree = "<group>"; };
 		45EA720425B71FA2001B2049 /* UIApplicationExtensionSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIApplicationExtensionSpec.swift; sourceTree = "<group>"; };
 		45EA720C25B72002001B2049 /* UIViewExtensionSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIViewExtensionSpec.swift; sourceTree = "<group>"; };
+		4B8F47C226B29ECA0029FA2E /* CoreGraphicsExtensionSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CoreGraphicsExtensionSpec.swift; sourceTree = "<group>"; };
 		607FACD01AFB9204008FA782 /* RInAppMessaging_Example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = RInAppMessaging_Example.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		607FACD41AFB9204008FA782 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		607FACD51AFB9204008FA782 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -284,6 +286,7 @@
 				45ADA53D247CFE9E00A9E2A3 /* ConfigurationRepositorySpec.swift */,
 				459B227B245289F300D218CE /* ConfigurationServiceSpec.swift */,
 				D9F418282110FD9F00E2158F /* ConfigurationSpec.swift */,
+				4B8F47C226B29ECA0029FA2E /* CoreGraphicsExtensionSpec.swift */,
 				459DE86B2407B5750002F451 /* CustomEventSpec.swift */,
 				45491058247F58660019864D /* CustomAttributeSpec.swift */,
 				4516601123CD411300310181 /* DependencyManagerSpec.swift */,
@@ -531,6 +534,7 @@
 				459B228024528A6900D218CE /* ImpressionServiceSpec.swift in Sources */,
 				4557A8B1257E544C00C9D241 /* IAMPreferenceSpec.swift in Sources */,
 				451E93A2248E3D3D00545D6B /* NimbleExtensions.swift in Sources */,
+				4B8F47C326B29ECA0029FA2E /* CoreGraphicsExtensionSpec.swift in Sources */,
 				D911DC4F211115730082B950 /* ConfigurationSpec.swift in Sources */,
 				45563B03240614AE004EAFD3 /* ReadyCampaignDispatcherSpec.swift in Sources */,
 				456FE1E924288C6500304872 /* CampaignTriggerAgentSpec.swift in Sources */,

--- a/RInAppMessaging/Classes/Extensions/CGSize+IAM.swift
+++ b/RInAppMessaging/Classes/Extensions/CGSize+IAM.swift
@@ -1,0 +1,6 @@
+extension CGSize {
+    /// returns a `CGSize` with the smallest integer values for its size to prevent drawing on pixel boundaries
+    var integral: CGSize {
+        CGSize(width: ceil(width), height: ceil(height))
+    }
+}

--- a/RInAppMessaging/Classes/Views/Components/FlexibleHeightImageView.swift
+++ b/RInAppMessaging/Classes/Views/Components/FlexibleHeightImageView.swift
@@ -13,7 +13,7 @@ internal class FlexibleHeightImageView: UIImageView {
         let width = super.intrinsicContentSize.width
         let ratio = image.size.height / image.size.width
 
-        return CGSize(width: width, height: bounds.width * ratio)
+        return CGSize(width: width, height: bounds.width * ratio).integral
     }
 
     override func layoutSubviews() {

--- a/Tests/CoreGraphicsExtensionSpec.swift
+++ b/Tests/CoreGraphicsExtensionSpec.swift
@@ -1,0 +1,39 @@
+import Quick
+import Nimble
+@testable import RInAppMessaging
+
+class CoreGraphicsExtensionsSpec: QuickSpec {
+    override func spec() {
+        describe("CGSize+IAM") {
+            context("when calling integral property") {
+                it("will return a CGSize with whole integers") {
+                    let given = CGSize(width: 0.23, height: 2.34)
+                    let ref = CGRect(origin: .zero, size: given).integral.size
+                    expect(ref).to(equal(given.integral))
+                    expect(ref).to(equal(CGSize(width: 1, height: 3)))
+                }
+
+                it("will return a max CGSize max magnitude") {
+                    let given = CGSize(width: CGFloat.greatestFiniteMagnitude, height: CGFloat.greatestFiniteMagnitude)
+                    let ref = CGRect(origin: .zero, size: given).integral.size
+                    expect(ref).to(equal(given.integral))
+                    expect(ref).to(equal(CGSize(width: CGFloat.greatestFiniteMagnitude, height: CGFloat.greatestFiniteMagnitude)))
+                }
+
+                it("will return a 1x1 CGSize with least normal magnitude") {
+                    let given = CGSize(width: CGFloat.leastNormalMagnitude, height: CGFloat.leastNormalMagnitude)
+                    let ref = CGRect(origin: .zero, size: given).integral.size
+                    expect(ref).to(equal(given.integral))
+                    expect(ref).to(equal(CGSize(width: 1, height: 1)))
+                }
+
+                it("will return a 1x1 CGSize with least non-zero magnitude") {
+                    let given = CGSize(width: CGFloat.leastNonzeroMagnitude, height: CGFloat.leastNonzeroMagnitude)
+                    let ref = CGRect(origin: .zero, size: given).integral.size
+                    expect(ref).to(equal(given.integral))
+                    expect(ref).to(equal(CGSize(width: 1, height: 1)))
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
# Description

Campaign image view's `intrinsicContentSize` is recalculated with its aspect ratio which ends up with a fractional `CGFloat`. This causes an issue in some cases where the image doesn't 100% fill the width of its container depending on the fraction with the image being 1px too short on the left and right. Should round CG values to the nearest whole point to avoid frames being drawn on pixel boundaries (ref. [NSHipster, Core​Graphics Geometry Primitives](https://nshipster.com/cggeometry/#integrating-rectangles)) so that it fits its container properly.

<img width="866" alt="ya" src="https://user-images.githubusercontent.com/3298414/127272698-a9aa4583-470b-446d-a94b-5ba16c96b5b6.png">

## Links

SDKCF-4022

Tested against the 6820 × 4552px image in this ticket on iPhone SE (2nd gen) and iPhone 12 Pro Max.


# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data **before every commit**, including API endpoints and keys
- [x] I ran `fastlane ci` without errors
