### PR TITLE
feat: Align Swift version support (SDKCF-4824)

### DIFF
--- a/RInAppMessaging.podspec
+++ b/RInAppMessaging.podspec
@@ -1,14 +1,15 @@
 Pod::Spec.new do |s|
   s.name             = 'RInAppMessaging'
-  s.version          = '3.0.0'
+  s.version          = '6.1.0'
   s.summary          = 'Rakuten module to manage and display in-app messages'
   s.homepage         = 'https://github.com/rakutentech/ios-inappmessaging'
   s.license          = { :type => 'MIT', :file => 'LICENSE' }
   s.authors          = 'Rakuten Ecosystem Mobile'
   s.source           = { :git => "https://github.com/rakutentech/ios-inappmessaging.git", :tag => s.version.to_s }  
-  s.ios.deployment_target = '11.0'
-  s.swift_version = '5.1'
+  s.ios.deployment_target = '12.0'
+  s.swift_versions = ['5.1', '5.2', '5.3', '5.4', '5.5']
 
-  s.source_files = 'RInAppMessaging/Classes/**/*.{swift,h,m}'
-  s.resource_bundles = { 'RInAppMessagingAssets' => ['RInAppMessaging/Assets/*'] }
+  s.dependency 'RSDKUtils', '~> 2.1'
+  s.source_files = 'Sources/RInAppMessaging/**/*.swift'
+  s.resource_bundles = { 'RInAppMessagingResources' => ['Sources/RInAppMessaging/Resources/*'] }
 end


### PR DESCRIPTION
## Align Swift version support for all SDKs.

According to these files, these are the handled Swift versions in RAnalytics, RPushPNP and IAM:

RAnalytics.podspec : Swift ['5.1', '5.2', '5.3', '5.4', '5.5']
RAnalytics Package.swift : Swift 5.3

RPushPNP.podspec : Swift 5.0

RInAppMessaging.podspec : Swift ['5.1', '5.2', '5.3', '5.4', '5.5']
IAM Package.swift : Swift 5.3

I propose to have ['5.3', '5.4', '5.5'] in the podspec files.

## Notes
Swift 5.1 is included in Xcode 11: https://www.swift.org/blog/swift-5-1-released/
Swift 5.2 is included in Xcode 11.4: https://www.swift.org/blog/swift-5-2-released/

That means that we drop the Xcode support for versions <= 11.4.

## Links
SDKCF-4824