### PR TITLE
fix: fix assertion failure when accessing `Bundle.sdkAssets` in some cases

### DIFF
--- a/RInAppMessaging.xcodeproj/project.pbxproj
+++ b/RInAppMessaging.xcodeproj/project.pbxproj
@@ -59,6 +59,7 @@
 		45ADA542247D206B00A9E2A3 /* RouterSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45ADA541247D206B00A9E2A3 /* RouterSpec.swift */; };
 		45AFB2F6245C18660080D21B /* MatchingUtilitySpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45AFB2F5245C18660080D21B /* MatchingUtilitySpec.swift */; };
 		45AFB308246CFB640080D21B /* LocaleSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45AFB307246CFB640080D21B /* LocaleSpec.swift */; };
+		45B3CC8427871C01005BA3F7 /* BundleSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45B3CC8327871C01005BA3F7 /* BundleSpec.swift */; };
 		45B5723F25ACE90F005A80F7 /* IntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45B5723E25ACE90F005A80F7 /* IntegrationTests.swift */; };
 		45BDFD032421D311004DEA0C /* CampaignsListManagerSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45BDFD022421D311004DEA0C /* CampaignsListManagerSpec.swift */; };
 		45BDFD052421EE7B004DEA0C /* SharedMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45BDFD042421EE7B004DEA0C /* SharedMocks.swift */; };
@@ -162,6 +163,7 @@
 		45ADA541247D206B00A9E2A3 /* RouterSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouterSpec.swift; sourceTree = "<group>"; };
 		45AFB2F5245C18660080D21B /* MatchingUtilitySpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MatchingUtilitySpec.swift; sourceTree = "<group>"; };
 		45AFB307246CFB640080D21B /* LocaleSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocaleSpec.swift; sourceTree = "<group>"; };
+		45B3CC8327871C01005BA3F7 /* BundleSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BundleSpec.swift; sourceTree = "<group>"; };
 		45B5723C25ACE90F005A80F7 /* IntegrationTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = IntegrationTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		45B5723E25ACE90F005A80F7 /* IntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntegrationTests.swift; sourceTree = "<group>"; };
 		45B5724025ACE90F005A80F7 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -368,6 +370,7 @@
 				45B572F625AE2163005A80F7 /* Helpers */,
 				45357AE32457EB49007D8FDC /* Payloads */,
 				C9827557262C423C00476505 /* BackoffSpec.swift */,
+				45B3CC8327871C01005BA3F7 /* BundleSpec.swift */,
 				45563B0624064D78004EAFD3 /* CampaignRepositorySpec.swift */,
 				45BDFD022421D311004DEA0C /* CampaignsListManagerSpec.swift */,
 				D92D1F2122249833008EA748 /* CampaignsValidatorSpec.swift */,
@@ -680,6 +683,7 @@
 				456FE1E72428513200304872 /* ErrorReportableSpec.swift in Sources */,
 				4538BCF6262AE8FA009952BE /* UserDataCacheSpec.swift in Sources */,
 				45BDFD052421EE7B004DEA0C /* SharedMocks.swift in Sources */,
+				45B3CC8427871C01005BA3F7 /* BundleSpec.swift in Sources */,
 				459B228024528A6900D218CE /* ImpressionServiceSpec.swift in Sources */,
 				4557A8B1257E544C00C9D241 /* AccountRepositorySpec.swift in Sources */,
 				D911DC4F211115730082B950 /* ConfigurationSpec.swift in Sources */,

--- a/Sources/RInAppMessaging/Router.swift
+++ b/Sources/RInAppMessaging/Router.swift
@@ -78,10 +78,7 @@ internal class Router: RouterType {
 
                 let view = viewConstructor()
                 let parentView = self.findParentView(rootView: rootView)
-                view.show(parentView: parentView,
-                          onDismiss: { cancelled in
-                    completion(cancelled)
-                })
+                view.show(parentView: parentView, onDismiss: completion)
             }
         }
     }

--- a/Sources/RInAppMessaging/Utilities/BundleInfo.swift
+++ b/Sources/RInAppMessaging/Utilities/BundleInfo.swift
@@ -44,7 +44,12 @@ internal extension Bundle {
         guard let sdkBundleURL = sdk?.resourceURL else {
             return nil
         }
-        return .init(url: sdkBundleURL.appendingPathComponent("RInAppMessagingResources.bundle"))
+        // in some cases `resourceURL` returns a path to .framework file and sometimes to the .bundle file inside
+        if sdkBundleURL.pathExtension == "bundle" {
+            return .init(url: sdkBundleURL)
+        } else {
+            return .init(url: sdkBundleURL.appendingPathComponent("RInAppMessagingResources.bundle"))
+        }
         #endif
     }
 

--- a/Sources/RInAppMessaging/Utilities/BundleInfo.swift
+++ b/Sources/RInAppMessaging/Utilities/BundleInfo.swift
@@ -41,15 +41,14 @@ internal extension Bundle {
         module
         #else
 
+        if let resourceBundle = bundle(bundleIdSubstring: "RInAppMessagingResources") {
+            return resourceBundle
+        }
+
         guard let sdkBundleURL = sdk?.resourceURL else {
             return nil
         }
-        // in some cases `resourceURL` returns a path to .framework file and sometimes to the .bundle file inside
-        if sdkBundleURL.pathExtension == "bundle" {
-            return .init(url: sdkBundleURL)
-        } else {
-            return .init(url: sdkBundleURL.appendingPathComponent("RInAppMessagingResources.bundle"))
-        }
+        return .init(url: sdkBundleURL.appendingPathComponent("RInAppMessagingResources.bundle"))
         #endif
     }
 

--- a/Tests/Tests/BundleSpec.swift
+++ b/Tests/Tests/BundleSpec.swift
@@ -1,0 +1,31 @@
+import Quick
+import Nimble
+@testable import RInAppMessaging
+
+class BundleSpec: QuickSpec {
+
+    override func spec() {
+        describe("BundleInfo") {
+
+            it("should return expected applicationId") {
+                expect(BundleInfo.applicationId).to(equal("jp.co.rakuten.inappmessaging.demo"))
+            }
+
+            it("should return expected appVersion") {
+                expect(BundleInfo.appVersion).to(equal("1.0"))
+            }
+
+            it("should return a valid inAppSdkVersion") {
+                // swiftlint:disable:next line_length
+                let semverRegex = #"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$"#
+                expect(BundleInfo.inAppSdkVersion).to(match(semverRegex))
+            }
+        }
+
+        describe("Bundle extensions") {
+            it("should return non-nil value for sdkAssets property") {
+                expect(Bundle.sdkAssets).toNot(beNil())
+            }
+        }
+    }
+}


### PR DESCRIPTION
# Description
It looks like in some cases (maybe when resource bundle is not yet loaded) `resourceURL` is returning a path to .framework instead of `RInAppMessagingResources.bundle` causing a crash (assertion failure).
This situation happened in one of our client's apps.

EDIT: It turns out that after calling `sdkAssets` for the first time it loads another bundle with `RInAppMessaging` in the identifier causing bundle search logic (inside RSDKUtils) to return .framework at first, and then later always .bundle (because it's first on the list of bundles containing 'RInAppMessaging' in the name) 

# Checklist
- [X] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [X] I wrote/updated tests for new/changed code
- [X] I removed all sensitive data **before every commit**, including API endpoints and keys
- [ ] I ran `fastlane ci` without errors
