### PR TITLE
feat: Align Swift version support (SDKCF-4824)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,6 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.4
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
 import PackageDescription
 
 let package = Package(

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ This module supports iOS 12.0 and above. It has been tested with iOS 12.5 and ab
 
 Xcode 12.5.x or Xcode 13+
 
+Swift >= 5.4 is supported.
+
 Note: The SDK may build on earlier Xcode versions but it is not officially supported or tested.
 
 # **How to install**

--- a/RInAppMessaging.podspec
+++ b/RInAppMessaging.podspec
@@ -7,7 +7,7 @@ Pod::Spec.new do |s|
   s.authors          = 'Rakuten Ecosystem Mobile'
   s.source           = { :git => "https://github.com/rakutentech/ios-inappmessaging.git", :tag => s.version.to_s }  
   s.ios.deployment_target = '12.0'
-  s.swift_versions = ['5.1', '5.2', '5.3', '5.4', '5.5']
+  s.swift_versions = ['5.4', '5.5']
 
   s.dependency 'RSDKUtils', '~> 2.1'
   s.source_files = 'Sources/RInAppMessaging/**/*.swift'


### PR DESCRIPTION
## Align Swift version support for all SDKs.

Our SDKs Readme files already mentions that only Xcode 12.5.x or Xcode 13+ are supported.

That means that we can drop the Xcode support for versions < 12.5.

Xcode 12.5 has Swift 5.4.

Then I propose to handle only Swift version >= 5.4.

Then we'll have ['5.4', '5.5'] in the podspec files.

## Notes
Swift 5.1 is included in Xcode 11: https://www.swift.org/blog/swift-5-1-released/
Swift 5.2 is included in Xcode 11.4: https://www.swift.org/blog/swift-5-2-released/
Swift 5.3 is included in Xcode 12: https://www.swift.org/blog/swift-5-3-released/

All Swift versions supported by Xcode:
https://swiftversion.net

## Links
SDKCF-4824