### PR TITLE
ci: Pin fastlane version to 2.200.0 to avoid missing xcresult issue

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source "https://rubygems.org"
 
-gem "fastlane", "~> 2.174"
+# unpin once https://github.com/fastlane/fastlane/issues/19841 is solved
+gem "fastlane", "2.200.0"
 gem "cocoapods"
 gem "xcode-install"
 gem "jazzy"


### PR DESCRIPTION
# Description
Fixes build issues on Bitrise related to missing xcresult file after scan that fails xcov/danger process.
This issue is present in version 2.201.0 and still persists after 2.201.1 hotfix.
Version pinning should be removed after
https://github.com/fastlane/fastlane/issues/19841 is fixed and released.

# Checklist
- [X] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [ ] I wrote/updated tests for new/changed code
- [X] I removed all sensitive data **before every commit**, including API endpoints and keys
- [ ] I ran `fastlane ci` without errors
