### PR TITLE
fix: set `triggers` property as optional again (for test campaigns) (SDKCF-4525)

### DIFF
--- a/Sources/RInAppMessaging/CampaignsValidator.swift
+++ b/Sources/RInAppMessaging/CampaignsValidator.swift
@@ -44,8 +44,7 @@ internal struct CampaignsValidator: CampaignsValidatorType {
                     continue
             }
 
-            let campaignTriggers = campaign.data.triggers
-            guard !campaignTriggers.isEmpty else {
+            guard let campaignTriggers = campaign.data.triggers else {
                 Logger.debug("campaign (\(campaign.id)) has no triggers.")
                 continue
             }

--- a/Sources/RInAppMessaging/EventMatcher.swift
+++ b/Sources/RInAppMessaging/EventMatcher.swift
@@ -52,8 +52,7 @@ internal class EventMatcher: EventMatcherType {
         }
 
         campaignRepository.list.forEach { campaign in
-            let campaignTriggers = campaign.data.triggers
-            guard !campaignTriggers.isEmpty else {
+            guard let campaignTriggers = campaign.data.triggers else {
                 Logger.debug("campaign (\(campaign.id)) has no triggers.")
                 return
             }
@@ -74,8 +73,7 @@ internal class EventMatcher: EventMatcherType {
     }
 
     func containsAllMatchedEvents(for campaign: Campaign) -> Bool {
-        let triggers = campaign.data.triggers
-        guard !triggers.isEmpty else {
+        guard let triggers = campaign.data.triggers, !triggers.isEmpty else {
             return false
         }
         let events = matchedEvents.get()[campaign.id, default: []] + persistentEvents

--- a/Sources/RInAppMessaging/Models/Responses/PingResponse.swift
+++ b/Sources/RInAppMessaging/Models/Responses/PingResponse.swift
@@ -78,7 +78,7 @@ internal struct CampaignData: Codable, Hashable {
     let campaignId: String
     let maxImpressions: Int
     let type: CampaignDisplayType
-    let triggers: [Trigger]
+    let triggers: [Trigger]?
     let isTest: Bool
     let messagePayload: MessagePayload
 


### PR DESCRIPTION
# Description
The test campaigns payload doesn't have `triggers` property so, at least for now, `triggers` is made optional again.
Unit tests are still using empty value as a default value.

## Links
SDKCF-4525

# Checklist
- [X] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [ ] I wrote/updated tests for new/changed code
- [X] I removed all sensitive data **before every commit**, including API endpoints and keys
- [X] I ran `fastlane ci` without errors
