### PR TITLE
fix: fix UI test issues on iPhone 12 mini and other devices

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -7,7 +7,7 @@ PODS:
   - GRMustache.swift (4.0.1)
   - Nimble (9.2.1)
   - Quick (4.0.0)
-  - RInAppMessaging (5.0.0):
+  - RInAppMessaging (6.1.0-snapshot):
     - RSDKUtils (~> 2.1)
   - RSDKUtils (2.1.0):
     - RSDKUtils/Main (= 2.1.0)
@@ -76,7 +76,7 @@ SPEC CHECKSUMS:
   GRMustache.swift: a6436504284b22b4b05daf5f46f77bd3fe00a9a2
   Nimble: e7e615c0335ee4bf5b0d786685451e62746117d5
   Quick: 6473349e43b9271a8d43839d9ba1c442ed1b7ac4
-  RInAppMessaging: 2a83698ad3c388e9029a1bb9078e6ce9d0cbf336
+  RInAppMessaging: 13e9faf1971a5b3b6435468e7c7c6199bf85320e
   RSDKUtils: 47d28aac1347d712e6d4db9a1332cae41b17738f
   Shock: 94c2d3f5f781fe63317c4ee1621dfb2d4cc271d3
   SwiftLint: e5c7f1fba68eccfc51509d5b2ce1699f5502e0c7

--- a/Tests/UITests/FullScreenViewSpec.swift
+++ b/Tests/UITests/FullScreenViewSpec.swift
@@ -53,13 +53,15 @@ class FullScreenViewSpec: QuickSpec {
                 }
 
                 it("should close the campaign") {
+                    expect(iamView.buttons["exitButton"].exists).to(beTrue())
                     iamView.buttons["exitButton"].tap()
                     expect(iamView.exists).to(beFalse())
                 }
 
                 it("should have 44pt touch area") {
                     let exitButtonCenter = iamView.buttons["exitButton"].coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5))
-                    let upperLeftCorner = exitButtonCenter.withOffset(CGVector(dx: -22, dy: -22))
+                    let upperLeftCorner = exitButtonCenter.withOffset(
+                        CGVector(dx: -21.5, dy: -21.5)) // reduced by .5 for cases when exit button has x.5 x/y position
                     upperLeftCorner.tap()
                     expect(iamView.exists).to(beFalse())
 

--- a/Tests/UITests/ModalViewSpec.swift
+++ b/Tests/UITests/ModalViewSpec.swift
@@ -53,13 +53,15 @@ class ModalViewSpec: QuickSpec {
                 }
 
                 it("should close the campaign") {
+                    expect(iamView.buttons["exitButton"].exists).to(beTrue())
                     iamView.buttons["exitButton"].tap()
                     expect(iamView.exists).to(beFalse())
                 }
 
                 it("should have 44pt touch area") {
                     let exitButtonCenter = iamView.buttons["exitButton"].coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5))
-                    let upperLeftCorner = exitButtonCenter.withOffset(CGVector(dx: -22, dy: -22))
+                    let upperLeftCorner = exitButtonCenter.withOffset(
+                        CGVector(dx: -21.5, dy: -21.5)) // reduced by .5 for cases when exit button has x.5 x/y position
                     upperLeftCorner.tap()
                     expect(iamView.exists).to(beFalse())
 

--- a/Tests/UITests/SlideUpViewSpec.swift
+++ b/Tests/UITests/SlideUpViewSpec.swift
@@ -12,6 +12,9 @@ class SlideUpViewSpec: QuickSpec {
         var iamView: XCUIElement {
             app.otherElements["IAMView-SlideUp"]
         }
+        var content: XCUIElement {
+            iamView.buttons["bodyMessage"]
+        }
 
         func launchAppIfNecessary(context: String) {
             mockServer.setup(route: MockServerHelper.pingRouteMock(jsonStub: context))
@@ -48,13 +51,15 @@ class SlideUpViewSpec: QuickSpec {
                 }
 
                 it("should close the campaign") {
+                    expect(iamView.buttons["exitButton"].exists).to(beTrue())
                     iamView.buttons["exitButton"].tap()
                     expect(iamView.exists).to(beFalse())
                 }
 
                 it("should have 44pt touch area") {
                     let exitButtonCenter = iamView.buttons["exitButton"].coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5))
-                    let upperLeftCorner = exitButtonCenter.withOffset(CGVector(dx: -22, dy: -22))
+                    let upperLeftCorner = exitButtonCenter.withOffset(
+                        CGVector(dx: -21.5, dy: -21.5)) // reduced by .5 for cases when exit button has x.5 x/y position
                     upperLeftCorner.tap()
                     expect(iamView.exists).to(beFalse())
 
@@ -77,7 +82,7 @@ class SlideUpViewSpec: QuickSpec {
                 }
 
                 it("should close campaign after tapping the content") {
-                    iamView.tap()
+                    content.tap()
                     expect(iamView.exists).to(beFalse())
                 }
             }
@@ -93,12 +98,12 @@ class SlideUpViewSpec: QuickSpec {
                 }
 
                 it("should close campaign after tapping the content") {
-                    iamView.tap()
+                    content.tap()
                     expect(iamView.exists).to(beFalse())
                 }
 
                 it("should trigger another campaign after tapping the content") {
-                    iamView.tap()
+                    content.tap()
                     expect(iamView.exists).to(beFalse())
                     expect(iamView.exists).toEventually(beTrue(), timeout: .seconds(2))
                 }

--- a/fastlane/.env
+++ b/fastlane/.env
@@ -2,4 +2,4 @@ REM_FL_TESTS_SCHEME=RInAppMessaging-Example
 REM_FL_TESTS_PROJECT=./RInAppMessaging.xcodeproj
 REM_FL_TESTS_WORKSPACE=./RInAppMessaging.xcworkspace
 REM_FL_TESTS_SLATHER_BASENAME=RInAppMessaging
-REM_FL_TESTS_DEVICE=iPhone 8
+REM_FL_TESTS_DEVICE=iPhone 11


### PR DESCRIPTION
# Description
Fixes failing UI tests on iPhone 12 mini.
* Issue with exit button - manual tap on the edge didn't work when exit button coordinates were not integers
* Issue with Slide-up  content tap - content tap is considered only when body label is tapped, not background.

# Checklist
- [X] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [X] I wrote/updated tests for new/changed code
- [X] I removed all sensitive data **before every commit**, including API endpoints and keys
- [X] I ran `fastlane ci` without errors
