### PR TITLE
improve: add error handling for display permission request (SDKCF-4728)

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -22,7 +22,7 @@ PODS:
   - Shock (6.0.3):
     - GRMustache.swift (~> 4.0.1)
     - SwiftNIOHTTP1 (~> 2.22.1)
-  - SwiftLint (0.45.0)
+  - SwiftLint (0.45.1)
   - SwiftNIO (2.22.1):
     - CNIOAtomics (= 2.22.1)
     - CNIODarwin (= 2.22.1)
@@ -79,7 +79,7 @@ SPEC CHECKSUMS:
   RInAppMessaging: 13e9faf1971a5b3b6435468e7c7c6199bf85320e
   RSDKUtils: 47d28aac1347d712e6d4db9a1332cae41b17738f
   Shock: 94c2d3f5f781fe63317c4ee1621dfb2d4cc271d3
-  SwiftLint: e5c7f1fba68eccfc51509d5b2ce1699f5502e0c7
+  SwiftLint: 06ac37e4d38c7068e0935bb30cda95f093bec761
   SwiftNIO: 763188229de166e046cc8975383cca388832e992
   SwiftNIOConcurrencyHelpers: 34d2e9d4d2b7886fa765086e845e6b19417be927
   SwiftNIOHTTP1: c0a9ce48ba256f349af4f09648a0e0939b11a65c

--- a/Sources/RInAppMessaging/CampaignDispatcher.swift
+++ b/Sources/RInAppMessaging/CampaignDispatcher.swift
@@ -5,7 +5,7 @@ internal protocol CampaignDispatcherDelegate: AnyObject {
     func shouldShowCampaignMessage(title: String, contexts: [String]) -> Bool
 }
 
-internal protocol CampaignDispatcherType {
+internal protocol CampaignDispatcherType: AnyObject {
     var delegate: CampaignDispatcherDelegate? { get set }
 
     func addToQueue(campaignID: String)

--- a/Sources/RInAppMessaging/ConfigurationManager.swift
+++ b/Sources/RInAppMessaging/ConfigurationManager.swift
@@ -5,7 +5,7 @@ import RSDKUtilsMain // SPM version
 import RSDKUtils
 #endif
 
-internal protocol ConfigurationManagerType: AnyObject, ErrorReportable {
+internal protocol ConfigurationManagerType: ErrorReportable {
     func fetchAndSaveConfigData(completion: @escaping (ConfigData) -> Void)
 }
 

--- a/Sources/RInAppMessaging/InAppMessagingModule.swift
+++ b/Sources/RInAppMessaging/InAppMessagingModule.swift
@@ -8,12 +8,12 @@ import class RSDKUtilsMain.AnalyticsBroadcaster
 /// Class represents bootstrap behaviour and main functionality of InAppMessaging.
 internal class InAppMessagingModule: ErrorDelegate, CampaignDispatcherDelegate, UserChangeObserver {
 
-    private var configurationManager: ConfigurationManagerType
-    private var campaignsListManager: CampaignsListManagerType
+    private let configurationManager: ConfigurationManagerType
+    private let campaignsListManager: CampaignsListManagerType
     private let accountRepository: AccountRepositoryType
     private let eventMatcher: EventMatcherType
-    private var readyCampaignDispatcher: CampaignDispatcherType
-    private var impressionService: ImpressionServiceType
+    private let readyCampaignDispatcher: CampaignDispatcherType
+    private let impressionService: ImpressionServiceType
     private let campaignTriggerAgent: CampaignTriggerAgentType
     private let campaignRepository: CampaignRepositoryType
     private let router: RouterType
@@ -35,7 +35,8 @@ internal class InAppMessagingModule: ErrorDelegate, CampaignDispatcherDelegate, 
          campaignTriggerAgent: CampaignTriggerAgentType,
          campaignRepository: CampaignRepositoryType,
          router: RouterType,
-         randomizer: RandomizerType) {
+         randomizer: RandomizerType,
+         displayPermissionService: DisplayPermissionServiceType) {
 
         self.configurationManager = configurationManager
         self.campaignsListManager = campaignsListManager
@@ -51,6 +52,7 @@ internal class InAppMessagingModule: ErrorDelegate, CampaignDispatcherDelegate, 
         self.configurationManager.errorDelegate = self
         self.campaignsListManager.errorDelegate = self
         self.impressionService.errorDelegate = self
+        displayPermissionService.errorDelegate = self
         self.readyCampaignDispatcher.delegate = self
         self.accountRepository.registerAccountUpdateObserver(self)
     }

--- a/Sources/RInAppMessaging/Protocols/ErrorReportable.swift
+++ b/Sources/RInAppMessaging/Protocols/ErrorReportable.swift
@@ -4,7 +4,7 @@ internal protocol ErrorDelegate: AnyObject {
     func didReceiveError(sender: ErrorReportable, error: NSError)
 }
 
-internal protocol ErrorReportable {
+internal protocol ErrorReportable: AnyObject {
     var errorDelegate: ErrorDelegate? { get set }
     func reportError(description: String, data: Any?)
 }

--- a/Sources/RInAppMessaging/RInAppMessaging.swift
+++ b/Sources/RInAppMessaging/RInAppMessaging.swift
@@ -83,7 +83,8 @@ import RSDKUtils
                 let campaignTriggerAgent = dependencyManager.resolve(type: CampaignTriggerAgentType.self),
                 let campaignRepository = dependencyManager.resolve(type: CampaignRepositoryType.self),
                 let router = dependencyManager.resolve(type: RouterType.self),
-                let randomizer = dependencyManager.resolve(type: Randomizer.self) else {
+                let randomizer = dependencyManager.resolve(type: Randomizer.self),
+                let displayPermissionService = dependencyManager.resolve(type: DisplayPermissionServiceType.self) else {
 
                     assertionFailure("In-App Messaging SDK module initialization failure: Dependencies could not be resolved")
                     return
@@ -99,7 +100,8 @@ import RSDKUtils
                                                      campaignTriggerAgent: campaignTriggerAgent,
                                                      campaignRepository: campaignRepository,
                                                      router: router,
-                                                     randomizer: randomizer)
+                                                     randomizer: randomizer,
+                                                     displayPermissionService: displayPermissionService)
             initializedModule?.aggregatedErrorHandler = { error in
                 errorDelegate?.inAppMessagingDidReturnError(error)
             }

--- a/Tests/Tests/Helpers/SharedMocks.swift
+++ b/Tests/Tests/Helpers/SharedMocks.swift
@@ -159,8 +159,13 @@ class MessageMixerServiceMock: MessageMixerServiceType {
 }
 
 class DisplayPermissionServiceMock: DisplayPermissionServiceType {
+    var shouldGrantPermission = true
+    var shouldPerformPing = false
+    weak var errorDelegate: ErrorDelegate?
+
     func checkPermission(forCampaign campaign: CampaignData) -> DisplayPermissionResponse {
-        DisplayPermissionResponse(display: true, performPing: false)
+        DisplayPermissionResponse(display: shouldGrantPermission,
+                                  performPing: shouldPerformPing)
     }
 }
 

--- a/Tests/Tests/InAppMessagingModuleSpec.swift
+++ b/Tests/Tests/InAppMessagingModuleSpec.swift
@@ -54,7 +54,8 @@ class InAppMessagingModuleSpec: QuickSpec {
                                                  campaignTriggerAgent: campaignTriggerAgent,
                                                  campaignRepository: campaignRepository,
                                                  router: router,
-                                                 randomizer: randomizer)
+                                                 randomizer: randomizer,
+                                                 displayPermissionService: DisplayPermissionServiceMock())
                 iamModule.delegate = delegate
             }
 

--- a/Tests/Tests/ReadyCampaignDispatcherSpec.swift
+++ b/Tests/Tests/ReadyCampaignDispatcherSpec.swift
@@ -13,14 +13,14 @@ class ReadyCampaignDispatcherSpec: QuickSpec {
     override func spec() {
         describe("CampaignDispatcher") {
             var dispatcher: CampaignDispatcher!
-            var permissionService: PermissionServiceMock!
+            var permissionService: DisplayPermissionServiceMock!
             var campaignRepository: CampaignRepositoryMock!
             var delegate: Delegate!
             var router: RouterMock!
             var httpSession: URLSessionMock!
 
             beforeEach {
-                permissionService = PermissionServiceMock()
+                permissionService = DisplayPermissionServiceMock()
                 campaignRepository = CampaignRepositoryMock()
                 router = RouterMock()
                 delegate = Delegate()
@@ -394,16 +394,6 @@ class ReadyCampaignDispatcherSpec: QuickSpec {
                 }
             }
         }
-    }
-}
-
-private class PermissionServiceMock: DisplayPermissionServiceType {
-    var shouldGrantPermission = false
-    var shouldPerformPing = false
-
-    func checkPermission(forCampaign campaign: CampaignData) -> DisplayPermissionResponse {
-        return DisplayPermissionResponse(display: shouldGrantPermission,
-                                         performPing: shouldPerformPing)
     }
 }
 


### PR DESCRIPTION
# Description
Added error handling for display permission requests with following rules:
* In case of connection error or HTTP status 5xx, retry the request ONCE without any delay.
* In case of other errors, or if retry didn't succeed, report an error (using error delegate).
* 'final' errors should still result in campaign not being displayed (without impression count update)

## Links
SDKCF-4728

# Checklist
- [X] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [X] I wrote/updated tests for new/changed code
- [X] I removed all sensitive data **before every commit**, including API endpoints and keys
- [X] I ran `fastlane ci` without errors
