### PR TITLE
fix: fix race condition when ping is called during retry process (SDKCF-4637)

### DIFF
--- a/Sources/RInAppMessaging/CampaignsListManager.swift
+++ b/Sources/RInAppMessaging/CampaignsListManager.swift
@@ -1,4 +1,4 @@
-import class Foundation.DispatchWorkItem
+import Foundation
 
 internal protocol CampaignsListManagerType: ErrorReportable {
     func refreshList()

--- a/Sources/RInAppMessaging/CampaignsListManager.swift
+++ b/Sources/RInAppMessaging/CampaignsListManager.swift
@@ -34,6 +34,10 @@ internal class CampaignsListManager: CampaignsListManagerType, TaskSchedulable {
     }
 
     private func pingMixerServer() {
+        guard scheduledTask == nil else {
+            // ping request is already queued
+            return
+        }
 
         let pingResult = messageMixerService.ping()
         let decodedResponse: PingResponse

--- a/Sources/RInAppMessaging/Constants.swift
+++ b/Sources/RInAppMessaging/Constants.swift
@@ -53,13 +53,17 @@ internal enum Constants {
         static let retryCount = 3
 
         enum Default {
-            static fileprivate(set) var initialRetryDelayMS = Int32(10000)
+            fileprivate static let defaultInitialRetryDelayMS = Int32(10000)
+            fileprivate(set) static var initialRetryDelayMS = defaultInitialRetryDelayMS
         }
 
         enum Randomized {
-            static fileprivate(set) var initialRetryDelayMS = Int32(60000)
-            static fileprivate(set) var backOffLowerBoundSeconds = Int32(1)
-            static fileprivate(set) var backOffUpperBoundSeconds = Int32(60)
+            fileprivate static let defaultInitialRetryDelayMS = Int32(60000)
+            fileprivate static let defaultBackOffLowerBoundSeconds = Int32(1)
+            fileprivate static let defaultBackOffUpperBoundSeconds = Int32(60)
+            fileprivate(set) static var initialRetryDelayMS = defaultInitialRetryDelayMS
+            fileprivate(set) static var backOffLowerBoundSeconds = defaultBackOffLowerBoundSeconds
+            fileprivate(set) static var backOffUpperBoundSeconds = defaultBackOffUpperBoundSeconds
         }
 
         enum Tests {
@@ -73,9 +77,9 @@ internal enum Constants {
             }
 
             static func setDefaults() {
-                Default.initialRetryDelayMS = Int32(10000)
-                Randomized.initialRetryDelayMS = Int32(60000)
-                Randomized.backOffUpperBoundSeconds = Int32(60)
+                Default.initialRetryDelayMS = Default.defaultInitialRetryDelayMS
+                Randomized.initialRetryDelayMS = Randomized.defaultInitialRetryDelayMS
+                Randomized.backOffUpperBoundSeconds = Randomized.defaultBackOffUpperBoundSeconds
             }
         }
     }

--- a/Sources/RInAppMessaging/Constants.swift
+++ b/Sources/RInAppMessaging/Constants.swift
@@ -71,6 +71,12 @@ internal enum Constants {
             static func setBackOffUpperBoundSeconds(_ bound: Int32) {
                 Randomized.backOffUpperBoundSeconds = bound
             }
+
+            static func setDefaults() {
+                Default.initialRetryDelayMS = Int32(10000)
+                Randomized.initialRetryDelayMS = Int32(60000)
+                Randomized.backOffUpperBoundSeconds = Int32(60)
+            }
         }
     }
 }

--- a/Sources/RInAppMessaging/Protocols/TaskSchedulable.swift
+++ b/Sources/RInAppMessaging/Protocols/TaskSchedulable.swift
@@ -30,8 +30,8 @@ extension TaskSchedulable {
             self.scheduledTask = WorkScheduler.scheduleTask(
                 milliseconds: milliseconds,
                 closure: { [weak self] in
-                    task()
                     self?.scheduledTask = nil
+                    task()
                 },
                 wallDeadline: wallDeadline)
         }

--- a/Tests/Tests/CampaignsListManagerSpec.swift
+++ b/Tests/Tests/CampaignsListManagerSpec.swift
@@ -40,8 +40,7 @@ class CampaignsListManagerSpec: QuickSpec {
                     }
 
                     afterEach {
-                        Constants.Retry.Tests.setInitialDelayMS(10000)
-                        Constants.Retry.Tests.setBackOffUpperBoundSeconds(60)
+                        Constants.Retry.Tests.setDefaults()
                     }
 
                     it("will not retry for .invalidConfiguration error") {
@@ -127,6 +126,7 @@ class CampaignsListManagerSpec: QuickSpec {
                     context("and refreshList was called again") {
 
                         it("shouldn't call ping if the call is already scheduled (should call only once)") {
+                            Constants.Retry.Tests.setInitialDelayMS(2000)
                             messageMixerService.mockedError = .requestError(.unknown)
                             manager.refreshList()
                             expect(manager.scheduledTask).toEventuallyNot(beNil())
@@ -134,9 +134,8 @@ class CampaignsListManagerSpec: QuickSpec {
                             messageMixerService.mockedResponse = PingResponse(nextPingMilliseconds: .max, currentPingMilliseconds: 0, data: [])
                             messageMixerService.wasPingCalled = false
                             manager.refreshList()
-                            expect(messageMixerService.wasPingCalled).to(beFalse()) // the above call ignored
-                            expect(messageMixerService.wasPingCalled).toEventually(beTrue()) // scheduled call
-                            expect(manager.scheduledTask).to(beNil())
+                            expect(messageMixerService.wasPingCalled).toAfterTimeout(beFalse()) // checks if the call above was ignored
+                            expect(messageMixerService.wasPingCalled).toEventually(beTrue(), timeout: .seconds(2)) // scheduled retry call (after 2s)
                         }
                     }
                 }

--- a/Tests/Tests/CampaignsListManagerSpec.swift
+++ b/Tests/Tests/CampaignsListManagerSpec.swift
@@ -123,6 +123,22 @@ class CampaignsListManagerSpec: QuickSpec {
                         manager.refreshList()
                         expect(errorDelegate.wasErrorReceived).to(beTrue())
                     }
+
+                    context("and refreshList was called again") {
+
+                        it("shouldn't call ping if the call is already scheduled (should call only once)") {
+                            messageMixerService.mockedError = .requestError(.unknown)
+                            manager.refreshList()
+                            expect(manager.scheduledTask).toEventuallyNot(beNil())
+
+                            messageMixerService.mockedResponse = PingResponse(nextPingMilliseconds: .max, currentPingMilliseconds: 0, data: [])
+                            messageMixerService.wasPingCalled = false
+                            manager.refreshList()
+                            expect(messageMixerService.wasPingCalled).to(beFalse()) // the above call ignored
+                            expect(messageMixerService.wasPingCalled).toEventually(beTrue()) // scheduled call
+                            expect(manager.scheduledTask).to(beNil())
+                        }
+                    }
                 }
 
                 context("and ping call succeeded") {

--- a/Tests/Tests/ConfigurationManagerSpec.swift
+++ b/Tests/Tests/ConfigurationManagerSpec.swift
@@ -87,8 +87,7 @@ class ConfigurationManagerSpec: QuickSpec {
                     }
 
                     afterEach {
-                        Constants.Retry.Tests.setInitialDelayMS(10000)
-                        Constants.Retry.Tests.setBackOffUpperBoundSeconds(60)
+                        Constants.Retry.Tests.setDefaults()
                     }
 
                     it("should retry") {

--- a/Tests/Tests/ImpressionServiceSpec.swift
+++ b/Tests/Tests/ImpressionServiceSpec.swift
@@ -100,8 +100,7 @@ class ImpressionServiceSpec: QuickSpec {
                 }
 
                 afterEach {
-                    Constants.Retry.Tests.setInitialDelayMS(10000)
-                    Constants.Retry.Tests.setBackOffUpperBoundSeconds(60)
+                    Constants.Retry.Tests.setDefaults()
                 }
 
                 it("will not report task failed error") {


### PR DESCRIPTION
# Description
Calling ping `refreshList` during retry process broke delay and state observation logic.

## Links
SDKCF-4637

# Checklist
- [X] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [X] I wrote/updated tests for new/changed code
- [X] I removed all sensitive data **before every commit**, including API endpoints and keys
- [ ] I ran `fastlane ci` without errors
