### PR TITLE
fix: [Tooltip] fix auto-disappear feature (SDKCF-4822)

### DIFF
--- a/Sources/RInAppMessaging/Router.swift
+++ b/Sources/RInAppMessaging/Router.swift
@@ -209,13 +209,16 @@ internal class Router: RouterType, ViewListenerObserver {
             }
 
             if let parentScrollView = superview as? UIScrollView {
-                let observer = parentScrollView.observe(\.frame, options: [.new, .old]) { _, _ in
-                    // update for changes like landscape/portrait screen transitions
+                let screenTransitionObserver = parentScrollView.observe(\.frame, options: []) { _, _ in
                     newPositionHandler()
                 }
-                self.observers.append(observer)
+                let viewVisibilityObserver = parentScrollView.observe(\.contentOffset, options: []) { _, _ in
+                    verifyVisibility()
+                }
+                self.observers.append(screenTransitionObserver)
+                self.observers.append(viewVisibilityObserver)
             } else {
-                let observer = targetView.observe(\.frame, options: [.new, .old]) { _, _ in
+                let observer = targetView.observe(\.frame, options: []) { _, _ in
                     newPositionHandler()
                 }
                 self.observers.append(observer)


### PR DESCRIPTION
# Description
Re-added `contentOffset` observer which is necessary to check if tooltip is visible and start auto-disappear timer

## Links
SDKCF-4822

# Checklist
- [X] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [ ] I wrote/updated tests for new/changed code
- [X] I removed all sensitive data **before every commit**, including API endpoints and keys
- [X] I ran `fastlane ci` without errors
