### PR TITLE
ci: integrate with Sonarqube (SDKCF-4693)

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -146,7 +146,8 @@ workflows:
         inputs:
         - scanner_properties: |-
             sonar.sources=Sources
-            sonar.projectKey=$BITRISE_APP_TITLE
+            sonar.projectKey=ios-inappmessaging
+            sonar.projectName=iOS In-App Messaging SDK
             sonar.host.url=$SONAR_HOST_URL
             sonar.login=$SONAR_API_TOKEN
             sonar.c.file.suffixes=-

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -14,6 +14,7 @@ workflows:
   primary:
     before_run:
     - _setup
+    - _sonarqube
     after_run:
     - _report
     steps:
@@ -126,6 +127,31 @@ workflows:
     - cocoapods-install@1:
         inputs:
         - verbose: 'false'
+
+  _sonarqube:
+    steps:
+    - script@1:
+        title: Setup env vars
+        inputs:
+        - content: |
+            #!/usr/bin/env bash
+
+            if [[ $BITRISE_GIT_BRANCH == release* ]]; then
+                envman add --key IS_RELEASE_BRANCH --value "true"
+            else
+                envman add --key IS_RELEASE_BRANCH --value "false"
+            fi
+    - sonarqube-scanner@1:
+        run_if: '{{getenv "SONAR_API_TOKEN" | ne "" | and (enveq "BITRISE_GIT_BRANCH" "master" | or (enveq "IS_RELEASE_BRANCH" "true") )}}'
+        inputs:
+        - scanner_properties: |-
+            sonar.sources=Sources
+            sonar.projectKey=$BITRISE_APP_TITLE
+            sonar.host.url=$SONAR_HOST_URL
+            sonar.login=$SONAR_API_TOKEN
+            sonar.c.file.suffixes=-
+            sonar.cpp.file.suffixes=-
+            sonar.objc.file.suffixes=-
 
   _report:
     steps:


### PR DESCRIPTION
# Description
For security reasons, SonarQube will run only on `master` and `release*` branches.

Here's a build showing that sonarqube step is skipped on this branch (manual build)
https://app.bitrise.io/build/e8569edd-c0ba-493a-8688-4821d5211b5d#?tab=log

Here's a build showing that sonarqube step is skipped on this PR (auto build)
https://app.bitrise.io/build/ddb60f0b-3997-4b03-a239-5cadb9ae900c#?tab=log

Here's a build showing that sonarqube step runs on release/test-sonar branch (manual build)
https://app.bitrise.io/build/0192cde2-410a-4716-8053-aac66a3fefac#?tab=log

## Links
SDKCF-4693

# Checklist
- [X] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [ ] I wrote/updated tests for new/changed code
- [X] I removed all sensitive data **before every commit**, including API endpoints and keys
- [ ] I ran `fastlane ci` without errors
