### PR TITLE
fix: ensure lowercase string value of Custom Attribute (SDKCF-4550)

### DIFF
--- a/Sources/RInAppMessaging/Models/CustomAttribute.swift
+++ b/Sources/RInAppMessaging/Models/CustomAttribute.swift
@@ -17,7 +17,7 @@ public class CustomAttribute: NSObject {
     @objc
     public init(withKeyName name: String, withStringValue value: String) {
         self.name = name.lowercased()
-        self.value = value
+        self.value = value.lowercased()
         self.type = .string
     }
 

--- a/Sources/RInAppMessaging/Models/Trigger.swift
+++ b/Sources/RInAppMessaging/Models/Trigger.swift
@@ -29,14 +29,14 @@ internal struct TriggerAttribute: Codable, Equatable {
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         name = try container.decode(String.self, forKey: CodingKeys.name).lowercased()
-        value = try container.decode(String.self, forKey: CodingKeys.value)
+        value = try container.decode(String.self, forKey: CodingKeys.value).lowercased()
         type = try container.decode(AttributeType.self, forKey: CodingKeys.type)
         `operator` = try container.decode(AttributeOperator.self, forKey: CodingKeys.operator)
     }
 
     init(name: String, value: String, type: AttributeType, `operator`: AttributeOperator) {
         self.name = name.lowercased()
-        self.value = value
+        self.value = value.lowercased()
         self.type = type
         self.operator = `operator`
     }

--- a/Tests/Tests/CustomAttributeSpec.swift
+++ b/Tests/Tests/CustomAttributeSpec.swift
@@ -37,9 +37,9 @@ class CustomAttributeSpec: QuickSpec {
 
             context("when accessing value") {
 
-                it("shouldn't modify string value (not lowercased)") {
+                it("should return lowercased string value") {
                     let att = CustomAttribute(withKeyName: "test", withStringValue: "TeSt4")
-                    expect(att.value as? String) == "TeSt4"
+                    expect(att.value as? String) == "test4"
                 }
             }
 

--- a/Tests/Tests/CustomEventSpec.swift
+++ b/Tests/Tests/CustomEventSpec.swift
@@ -482,8 +482,8 @@ class CustomEventsSpec: QuickSpec {
                 expect(validatorHandler.validatedElements).to(haveCount(1))
             }
 
-            it("should not have a campaign because of case-sensitive attribute value mismatch") {
-                let mockResponse = TestHelpers.MockResponse.caseSensitiveAttributeValue
+            it("should accept a campaign that is matched even with a case-insensitive attribute value") {
+                let mockResponse = TestHelpers.MockResponse.caseInsensitiveAttributeValue
                 campaignRepository.syncWith(list: mockResponse.data, timestampMilliseconds: 0)
 
                 let customEvent = CustomEvent(
@@ -495,7 +495,7 @@ class CustomEventsSpec: QuickSpec {
 
                 eventMatcher.matchAndStore(event: customEvent)
                 campaignsValidator.validate(validatedCampaignHandler: validatorHandler.closure)
-                expect(validatorHandler.validatedElements).to(beEmpty())
+                expect(validatorHandler.validatedElements).to(haveCount(1))
             }
         }
     }

--- a/Tests/Tests/Helpers/TestHelpers.swift
+++ b/Tests/Tests/Helpers/TestHelpers.swift
@@ -422,7 +422,7 @@ struct TestHelpers {
                                             )])
         }()
 
-        static let caseSensitiveAttributeValue: PingResponse = {
+        static let caseInsensitiveAttributeValue: PingResponse = {
             return withGeneratedCampaigns(count: 1,
                                           test: false,
                                           delay: 0,

--- a/Tests/Tests/SerializationSpec.swift
+++ b/Tests/Tests/SerializationSpec.swift
@@ -88,8 +88,8 @@ class SerializationSpec: QuickSpec {
                     expect(trigger.attributes[0].name) == "aname1"
                 }
 
-                it("shouldn't have lowercased trigger value") {
-                    expect(trigger.attributes[0].value) == "VaLUe4"
+                it("should have lowercased trigger value") {
+                    expect(trigger.attributes[0].value) == "value4"
                 }
             }
         }


### PR DESCRIPTION
# Description
It turns out that Attribute values should be lowercased as well.

## Links
SDKCF-4550

# Checklist
- [X] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [X] I wrote/updated tests for new/changed code
- [X] I removed all sensitive data **before every commit**, including API endpoints and keys
- [ ] I ran `fastlane ci` without errors
