### PR TITLE
fix: make the swift build target configurable (SDKCF-4790)

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -42,7 +42,8 @@ platform :ios do
   end
 
   lane :build_swift_package do
-    sh 'swift build -Xswiftc "-sdk" -Xswiftc `xcrun --sdk iphonesimulator --show-sdk-path` -Xswiftc "-target" -Xswiftc "x86_64-apple-ios15.0-simulator"'
+    swift_target = ENV['REM_FL_SWIFT_TARGET'] || "x86_64-apple-ios15.0-simulator"
+    sh "swift build -Xswiftc \"-sdk\" -Xswiftc `xcrun --sdk iphonesimulator --show-sdk-path` -Xswiftc \"-target\" -Xswiftc #{swift_target}"
   end
 
   lane :coverage do


### PR DESCRIPTION
# Description
- To get the swift build command to succeed on Xcode 12.x we need to set a different target
- This change makes the target configurable by an injectable env var

## Links
SDKCF-4790

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [ ] I wrote/updated tests for new/changed code
- [ ] I removed all sensitive data **before every commit**, including API endpoints and keys
- [ ] I ran `fastlane ci` without errors
