### PR TITLE
fix: fix AtomicWrapper concurrency

### DIFF
--- a/RInAppMessaging/Classes/Protocols/Lockable.swift
+++ b/RInAppMessaging/Classes/Protocols/Lockable.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 /// Protocol to mark object that have resources that can be thread locked
 internal protocol Lockable {
     var resourcesToLock: [LockableResource] { get }

--- a/RInAppMessaging/Classes/Utilities/AtomicWrapper.swift
+++ b/RInAppMessaging/Classes/Utilities/AtomicWrapper.swift
@@ -1,8 +1,10 @@
+import Foundation
+
 /// This wrapper ensures synchronized access to the value only for getter and setter.
 /// Mutating functions, subscript, incrementation etc. are not synchronized by default -
 /// use `mutate` function to ensure operation atomicity.
 @propertyWrapper
-struct AtomicGetSet<Value> {
+class AtomicGetSet<Value> {
     private let queue = PropertyQueueGenerator.spawnQueue(domain: "IAM.AtomicProperty")
     private var value: Value
 
@@ -15,12 +17,12 @@ struct AtomicGetSet<Value> {
             return queue.sync { value }
         }
         set {
-            queue.sync { value = newValue }
+            queue.sync(flags: .barrier) { value = newValue }
         }
     }
 
-    mutating func mutate(_ mutation: (inout Value) -> Void) {
-        queue.sync {
+    func mutate(_ mutation: (inout Value) -> Void) {
+        queue.sync(flags: .barrier) {
             mutation(&value)
         }
     }
@@ -31,6 +33,6 @@ private struct PropertyQueueGenerator {
 
     static func spawnQueue(domain: String) -> DispatchQueue {
         lastQueueNumber += 1
-        return DispatchQueue(label: domain + "\(lastQueueNumber))")
+        return DispatchQueue(label: domain + "\(lastQueueNumber))", attributes: .concurrent)
     }
 }

--- a/Tests/UserDataCacheSpec.swift
+++ b/Tests/UserDataCacheSpec.swift
@@ -92,11 +92,15 @@ class UserDataCacheSpec: QuickSpec {
                     var queue1IsDone = false
                     var queue2IsDone = false
                     queue1.async {
-                        userCache.cacheCampaignData([], userIdentifiers: [])
+                        for _ in 1...1000 {
+                            userCache.cacheCampaignData([], userIdentifiers: [])
+                        }
                         DispatchQueue.main.async { queue1IsDone = true }
                     }
                     queue2.async {
-                        userCache.cacheCampaignData([], userIdentifiers: [])
+                        for _ in 1...1000 {
+                            userCache.cacheCampaignData([], userIdentifiers: [])
+                        }
                         DispatchQueue.main.async { queue2IsDone = true }
                     }
                     expect(queue1IsDone).toEventually(beTrue())


### PR DESCRIPTION
# Description
Changing AtomicGetSet to class and using concurrent queue fixes intermittent crashes that were happening.
Here's the stacktrace for crash in AtomicWrapper.swift line 20:
```
* thread #20, queue = 'IAM.AtomicProperty489)', stop reason = EXC_BAD_ACCESS (code=1, address=0x3be9ea32eab0)
    frame #0: 0x000000010924f2bd libswiftCore.dylib`_swift_release_dealloc + 13
    frame #1: 0x0000000108c0a0bd RInAppMessaging`partial apply for specialized closure #1 in AtomicGetSet.wrappedValue.setter [inlined] generic not re-abstracted specialization <Swift.Dictionary<Swift.String, RInAppMessaging.UserDataCacheContainer>> of closure #1 () -> () in RInAppMessaging.AtomicGetSet.wrappedValue.setter : τ_0_0 at <compiler-generated>:0 [opt]
    frame #2: 0x0000000108c0a09e RInAppMessaging`partial apply for specialized closure #1 in AtomicGetSet.wrappedValue.setter at <compiler-generated>:0 [opt]
    frame #3: 0x0000000108be5dcc RInAppMessaging`thunk for @callee_guaranteed () -> () at <compiler-generated>:0 [opt]
    frame #4: 0x0000000108be5dee RInAppMessaging`thunk for @escaping @callee_guaranteed () -> () at <compiler-generated>:0 [opt]
    frame #5: 0x00007fff201078df libdispatch.dylib`_dispatch_client_callout + 8
    frame #6: 0x00007fff201155e1 libdispatch.dylib`_dispatch_lane_barrier_sync_invoke_and_complete + 94
  * frame #7: 0x0000000108c08e97 RInAppMessaging`specialized AtomicGetSet.wrappedValue.setter(newValue=<unavailable>, self=<unavailable>) at AtomicWrapper.swift:20:19 [opt]
    frame #8: 0x0000000108c62caf RInAppMessaging`UserDataCache.cacheCampaignData(data=0 values, userIdentifiers=<unavailable>, self=0x0000600000786980) at UserDataCache.swift:55:36 [opt]
    frame #9: 0x0000000109e97d94 Tests`merged closure #1 () -> () in closure #1 () -> () in closure #8 () -> () in closure #2 () -> () in Tests.UserDataCacheSpec.spec() -> () + 212
    frame #10: 0x0000000109e97c7e Tests`thunk for @escaping @callee_guaranteed () -> () at <compiler-generated>:0 [opt]
    frame #11: 0x00007fff2010670d libdispatch.dylib`_dispatch_call_block_and_release + 12
    frame #12: 0x00007fff201078df libdispatch.dylib`_dispatch_client_callout + 8
    frame #13: 0x00007fff2010de15 libdispatch.dylib`_dispatch_lane_serial_drain + 715
    frame #14: 0x00007fff2010e98c libdispatch.dylib`_dispatch_lane_invoke + 400
    frame #15: 0x00007fff20118f81 libdispatch.dylib`_dispatch_workloop_worker_thread + 772
    frame #16: 0x00007fff6034045d libsystem_pthread.dylib`_pthread_wqthread + 314
    frame #17: 0x00007fff6033f42f libsystem_pthread.dylib`start_wqthread + 15
```
 
The fix bases on solutions and suggestions from https://www.donnywals.com/why-your-atomic-property-wrapper-doesnt-work-for-collection-types/

# Checklist
- [X] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [X] I wrote/updated tests for new/changed code
- [X] I removed all sensitive data **before every commit**, including API endpoints and keys
- [X] I ran `fastlane ci` without errors
