### PR TITLE
refactor: align public API with Android (SDKCF-4940)

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -7,7 +7,7 @@ PODS:
   - GRMustache.swift (4.0.1)
   - Nimble (9.2.1)
   - Quick (4.0.0)
-  - RInAppMessaging (6.1.0-snapshot):
+  - RInAppMessaging (6.2.0-snapshot):
     - RSDKUtils (~> 2.1)
   - RSDKUtils (2.1.0):
     - RSDKUtils/Main (= 2.1.0)
@@ -76,7 +76,7 @@ SPEC CHECKSUMS:
   GRMustache.swift: a6436504284b22b4b05daf5f46f77bd3fe00a9a2
   Nimble: e7e615c0335ee4bf5b0d786685451e62746117d5
   Quick: 6473349e43b9271a8d43839d9ba1c442ed1b7ac4
-  RInAppMessaging: 13e9faf1971a5b3b6435468e7c7c6199bf85320e
+  RInAppMessaging: c8389bcfd9b9f385c715d4869e6449be3f1cbab5
   RSDKUtils: 47d28aac1347d712e6d4db9a1332cae41b17738f
   Shock: 94c2d3f5f781fe63317c4ee1621dfb2d4cc271d3
   SwiftLint: 06ac37e4d38c7068e0935bb30cda95f093bec761

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ To use the module you must set the following values in your app's `Info.plist`:
 
 | Key     | Value     |
 | :---:   | :---:     |
-| `InAppMessagingAppSubscriptionID` | your_subscription_key |
+| `InAppMessagingAppSubscriptionID` | your\_subscription\_key |
 | `InAppMessagingConfigurationURL` | Endpoint for fetching the configuration |
 
 
@@ -196,12 +196,13 @@ From the SDK side, host app developers will be able to log custom events as show
 
 ## **Optional features**
 
-### **RInAppMessagingDelegate**
+### **Campaign context verification**
 
-An optional delegate. Set the `RInAppMessaging.delegate` and implement the protocol method `inAppMessagingShouldShowCampaignWithContexts(contexts:campaignTitle:)` in order to be called before a message is displayed when a campaign title contains one or more contexts. A context is defined as the text inside "[]" within an IAM portal "Campaign Name" e.g. the campaign name is "[ctx1] title" so the context is "ctx1".
+An optional variable `onVerifyContext` is called before a message is displayed for campaigns that have one or more contexts defined. A context can be added as the text inside "[]" within an IAM portal "Campaign Name" e.g. the campaign name is "[ctx1] title" so the context is "ctx1". Return `false` in `onVerifyContext` closure to prevent campaign from displaying (it won't count as an impression).<br/>
+__Note__: `onVerifyContext` is not called for campaigns without defined contexts
 
 ```swift
-func inAppMessagingShouldShowCampaignWithContexts(contexts: [String], campaignTitle: String) -> Bool {
+RInAppMessaging.onVerifyContext = { (contexts: [String], campaignTitle: String) in
     guard campaignTitle == "[context1] campaign-title-1", contexts.contains("context1") else {
         return true
     }
@@ -213,14 +214,23 @@ func inAppMessagingShouldShowCampaignWithContexts(contexts: [String], campaignTi
 }
 ```
 
-### **RInAppMessagingErrorDelegate**
+### **Error callback**
 
-An optional error delegate. Set the `RInAppMessaging.errorDelegate` and implement the protocol method `inAppMessagingDidReturnError(error:)` to receive an `NSError` object whenever an internal SDK error occurs. This allows you to log the errors somewhere, e.g. a 3rd party analytics service, for later troubleshooting.
+Developers can set an optional variable `errorCallback` to receive internal SDK errors. This allows you to log the errors somewhere, e.g. a 3rd party analytics service, for later troubleshooting.
+```swift
+import RInAppMessaging
 
-### **(BOOL)accessibilityCompatibleDisplay**  
+func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
+    RInAppMessaging.errorCallback = { [weak self] error in
+        self?.logger.log(error.description)
+    }
+}
+```
 
-This flag can be used to support UI test automation tools like Appium. When set to `true`, the SDK will use a different display method which changes campaign messages' view hierarchy. This can solve issues with accessibility tools having problems detecting visible items.
- __Note__: There is a possibility that changing this flag will cause campaigns to display incorrectly.
+### **Accessibility / Automation tests support**  
+
+The campaign message view contains elements with `accessibilityIdentifier` value. In some apps those elements might not visible for test automation tools like Appium. To fix that issue set `accessibilityCompatibleDisplay` flag to `true`. The SDK will use a different logic to display campaign messages.<br/>
+__Note__: This feature changes the way campaign views are added to the view hierarchy which, in some apps, might result in campaigns to be displayed incorrectly.
 
 ```swift
 import RInAppMessaging

--- a/Sources/RInAppMessaging/InAppMessagingModule.swift
+++ b/Sources/RInAppMessaging/InAppMessagingModule.swift
@@ -24,7 +24,7 @@ internal class InAppMessagingModule: ErrorDelegate, CampaignDispatcherDelegate, 
     private var eventBuffer = [Event]()
 
     var aggregatedErrorHandler: ((NSError) -> Void)?
-    weak var delegate: RInAppMessagingDelegate?
+    var onVerifyContext: ((_ contexts: [String], _ campaignTitle: String) -> Bool)?
 
     init(configurationManager: ConfigurationManagerType,
          campaignsListManager: CampaignsListManagerType,
@@ -150,11 +150,7 @@ extension InAppMessagingModule {
     }
 
     func shouldShowCampaignMessage(title: String, contexts: [String]) -> Bool {
-        guard let delegate = delegate else {
-            return true
-        }
-        return delegate.inAppMessagingShouldShowCampaignWithContexts(contexts: contexts,
-                                                                     campaignTitle: title)
+        onVerifyContext?(contexts, title) ?? true
     }
 }
 

--- a/Sources/RInAppMessaging/RInAppMessaging.swift
+++ b/Sources/RInAppMessaging/RInAppMessaging.swift
@@ -99,7 +99,6 @@ import RSDKUtils
             initializedModule?.initialize(deinitHandler: {
                 self.initializedModule = nil
                 self.dependencyManager = nil
-                self.onVerifyContext = nil
             })
         }
     }

--- a/Sources/RInAppMessaging/RInAppMessaging.swift
+++ b/Sources/RInAppMessaging/RInAppMessaging.swift
@@ -5,20 +5,6 @@ import RSDKUtilsMain // SPM version
 import RSDKUtils
 #endif
 
-/// Protocol for optional delagate
-@objc public protocol RInAppMessagingDelegate: AnyObject {
-    /// Method called only for campaigns with context just before displaying its message
-    func inAppMessagingShouldShowCampaignWithContexts(contexts: [String], campaignTitle: String) -> Bool
-}
-
-/// Protocol for optional error delegate of InAppMessaging module
-@objc public protocol RInAppMessagingErrorDelegate {
-    /// Method will be called whenever any internal error occurs.
-    /// This functionality is made for debugging purposes.
-    /// Normally those errors handled by the SDK
-    func inAppMessagingDidReturnError(_ error: NSError)
-}
-
 /// Class that contains the public methods for host application to call.
 /// Entry point for host application to communicate with InAppMessaging.
 /// Conforms to NSObject and exposed with objc tag to make it work with Obj-c projects.
@@ -43,13 +29,19 @@ import RSDKUtils
         }
     }
 
-    /// Optional error delegate for debugging purposes
-    @objc public static weak var errorDelegate: RInAppMessagingErrorDelegate?
-
-    /// Optional delegate for advanced features
-    @objc public static weak var delegate: RInAppMessagingDelegate? {
+    /// An optional callback called only for campaigns with defined context just before displaying its message.
+    /// Return `false` to prevent the message from displaying.
+    @objc public static var onVerifyContext: ((_ contexts: [String], _ campaignTitle: String) -> Bool)? {
         didSet {
-            initializedModule?.delegate = delegate
+            initializedModule?.onVerifyContext = onVerifyContext
+        }
+    }
+
+    /// A closure called whenever any internal error occurs.
+    /// This functionality is made for debugging purposes to provide more information for developers.
+    @objc public static var errorCallback: ((NSError) -> Void)? {
+        didSet {
+            initializedModule?.aggregatedErrorHandler = errorCallback
         }
     }
 
@@ -66,7 +58,7 @@ import RSDKUtils
         configure(dependencyManager: dependencyManager)
     }
 
-    static func configure(dependencyManager: TypedDependencyManager) {
+    internal static func configure(dependencyManager: TypedDependencyManager) {
         self.dependencyManager = dependencyManager
 
         inAppQueue.async {
@@ -102,13 +94,12 @@ import RSDKUtils
                                                      router: router,
                                                      randomizer: randomizer,
                                                      displayPermissionService: displayPermissionService)
-            initializedModule?.aggregatedErrorHandler = { error in
-                errorDelegate?.inAppMessagingDidReturnError(error)
-            }
-            initializedModule?.delegate = delegate
+            initializedModule?.aggregatedErrorHandler = errorCallback
+            initializedModule?.onVerifyContext = onVerifyContext
             initializedModule?.initialize(deinitHandler: {
                 self.initializedModule = nil
                 self.dependencyManager = nil
+                self.onVerifyContext = nil
             })
         }
     }
@@ -165,6 +156,6 @@ import RSDKUtils
                             code: 0,
                             userInfo: [NSLocalizedDescriptionKey: "InAppMessaging: " + description])
         Logger.debug(description)
-        errorDelegate?.inAppMessagingDidReturnError(error)
+        errorCallback?(error)
     }
 }

--- a/Tests/Tests/Helpers/SharedMocks.swift
+++ b/Tests/Tests/Helpers/SharedMocks.swift
@@ -303,6 +303,8 @@ class RouterMock: RouterType {
     var wasDiscardCampaignCalled = false
     var displayTime = TimeInterval(0.1)
 
+    private let displayQueue = DispatchQueue(label: "RouterMock.displayQueue")
+
     func displayCampaign(_ campaign: Campaign,
                          associatedImageData: Data?,
                          confirmation: @escaping @autoclosure () -> Bool,
@@ -311,11 +313,11 @@ class RouterMock: RouterType {
             completion(true)
             return
         }
-        DispatchQueue.global().async { [weak self] in
+        let delayUSeconds = Int(displayTime * Double(USEC_PER_SEC))
+        displayQueue.asyncAfter(deadline: .now() + .microseconds(delayUSeconds)) { [weak self] in
             guard let self = self else {
                 return
             }
-            usleep(useconds_t(self.displayTime * Double(USEC_PER_SEC))) // simulate display time
             self.lastDisplayedCampaign = campaign
             self.displayedCampaignsCount += 1
             completion(false)

--- a/Tests/Tests/Helpers/SharedMocks.swift
+++ b/Tests/Tests/Helpers/SharedMocks.swift
@@ -301,6 +301,7 @@ class RouterMock: RouterType {
     var lastDisplayedCampaign: Campaign?
     var displayedCampaignsCount = 0
     var wasDiscardCampaignCalled = false
+    var wasDisplayCampaignCalled = false
     var displayTime = TimeInterval(0.1)
 
     private let displayQueue = DispatchQueue(label: "RouterMock.displayQueue")
@@ -309,6 +310,8 @@ class RouterMock: RouterType {
                          associatedImageData: Data?,
                          confirmation: @escaping @autoclosure () -> Bool,
                          completion: @escaping (_ cancelled: Bool) -> Void) {
+
+        wasDisplayCampaignCalled = true
         guard confirmation() else {
             completion(true)
             return

--- a/Tests/Tests/InAppMessagingModuleSpec.swift
+++ b/Tests/Tests/InAppMessagingModuleSpec.swift
@@ -65,7 +65,7 @@ class InAppMessagingModuleSpec: QuickSpec {
                 expect(iamModule.shouldShowCampaignMessage(title: "", contexts: [])).to(beTrue())
             }
 
-            it("will call delegate method if shouldShowCampaignMessage was called") {
+            it("will call onVerifyContext if shouldShowCampaignMessage was called") {
                 var onVerifyContextCalled = false
                 iamModule.onVerifyContext = { _, _ in
                     onVerifyContextCalled = true

--- a/Tests/Tests/InAppMessagingModuleSpec.swift
+++ b/Tests/Tests/InAppMessagingModuleSpec.swift
@@ -28,7 +28,6 @@ class InAppMessagingModuleSpec: QuickSpec {
             var campaignRepository: CampaignRepositoryMock!
             var router: RouterMock!
             var randomizer: RandomizerMock!
-            var delegate: Delegate!
 
             beforeEach {
                 configurationManager = ConfigurationManagerMock()
@@ -44,7 +43,6 @@ class InAppMessagingModuleSpec: QuickSpec {
                 campaignRepository = CampaignRepositoryMock()
                 router = RouterMock()
                 randomizer = RandomizerMock()
-                delegate = Delegate()
                 iamModule = InAppMessagingModule(configurationManager: configurationManager,
                                                  campaignsListManager: campaignsListManager,
                                                  impressionService: impressionService,
@@ -56,21 +54,26 @@ class InAppMessagingModuleSpec: QuickSpec {
                                                  router: router,
                                                  randomizer: randomizer,
                                                  displayPermissionService: DisplayPermissionServiceMock())
-                iamModule.delegate = delegate
             }
 
             it("is enabled by deafult") {
                 expect(iamModule.isEnabled).to(beTrue())
             }
 
-            it("will return true for shouldShowCampaignMessage if delegate is nil") {
-                iamModule.delegate = nil
+            it("will return true for shouldShowCampaignMessage if onVerifyContext is nil") {
+                iamModule.onVerifyContext = nil
                 expect(iamModule.shouldShowCampaignMessage(title: "", contexts: [])).to(beTrue())
             }
 
             it("will call delegate method if shouldShowCampaignMessage was called") {
+                var onVerifyContextCalled = false
+                iamModule.onVerifyContext = { _, _ in
+                    onVerifyContextCalled = true
+                    return true
+                }
                 _ = iamModule.shouldShowCampaignMessage(title: "", contexts: [])
-                expect(delegate.wasShouldShowCampaignCalled).to(beTrue())
+
+                expect(onVerifyContextCalled).to(beTrue())
             }
 
             context("when calling initialize") {
@@ -639,14 +642,5 @@ class InAppMessagingModuleSpec: QuickSpec {
                 }
             }
         }
-    }
-}
-
-private class Delegate: RInAppMessagingDelegate {
-    var wasShouldShowCampaignCalled = false
-
-    func inAppMessagingShouldShowCampaignWithContexts(contexts: [String], campaignTitle: String) -> Bool {
-        wasShouldShowCampaignCalled = true
-        return true
     }
 }

--- a/Tests/Tests/PublicAPISpec.swift
+++ b/Tests/Tests/PublicAPISpec.swift
@@ -138,9 +138,11 @@ class PublicAPISpec: QuickSpec {
                 })))
             }
 
-            it("will pass errors to errorDelegate") {
+            it("will pass internal errors to errorCallback") {
                 messageMixerService.mockedError = .invalidConfiguration
                 campaignsListManager.refreshList()
+
+                // errorReceiver is updated inside errorCallback
                 expect(errorReceiver.returnedError?.domain).toEventually(
                     equal("InAppMessaging.CampaignsListManager"))
                 expect(errorReceiver.returnedError?.localizedDescription).toEventually(
@@ -225,7 +227,7 @@ class PublicAPISpec: QuickSpec {
                 }
             }
 
-            context("delegate") {
+            context("onVerifyContext") {
 
                 it("will not call the method if there are no contexts") {
                     generateAndDisplayLoginCampaigns(count: 1, addContexts: false)

--- a/Tests/Tests/ReadyCampaignDispatcherSpec.swift
+++ b/Tests/Tests/ReadyCampaignDispatcherSpec.swift
@@ -300,10 +300,10 @@ class ReadyCampaignDispatcherSpec: QuickSpec {
                         dispatcher.dispatchAllIfNeeded()
                     }
 
-                    it("will not stop dispatching if campaign is displayed") {
-                        router.displayTime = 2.0
+                    it("will not change dispatching mode to false if campaign is displayed") {
+                        router.displayTime = 3.0
                         expect(dispatcher.isDispatching).toEventually(beTrue())
-                        expect(dispatcher.scheduledTask).toEventually(beNil()) // wait
+                        expect(dispatcher.scheduledTask).to(beNil())
                         dispatcher.resetQueue()
                         expect(dispatcher.isDispatching).toAfterTimeout(beTrue())
                     }


### PR DESCRIPTION
# Description
Changed `RInAppMessagingDelegate` and `RInAppMessagingErrorDelegate` methods to static closures to align with Android

## Links
SDKCF-4940
SDKCF-3968

# Checklist
- [X] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [X] I wrote/updated tests for new/changed code
- [X] I removed all sensitive data **before every commit**, including API endpoints and keys
- [ ] I ran `fastlane ci` without errors
