### PR TITLE
improve: cache test campaigns and validate their state (SDKCF-5027)

### DIFF
--- a/Sources/RInAppMessaging/CampaignDispatcher.swift
+++ b/Sources/RInAppMessaging/CampaignDispatcher.swift
@@ -96,7 +96,7 @@ internal class CampaignDispatcher: CampaignDispatcherType, TaskSchedulable {
             delegate?.performPing()
         }
 
-        guard campaign.data.isTest || (permissionResponse.display && campaign.impressionsLeft > 0) else {
+        guard campaign.impressionsLeft > 0 && (permissionResponse.display || campaign.data.isTest) else {
             dispatchNext()
             return
         }

--- a/Sources/RInAppMessaging/CampaignsValidator.swift
+++ b/Sources/RInAppMessaging/CampaignsValidator.swift
@@ -31,18 +31,18 @@ internal struct CampaignsValidator: CampaignsValidatorType {
     func validate(validatedCampaignHandler: (_ campaign: Campaign, _ events: Set<Event>) -> Void) {
 
         for campaign in campaignRepository.list {
-            guard !campaign.data.isTest else {
-                validatedCampaignHandler(campaign, [])
-                // test campaigns are always ready
-                continue
-            }
-
             guard campaign.impressionsLeft > 0,
-                !campaign.isOptedOut,
                 !campaign.isOutdated else {
                     // campaign is not ready
                     continue
             }
+
+            guard !campaign.data.isTest else {
+                validatedCampaignHandler(campaign, [])
+                // test campaign triggers are always satisfied
+                continue
+            }
+            guard !campaign.isOptedOut else { continue }
 
             guard let campaignTriggers = campaign.data.triggers else {
                 Logger.debug("campaign (\(campaign.id)) has no triggers.")

--- a/Sources/RInAppMessaging/Repositories/CampaignRepository.swift
+++ b/Sources/RInAppMessaging/Repositories/CampaignRepository.swift
@@ -97,7 +97,7 @@ internal class CampaignRepository: CampaignRepositoryType {
             updatedList.append(updatedCampaign)
         }
         campaigns.set(value: updatedList + testCampaigns)
-        saveDataToCache(updatedList)
+        saveDataToCache(updatedList + testCampaigns)
     }
 
     @discardableResult
@@ -171,10 +171,7 @@ internal class CampaignRepository: CampaignRepositoryType {
         newList[index] = updatedCampaign
         campaigns.set(value: newList)
 
-        if !campaign.data.isTest {
-            saveDataToCache(newList)
-        }
-
+        saveDataToCache(newList)
         return updatedCampaign
     }
 

--- a/Tests/Tests/CampaignRepositorySpec.swift
+++ b/Tests/Tests/CampaignRepositorySpec.swift
@@ -127,10 +127,10 @@ class CampaignRepositorySpec: QuickSpec {
                     expect(lastUserCache?.campaignData).to(equal(userCache?.campaignData))
                 }
 
-                it("will not save test campaigns to the cache") {
+                it("will save test campaigns to the cache") {
                     userInfoProvider.userID = "user"
                     campaignRepository.syncWith(list: [testCampaign], timestampMilliseconds: 0)
-                    expect(userCache?.campaignData).toNot(equal([testCampaign]))
+                    expect(userCache?.campaignData).to(equal([testCampaign]))
                     expect(lastUserCache?.campaignData).to(equal(userCache?.campaignData))
                 }
             }
@@ -170,12 +170,12 @@ class CampaignRepositorySpec: QuickSpec {
                     expect(lastUserCache?.campaignData).to(equal(userCache?.campaignData))
                 }
 
-                it("will NOT save updated list to the cache if campaign is marked as `isTest`") {
+                it("will NOT cache updated campaign if it's marked as `isTest`") {
                     userInfoProvider.userID = "user"
                     campaignRepository.syncWith(list: [testCampaign], timestampMilliseconds: 0)
                     campaignRepository.optOutCampaign(testCampaign)
-                    expect(userCache?.campaignData).to(beEmpty())
-                    expect(lastUserCache?.campaignData).to(beEmpty())
+                    expect(userCache?.campaignData?.first?.isOptedOut).to(beFalse())
+                    expect(lastUserCache?.campaignData?.first?.isOptedOut).to(beFalse())
                 }
             }
 
@@ -222,12 +222,12 @@ class CampaignRepositorySpec: QuickSpec {
                     expect(lastUserCache?.campaignData).to(equal(userCache?.campaignData))
                 }
 
-                it("will NOT save updated list to the cache if campaign is marked as `isTest`") {
+                it("will save updated campaign even if it's marked as `isTest`") {
                     userInfoProvider.userID = "user"
                     campaignRepository.syncWith(list: [testCampaign], timestampMilliseconds: 0)
                     campaignRepository.decrementImpressionsLeftInCampaign(id: testCampaign.id)
-                    expect(userCache?.campaignData).to(beEmpty())
-                    expect(lastUserCache?.campaignData).to(beEmpty())
+                    expect(userCache?.campaignData?.first?.impressionsLeft).to(equal(2))
+                    expect(lastUserCache?.campaignData?.first?.impressionsLeft).to(equal(2))
                 }
             }
 
@@ -266,12 +266,12 @@ class CampaignRepositorySpec: QuickSpec {
                     expect(lastUserCache?.campaignData).to(equal(userCache?.campaignData))
                 }
 
-                it("will NOT save updated list to the cache if campaign is marked as `isTest`") {
+                it("will save updated campaign even if it's marked as `isTest`") {
                     userInfoProvider.userID = "user"
                     campaignRepository.syncWith(list: [testCampaign], timestampMilliseconds: 0)
                     campaignRepository.incrementImpressionsLeftInCampaign(id: testCampaign.id)
-                    expect(userCache?.campaignData).to(beEmpty())
-                    expect(lastUserCache?.campaignData).to(beEmpty())
+                    expect(userCache?.campaignData?.first?.impressionsLeft).to(equal(4))
+                    expect(lastUserCache?.campaignData?.first?.impressionsLeft).to(equal(4))
                 }
             }
 

--- a/Tests/UITests/ResponseStubs/full-image-only.json
+++ b/Tests/UITests/ResponseStubs/full-image-only.json
@@ -7,7 +7,7 @@
                 "campaignId": "full-image-only",
                 "maxImpressions": 999,
                 "type": 2,
-                "isTest": true,
+                "isTest": false,
                 "isCampaignDismissable": false,
                 "hasNoEndDate": false,
                 "infiniteImpressions": true,
@@ -35,7 +35,7 @@
                     "messageSettings": {
                         "displaySettings": {
                             "slideFrom": 1,
-                            "endTimeMillis": 0,
+                            "endTimeMillis": 9999999999999,
                             "orientation": 1,
                             "textAlign": 2,
                             "optOut": false,

--- a/Tests/UITests/ResponseStubs/full-text-image.json
+++ b/Tests/UITests/ResponseStubs/full-text-image.json
@@ -7,7 +7,7 @@
                 "campaignId": "full-text-image",
                 "maxImpressions": 999,
                 "type": 2,
-                "isTest": true,
+                "isTest": false,
                 "isCampaignDismissable": true,
                 "hasNoEndDate": false,
                 "infiniteImpressions": true,
@@ -35,7 +35,7 @@
                     "messageSettings": {
                         "displaySettings": {
                             "slideFrom": 1,
-                            "endTimeMillis": 0,
+                            "endTimeMillis": 9999999999999,
                             "orientation": 1,
                             "textAlign": 2,
                             "optOut": false,

--- a/Tests/UITests/ResponseStubs/full-text-only.json
+++ b/Tests/UITests/ResponseStubs/full-text-only.json
@@ -7,7 +7,7 @@
                 "campaignId": "full-text-only",
                 "maxImpressions": 999,
                 "type": 2,
-                "isTest": true,
+                "isTest": false,
                 "isCampaignDismissable": true,
                 "hasNoEndDate": false,
                 "infiniteImpressions": true,
@@ -34,7 +34,7 @@
                     "messageSettings": {
                         "displaySettings": {
                             "slideFrom": 1,
-                            "endTimeMillis": 0,
+                            "endTimeMillis": 9999999999999,
                             "orientation": 1,
                             "textAlign": 2,
                             "optOut": false,

--- a/Tests/UITests/ResponseStubs/modal-image-only.json
+++ b/Tests/UITests/ResponseStubs/modal-image-only.json
@@ -7,7 +7,7 @@
                 "campaignId": "modal-image-only",
                 "maxImpressions": 999,
                 "type": 1,
-                "isTest": true,
+                "isTest": false,
                 "isCampaignDismissable": false,
                 "hasNoEndDate": false,
                 "infiniteImpressions": true,
@@ -35,7 +35,7 @@
                     "messageSettings": {
                         "displaySettings": {
                             "slideFrom": 1,
-                            "endTimeMillis": 0,
+                            "endTimeMillis": 9999999999999,
                             "orientation": 1,
                             "textAlign": 2,
                             "optOut": false,

--- a/Tests/UITests/ResponseStubs/modal-text-image.json
+++ b/Tests/UITests/ResponseStubs/modal-text-image.json
@@ -7,7 +7,7 @@
                 "campaignId": "modal-text-image",
                 "maxImpressions": 999,
                 "type": 1,
-                "isTest": true,
+                "isTest": false,
                 "isCampaignDismissable": true,
                 "hasNoEndDate": false,
                 "infiniteImpressions": true,
@@ -35,7 +35,7 @@
                     "messageSettings": {
                         "displaySettings": {
                             "slideFrom": 1,
-                            "endTimeMillis": 0,
+                            "endTimeMillis": 9999999999999,
                             "orientation": 1,
                             "textAlign": 2,
                             "optOut": false,

--- a/Tests/UITests/ResponseStubs/modal-text-only.json
+++ b/Tests/UITests/ResponseStubs/modal-text-only.json
@@ -7,7 +7,7 @@
                 "campaignId": "modal-text-only",
                 "maxImpressions": 999,
                 "type": 1,
-                "isTest": true,
+                "isTest": false,
                 "isCampaignDismissable": true,
                 "hasNoEndDate": false,
                 "infiniteImpressions": true,
@@ -34,7 +34,7 @@
                     "messageSettings": {
                         "displaySettings": {
                             "slideFrom": 1,
-                            "endTimeMillis": 0,
+                            "endTimeMillis": 9999999999999,
                             "orientation": 1,
                             "textAlign": 2,
                             "optOut": false,

--- a/Tests/UITests/ResponseStubs/slide-up-close.json
+++ b/Tests/UITests/ResponseStubs/slide-up-close.json
@@ -7,7 +7,7 @@
                 "campaignId": "slide-up-redirect",
                 "maxImpressions": 999,
                 "type": 3,
-                "isTest": true,
+                "isTest": false,
                 "isCampaignDismissable": true,
                 "hasNoEndDate": false,
                 "infiniteImpressions": true,
@@ -34,7 +34,7 @@
                     "messageSettings": {
                         "displaySettings": {
                             "slideFrom": 1,
-                            "endTimeMillis": 0,
+                            "endTimeMillis": 9999999999999,
                             "orientation": 1,
                             "textAlign": 2,
                             "optOut": true,


### PR DESCRIPTION
# Description
Test campaigns are now saved in cache. Their `impressionLeft` value and endDate are now validated before display.
The PR fixes the issue when test campaigns are observed multiple times in situation where they are still present in the ping response data (after sending impression request).

## Links
SDKCF-5027

# Checklist
- [X] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [X] I wrote/updated tests for new/changed code
- [X] I removed all sensitive data **before every commit**, including API endpoints and keys
- [X] I ran `fastlane ci` without errors
