### PR TITLE
ci: fix _sonarqube workflow execution (SDKCF-4730)

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -14,8 +14,8 @@ workflows:
   primary:
     before_run:
     - _setup
-    - _sonarqube
     after_run:
+    - _sonarqube
     - _report
     steps:
     - fastlane@3:


### PR DESCRIPTION
# Description
I forgot to do that in my previous PR.
Sonarqube scanner must be run AFTER build&test process.
(_sonarqube workflow is not executed for PRs)

## Links
SDKCF-4730

# Checklist
- [X] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [ ] I wrote/updated tests for new/changed code
- [X] I removed all sensitive data **before every commit**, including API endpoints and keys
- [ ] I ran `fastlane ci` without errors
