### PR TITLE
refactor: remove duplicate ExitButton instance

### DIFF
--- a/Sources/RInAppMessaging/Views/SlideUpView.swift
+++ b/Sources/RInAppMessaging/Views/SlideUpView.swift
@@ -138,7 +138,6 @@ internal class SlideUpView: UIView, SlideUpViewType {
     }
 
     private func setupExitButton(_ contextualColour: UIColor) {
-        let exitButton = ExitButton()
         exitButton.invertedColors = contextualColour.isBright
         exitButton.addTarget(self, action: #selector(onExitButtonClick), for: .touchUpInside)
         exitButton.translatesAutoresizingMaskIntoConstraints = false


### PR DESCRIPTION
>Rename "exitButton" which has the same name as the field declared at line 33.

Fixes this warning that was missed in #130 