### PR TITLE
fix: treat all responses with http status codes 300+ as errors (SDKCF-4637)

### DIFF
--- a/Sources/RInAppMessaging/Protocols/HttpRequestable.swift
+++ b/Sources/RInAppMessaging/Protocols/HttpRequestable.swift
@@ -147,7 +147,8 @@ extension HttpRequestable {
 
             let statusCode = (response as? HTTPURLResponse)?.statusCode ?? 0
 
-            guard let dataToReturn = data,
+            guard 100..<300 ~= statusCode,
+                  let dataToReturn = data,
                   let serverResponse = response as? HTTPURLResponse else {
 
                 completion(.failure(.httpError(UInt(statusCode), response, data)))


### PR DESCRIPTION
# Description
This PR actually restores previous behaviour (and unit tests) that was mistakenly deleted.

## Links
SDKCF-4637

# Checklist
- [X] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [X] I wrote/updated tests for new/changed code
- [X] I removed all sensitive data **before every commit**, including API endpoints and keys
- [X] I ran `fastlane ci` without errors
