### PR TITLE
build: fix SPM dependency name issue

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -15,12 +15,12 @@ let package = Package(
             targets: ["RInAppMessaging"])
     ],
     dependencies: [
-        .package(url: "https://github.com/rakutentech/ios-sdkutils.git", .upToNextMajor(from: "2.1.0"))
+        .package(name: "RSDKUtils", url: "https://github.com/rakutentech/ios-sdkutils.git", .upToNextMajor(from: "2.1.0"))
     ],
     targets: [
         .target(
             name: "RInAppMessaging",
-            dependencies: [.product(name: "RSDKUtilsMain", package: "ios-sdkutils")],
+            dependencies: [.product(name: "RSDKUtilsMain", package: "RSDKUtils")],
             resources: [.process("Resources")]
         )
     ],


### PR DESCRIPTION
# Description
Added explicit name for RSDKUtils SPM dependency to fix error on Xcode 12.5

# Checklist
- [X] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [ ] I wrote/updated tests for new/changed code
- [X] I removed all sensitive data **before every commit**, including API endpoints and keys
- [X] I ran `fastlane ci` without errors
