### PR TITLE
fix: ensure lowercase name of custom Event, Trigger and Attribute (SDKCF-4550)

### DIFF
--- a/Sources/RInAppMessaging/Events/Event.swift
+++ b/Sources/RInAppMessaging/Events/Event.swift
@@ -9,9 +9,9 @@ import Foundation
         case type, timestamp, name
     }
 
-    var type: EventType
-    var timestamp: Int64
-    var name: String
+    let type: EventType
+    let timestamp: Int64
+    let name: String
 
     var analyticsParameters: [String: Any] {
         return [:]

--- a/Sources/RInAppMessaging/Models/Responses/PingResponse.swift
+++ b/Sources/RInAppMessaging/Models/Responses/PingResponse.swift
@@ -95,13 +95,6 @@ internal struct CampaignData: Codable, Hashable {
     }
 }
 
-internal struct Trigger: Codable, Equatable {
-    let type: CampaignTriggerType
-    let eventType: EventType
-    let eventName: String
-    let attributes: [TriggerAttribute]
-}
-
 internal struct MessagePayload: Codable {
     let title: String
     let messageBody: String?

--- a/Sources/RInAppMessaging/Models/Trigger.swift
+++ b/Sources/RInAppMessaging/Models/Trigger.swift
@@ -1,0 +1,43 @@
+internal struct Trigger: Codable, Equatable {
+    let type: CampaignTriggerType
+    let eventType: EventType
+    let eventName: String
+    let attributes: [TriggerAttribute]
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        type = try container.decode(CampaignTriggerType.self, forKey: CodingKeys.type)
+        eventType = try container.decode(EventType.self, forKey: CodingKeys.eventType)
+        eventName = try container.decode(String.self, forKey: CodingKeys.eventName).lowercased()
+        attributes = try container.decode([TriggerAttribute].self, forKey: CodingKeys.attributes)
+    }
+
+    init(type: CampaignTriggerType, eventType: EventType, eventName: String, attributes: [TriggerAttribute]) {
+        self.type = type
+        self.eventType = eventType
+        self.eventName = eventName.lowercased()
+        self.attributes = attributes
+    }
+}
+
+internal struct TriggerAttribute: Codable, Equatable {
+    let name: String
+    let value: String
+    let type: AttributeType
+    let `operator`: AttributeOperator
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        name = try container.decode(String.self, forKey: CodingKeys.name).lowercased()
+        value = try container.decode(String.self, forKey: CodingKeys.value)
+        type = try container.decode(AttributeType.self, forKey: CodingKeys.type)
+        `operator` = try container.decode(AttributeOperator.self, forKey: CodingKeys.operator)
+    }
+
+    init(name: String, value: String, type: AttributeType, `operator`: AttributeOperator) {
+        self.name = name.lowercased()
+        self.value = value
+        self.type = type
+        self.operator = `operator`
+    }
+}

--- a/Sources/RInAppMessaging/Models/TriggerAttribute.swift
+++ b/Sources/RInAppMessaging/Models/TriggerAttribute.swift
@@ -1,6 +1,0 @@
-internal struct TriggerAttribute: Codable, Equatable {
-    let name: String
-    let value: String
-    let type: AttributeType
-    let `operator`: AttributeOperator
-}

--- a/Tests/Tests/CommonUtilitySpec.swift
+++ b/Tests/Tests/CommonUtilitySpec.swift
@@ -146,6 +146,13 @@ class CommonUtilitySpec: QuickSpec {
                         expect(result?.type).to(equal(.string))
                         expect(result?.value as? String).to(equal(""))
                     }
+
+                    it("will return lowercaed name") {
+                        let attribute = TriggerAttribute(name: "ATT", value: "5",
+                                                         type: .string, operator: .invalid)
+                        let result = CommonUtility.convertAttributeObjectToCustomAttribute(attribute)
+                        expect(result?.name) == "att"
+                    }
                 }
 
                 context("when given attribute is integer type") {
@@ -177,6 +184,13 @@ class CommonUtilitySpec: QuickSpec {
                                                          type: .integer, operator: .invalid)
                         let result = CommonUtility.convertAttributeObjectToCustomAttribute(attribute)
                         expect(result).to(beNil())
+                    }
+
+                    it("will return lowercaed name") {
+                        let attribute = TriggerAttribute(name: "ATT", value: "1",
+                                                         type: .integer, operator: .invalid)
+                        let result = CommonUtility.convertAttributeObjectToCustomAttribute(attribute)
+                        expect(result?.name) == "att"
                     }
                 }
 
@@ -214,6 +228,13 @@ class CommonUtilitySpec: QuickSpec {
                             let result = CommonUtility.convertAttributeObjectToCustomAttribute(attribute)
                             expect(result?.type).to(equal(.boolean))
                             expect(result?.value as? Bool).to(equal(false))
+                        }
+
+                        it("will return lowercaed name") {
+                            let attribute = TriggerAttribute(name: "ATT", value: "0",
+                                                             type: .boolean, operator: .invalid)
+                            let result = CommonUtility.convertAttributeObjectToCustomAttribute(attribute)
+                            expect(result?.name) == "att"
                         }
                     }
 
@@ -257,6 +278,13 @@ class CommonUtilitySpec: QuickSpec {
                             let result = CommonUtility.convertAttributeObjectToCustomAttribute(attribute)
                             expect(result?.type).to(equal(.double))
                             expect(result?.value as? Double).to(equal(-5.0))
+                        }
+
+                        it("will return lowercaed name") {
+                            let attribute = TriggerAttribute(name: "ATT", value: "1.2",
+                                                             type: .double, operator: .invalid)
+                            let result = CommonUtility.convertAttributeObjectToCustomAttribute(attribute)
+                            expect(result?.name) == "att"
                         }
                     }
 
@@ -304,6 +332,13 @@ class CommonUtilitySpec: QuickSpec {
                                                          type: .timeInMilliseconds, operator: .invalid)
                         let result = CommonUtility.convertAttributeObjectToCustomAttribute(attribute)
                         expect(result).to(beNil())
+                    }
+
+                    it("will return lowercaed name") {
+                        let attribute = TriggerAttribute(name: "ATT", value: "12",
+                                                         type: .timeInMilliseconds, operator: .invalid)
+                        let result = CommonUtility.convertAttributeObjectToCustomAttribute(attribute)
+                        expect(result?.name) == "att"
                     }
                 }
             }

--- a/Tests/Tests/CommonUtilitySpec.swift
+++ b/Tests/Tests/CommonUtilitySpec.swift
@@ -147,7 +147,7 @@ class CommonUtilitySpec: QuickSpec {
                         expect(result?.value as? String).to(equal(""))
                     }
 
-                    it("will return lowercaed name") {
+                    it("will return lowercased name") {
                         let attribute = TriggerAttribute(name: "ATT", value: "5",
                                                          type: .string, operator: .invalid)
                         let result = CommonUtility.convertAttributeObjectToCustomAttribute(attribute)
@@ -186,7 +186,7 @@ class CommonUtilitySpec: QuickSpec {
                         expect(result).to(beNil())
                     }
 
-                    it("will return lowercaed name") {
+                    it("will return lowercased name") {
                         let attribute = TriggerAttribute(name: "ATT", value: "1",
                                                          type: .integer, operator: .invalid)
                         let result = CommonUtility.convertAttributeObjectToCustomAttribute(attribute)
@@ -230,7 +230,7 @@ class CommonUtilitySpec: QuickSpec {
                             expect(result?.value as? Bool).to(equal(false))
                         }
 
-                        it("will return lowercaed name") {
+                        it("will return lowercased name") {
                             let attribute = TriggerAttribute(name: "ATT", value: "0",
                                                              type: .boolean, operator: .invalid)
                             let result = CommonUtility.convertAttributeObjectToCustomAttribute(attribute)
@@ -280,7 +280,7 @@ class CommonUtilitySpec: QuickSpec {
                             expect(result?.value as? Double).to(equal(-5.0))
                         }
 
-                        it("will return lowercaed name") {
+                        it("will return lowercased name") {
                             let attribute = TriggerAttribute(name: "ATT", value: "1.2",
                                                              type: .double, operator: .invalid)
                             let result = CommonUtility.convertAttributeObjectToCustomAttribute(attribute)
@@ -334,7 +334,7 @@ class CommonUtilitySpec: QuickSpec {
                         expect(result).to(beNil())
                     }
 
-                    it("will return lowercaed name") {
+                    it("will return lowercased name") {
                         let attribute = TriggerAttribute(name: "ATT", value: "12",
                                                          type: .timeInMilliseconds, operator: .invalid)
                         let result = CommonUtility.convertAttributeObjectToCustomAttribute(attribute)

--- a/Tests/Tests/CustomAttributeSpec.swift
+++ b/Tests/Tests/CustomAttributeSpec.swift
@@ -7,6 +7,41 @@ class CustomAttributeSpec: QuickSpec {
     override func spec() {
 
         describe("CustomAttribute") {
+            context("when accessing name") {
+
+                it("should return lowercased string for bool type") {
+                    let att = CustomAttribute(withKeyName: "TeSt4", withBoolValue: false)
+                    expect(att.name) == "test4"
+                }
+
+                it("should return lowercased string for int type") {
+                    let att = CustomAttribute(withKeyName: "TeSt4", withIntValue: 5)
+                    expect(att.name) == "test4"
+                }
+
+                it("should return lowercased string for double type") {
+                    let att = CustomAttribute(withKeyName: "TeSt4", withDoubleValue: 2.1)
+                    expect(att.name) == "test4"
+                }
+
+                it("should return lowercased string for time type") {
+                    let att = CustomAttribute(withKeyName: "TeSt4", withTimeInMilliValue: 100)
+                    expect(att.name) == "test4"
+                }
+
+                it("should return lowercased string for string type") {
+                    let att = CustomAttribute(withKeyName: "TeSt4", withStringValue: "AAA")
+                    expect(att.name) == "test4"
+                }
+            }
+
+            context("when accessing value") {
+
+                it("shouldn't modify string value (not lowercased)") {
+                    let att = CustomAttribute(withKeyName: "test", withStringValue: "TeSt4")
+                    expect(att.value as? String) == "TeSt4"
+                }
+            }
 
             context("when comparing objects") {
 

--- a/Tests/Tests/CustomEventSpec.swift
+++ b/Tests/Tests/CustomEventSpec.swift
@@ -24,6 +24,16 @@ class CustomEventsSpec: QuickSpec {
             validatorHandler = ValidatorHandler()
         }
 
+        describe("CustomEvent") {
+            context("when accessing name") {
+
+                it("should return lowercased string") {
+                    let event = CustomEvent(withName: "TeSt4", withCustomAttributes: nil)
+                    expect(event.name) == "test4"
+                }
+            }
+        }
+
         describe("CampaignsValidator") {
             it("should accept a campaign that is matched using an custom event with a STRING type and equals operator") {
                 let mockResponse = TestHelpers.MockResponse.stringTypeWithEqualsOperator

--- a/Tests/Tests/SerializationSpec.swift
+++ b/Tests/Tests/SerializationSpec.swift
@@ -1,6 +1,6 @@
+import Foundation
 import Quick
 import Nimble
-import class Foundation.JSONEncoder
 @testable import RInAppMessaging
 
 class SerializationSpec: QuickSpec {
@@ -55,6 +55,41 @@ class SerializationSpec: QuickSpec {
                 it("will properly read context even if there are invalid ones") {
                     let campaign = TestHelpers.generateCampaign(id: "id", title: "ctxbad] title [ctx]")
                     expect(campaign.contexts).to(elementsEqual(["ctx"]))
+                }
+            }
+        }
+
+        describe("Triggers") {
+
+            context("when parsing custom triggers with attributes") {
+
+                let json = #"""
+                {
+                    "type": 1,
+                    "eventType": 4,
+                    "eventName": "Custom EVENT",
+                    "attributes": [
+                        {
+                            "name": "aName1",
+                            "value": "VaLUe4",
+                            "type": 1,
+                            "operator": 1
+                        }
+                    ]
+                }
+                """#
+                let trigger: Trigger! = try? JSONDecoder().decode(Trigger.self, from: json.data(using: .utf8)!)
+
+                it("should have lowercased trigger name") {
+                    expect(trigger.eventName) == "custom event"
+                }
+
+                it("should have lowercased attribute name") {
+                    expect(trigger.attributes[0].name) == "aname1"
+                }
+
+                it("shouldn't have lowercased trigger value") {
+                    expect(trigger.attributes[0].value) == "VaLUe4"
                 }
             }
         }


### PR DESCRIPTION
# Description
Ensure lowercase name of custom Event, Trigger and Attribute.

## Links
SDKCF-4550

# Checklist
- [X] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [X] I wrote/updated tests for new/changed code
- [X] I removed all sensitive data **before every commit**, including API endpoints and keys
- [X] I ran `fastlane ci` without errors
