### PR TITLE
fix: fix initial delays for randomized backoff retries (SDKCF-4637)

### DIFF
--- a/Sources/RInAppMessaging/CampaignsListManager.swift
+++ b/Sources/RInAppMessaging/CampaignsListManager.swift
@@ -99,7 +99,7 @@ internal class CampaignsListManager: CampaignsListManagerType, TaskSchedulable {
     }
 
     private func scheduleNextPingCallWithRandomizedBackoff() {
-        if case .success = responseStateMachine.previousState {
+        if responseStateMachine.consecutiveErrorCount <= 1 {
             retryDelayMS = Constants.Retry.Randomized.initialRetryDelayMS
         }
         scheduleNextPingCall(in: Int(retryDelayMS))

--- a/Sources/RInAppMessaging/ConfigurationManager.swift
+++ b/Sources/RInAppMessaging/ConfigurationManager.swift
@@ -100,7 +100,7 @@ internal class ConfigurationManager: ConfigurationManagerType, TaskSchedulable {
     }
 
     private func scheduleRetryWithRandomizedBackoff(retryHandler: @escaping () -> Void) {
-        if case .success = responseStateMachine.previousState {
+        if responseStateMachine.consecutiveErrorCount <= 1 {
             retryDelayMS = Constants.Retry.Randomized.initialRetryDelayMS
         }
         scheduleTask(milliseconds: Int(retryDelayMS), wallDeadline: true, retryHandler)


### PR DESCRIPTION
# Description
Initial delay for randomized backoff retry (60s) was never set because the condition was always executed after at least one failure (always false) causing retries to start with standard backoff value - 10s

## Links
SDKCF-4637

# Checklist
- [X] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [X] I wrote/updated tests for new/changed code
- [X] I removed all sensitive data **before every commit**, including API endpoints and keys
- [ ] I ran `fastlane ci` without errors
