### PR TITLE
docs: move internal auth SDK examples SDKCF-4169

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,6 @@ To use the module you must set the following values in your app's `Info.plist`:
 | `InAppMessagingAppSubscriptionID` | your_subscription_key |
 | `InAppMessagingConfigurationURL` | Endpoint for fetching the configuration |
 
-⚠️ Targeted campaigns not showing? When using the staging dashboard and internal RAuthentication/Identity SDK's staging environment, you must specify the corresponding staging values here.
-
 
 ## **Enable and disable the SDK remotely**
 We recommend, as good engineering practice, that you integrate with a remote config service so that you can fetch a feature flag, e.g. `Enable_IAM_SDK`, and use its value to dynamically enable/disable the SDK without making an app release. There are many remote config services on the market, both free and paid.

--- a/README.md
+++ b/README.md
@@ -111,38 +111,16 @@ RInAppMessaging.logEvent(CustomEvent(withName: "any_event_name_here", withCustom
 
 ### **registerPreference()**
 
-A preference is what will allow IAM to identify users for targeting and segmentation. At the moment, IAM will take in any of the following identifiers:
+A preference is what will allow IAM to identify users for targeting and segmentation. At the moment, IAM will take in any of the following identifiers (not all need to be provided):
 
 1.  RakutenID - Any value that is considered by the app as user identifier.
 1.  UserID - The ID when registering a Rakuten account. e.g. an email address
-1.  IDTrackingIdentifier - The value provided by the internal identity SDK as the "tracking identifier" value.
+1.  IDTrackingIdentifier - The value provided by the internal ID SDK as the "tracking identifier" value.
 1.  AccessToken - This is the token provided by the internal RAuthentication SDK as the "accessToken" value
 
 To help IAM identify users, please set a new preference every time a user changes their login state i.e. when they log in or log out.  
 After logout is complete please call  `registerPreference()` with nil parameter.  
-Not all identifiers have to be provided.
-
-#### Using the internal RAuthentication SDK
-To enable user targeting, you must provide an accessToken along with associated userId in `IAMPreferenceBuilder`.
-
-```swift
-let preference = IAMPreferenceBuilder()
-    .setUserId("testaccount@gmail.com")
-    .setAccessToken("27364827346")
-    .build()
-
-RInAppMessaging.registerPreference(preference)
-```
-
-#### Using the internal Identity SDK
-
-```swift
-let preference = IAMPreferenceBuilder()
-    .setIDTrackingIdentifier("998236")
-    .build()
-
-RInAppMessaging.registerPreference(preference)
-```
+Preferences are not persisted so this function needs to be called on every launch.
 
 #### Generic example using RakutenID
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ To use the module you must set the following values in your app's `Info.plist`:
 | `InAppMessagingAppSubscriptionID` | your_subscription_key |
 | `InAppMessagingConfigurationURL` | Endpoint for fetching the configuration |
 
+⚠️ Targeted campaigns not showing? When using the staging dashboard and internal RAuthentication/Identity SDK's staging environment, you must specify the corresponding staging values here.
+
 
 ## **Enable and disable the SDK remotely**
 We recommend, as good engineering practice, that you integrate with a remote config service so that you can fetch a feature flag, e.g. `Enable_IAM_SDK`, and use its value to dynamically enable/disable the SDK without making an app release. There are many remote config services on the market, both free and paid.


### PR DESCRIPTION
# Description

Move internal SDK usage references/examples for `registerPreference` to our internal docs.

## Links

mitigates SDKCF-4061

# Checklist
- [ ] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [ ] I wrote/updated tests for new/changed code
- [ ] I removed all sensitive data **before every commit**, including API endpoints and keys
- [ ] I ran `fastlane ci` without errors
