### PR TITLE
fix: fix request retry conut issue, improve delay testing (SDKCF-4637)

### DIFF
--- a/Sources/RInAppMessaging/Constants.swift
+++ b/Sources/RInAppMessaging/Constants.swift
@@ -50,14 +50,27 @@ internal enum Constants {
     }
 
     enum Retry {
+        static let retryCount = 3
+
         enum Default {
-            static let initialRetryDelayMS = Int32(10000)
+            static fileprivate(set) var initialRetryDelayMS = Int32(10000)
         }
 
-        enum TooManyRequestsError {
-            static let initialRetryDelayMS = Int32(60000)
-            static let backOffLowerBoundInSecond = Int32(1) // second
-            static let backOffUpperBoundInSecond = Int32(60) // second
+        enum Randomized {
+            static fileprivate(set) var initialRetryDelayMS = Int32(60000)
+            static fileprivate(set) var backOffLowerBoundSeconds = Int32(1)
+            static fileprivate(set) var backOffUpperBoundSeconds = Int32(60)
+        }
+
+        enum Tests {
+            static func setInitialDelayMS(_ delay: Int32) {
+                Default.initialRetryDelayMS = delay
+                Randomized.initialRetryDelayMS = delay
+            }
+
+            static func setBackOffUpperBoundSeconds(_ bound: Int32) {
+                Randomized.backOffUpperBoundSeconds = bound
+            }
         }
     }
 }

--- a/Sources/RInAppMessaging/Extensions/Int32+IAM.swift
+++ b/Sources/RInAppMessaging/Extensions/Int32+IAM.swift
@@ -11,8 +11,8 @@ extension Int32 {
     /// - Parameters:
     ///     - min: the minimum value in second.
     ///     - max: the maximum value in second.
-    mutating func increaseRandomizedBackoff(min: Int32 = Constants.Retry.TooManyRequestsError.backOffLowerBoundInSecond,
-                                            max: Int32 = Constants.Retry.TooManyRequestsError.backOffUpperBoundInSecond) {
+    mutating func increaseRandomizedBackoff(min: Int32 = Constants.Retry.Randomized.backOffLowerBoundSeconds,
+                                            max: Int32 = Constants.Retry.Randomized.backOffUpperBoundSeconds) {
         increaseBackOff()
         self += Int32.random(in: min...max)*1000
     }

--- a/Sources/RInAppMessaging/Protocols/TaskSchedulable.swift
+++ b/Sources/RInAppMessaging/Protocols/TaskSchedulable.swift
@@ -27,9 +27,13 @@ extension TaskSchedulable {
     func scheduleTask(milliseconds: Int, wallDeadline: Bool, _ task: @escaping () -> Void) {
         DispatchQueue.main.async {
             self.scheduledTask?.cancel()
-            self.scheduledTask = WorkScheduler.scheduleTask(milliseconds: milliseconds,
-                                                            closure: task,
-                                                            wallDeadline: wallDeadline)
+            self.scheduledTask = WorkScheduler.scheduleTask(
+                milliseconds: milliseconds,
+                closure: { [weak self] in
+                    task()
+                    self?.scheduledTask = nil
+                },
+                wallDeadline: wallDeadline)
         }
     }
 }

--- a/Sources/RInAppMessaging/Services/ImpressionService.swift
+++ b/Sources/RInAppMessaging/Services/ImpressionService.swift
@@ -26,7 +26,8 @@ internal class ImpressionService: ImpressionServiceType, HttpRequestable, TaskSc
     private let accountRepository: AccountRepositoryType
     private let configurationRepository: ConfigurationRepositoryType
     private var responseStateMachine = ResponseStateMachine()
-    private var retryDelayMS = Constants.Retry.Default.initialRetryDelayMS
+    // lazy allows mocking in unit tests
+    private lazy var retryDelayMS = Constants.Retry.Default.initialRetryDelayMS
 
     weak var errorDelegate: ErrorDelegate?
     private(set) var httpSession: URLSession
@@ -88,7 +89,7 @@ internal class ImpressionService: ImpressionServiceType, HttpRequestable, TaskSc
 
                     switch error {
                     case .httpError(let statusCode, _, _) where statusCode >= 500:
-                        guard self.responseStateMachine.consecutiveErrorCount < 3 else {
+                        guard self.responseStateMachine.consecutiveErrorCount <= Constants.Retry.retryCount else {
                             return
                         }
                         self.retryImpressionRequest(endpoint: endpoint, parameters: parameters)

--- a/Tests/Tests/BackoffSpec.swift
+++ b/Tests/Tests/BackoffSpec.swift
@@ -20,8 +20,8 @@ class BackoffSpec: QuickSpec {
                 retryMS.increaseRandomizedBackoff()
 
                 let expectedResult = initialValue.multipliedReportingOverflow(by: 2).partialValue
-                expect(retryMS >= expectedResult + (Constants.Retry.TooManyRequestsError.backOffLowerBoundInSecond * 1000)).to(beTrue())
-                expect(retryMS <= expectedResult + (Constants.Retry.TooManyRequestsError.backOffUpperBoundInSecond * 1000)).to(beTrue())
+                expect(retryMS >= expectedResult + (Constants.Retry.Randomized.backOffLowerBoundSeconds * 1000)).to(beTrue())
+                expect(retryMS <= expectedResult + (Constants.Retry.Randomized.backOffUpperBoundSeconds * 1000)).to(beTrue())
             }
         }
     }

--- a/Tests/Tests/Helpers/SharedMocks.swift
+++ b/Tests/Tests/Helpers/SharedMocks.swift
@@ -138,9 +138,12 @@ class MessageMixerServiceMock: MessageMixerServiceType {
     var mockedResponse: PingResponse?
     var mockedError = MessageMixerServiceError.invalidConfiguration
     var delay: TimeInterval = 0
+    var pingCallCount = 0
 
     func ping() -> Result<PingResponse, MessageMixerServiceError> {
-        self.wasPingCalled = true
+        wasPingCalled = true
+        pingCallCount += 1
+
         if delay > 0 {
             guard Thread.current != .main else {
                 fatalError("Delay function shoudn't be used on the main thread")


### PR DESCRIPTION
# Description
Request retry counting didn't count the initial error so there was always one retry call missing.
I improved tests by adding an option to mock initial delay to significantly reduce time of some test cases.

## Links
SDKCF-4637

# Checklist
- [X] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [X] I wrote/updated tests for new/changed code
- [X] I removed all sensitive data **before every commit**, including API endpoints and keys
- [X] I ran `fastlane ci` without errors
