### PR TITLE
improve: draw button's border if it has the same bg color as campaign (SDKCF-4859)

### DIFF
--- a/RInAppMessaging.xcodeproj/project.pbxproj
+++ b/RInAppMessaging.xcodeproj/project.pbxproj
@@ -37,6 +37,7 @@
 		45563B03240614AE004EAFD3 /* ReadyCampaignDispatcherSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45563B02240614AE004EAFD3 /* ReadyCampaignDispatcherSpec.swift */; };
 		45563B0724064D78004EAFD3 /* CampaignRepositorySpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45563B0624064D78004EAFD3 /* CampaignRepositorySpec.swift */; };
 		4557A8B1257E544C00C9D241 /* AccountRepositorySpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4557A8B0257E544C00C9D241 /* AccountRepositorySpec.swift */; };
+		455FEBE227F214640064470D /* UIColorExtensionSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 455FEBE127F214640064470D /* UIColorExtensionSpec.swift */; };
 		4560062C26FB968B003227FE /* UserInfoProviderSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4560062B26FB968B003227FE /* UserInfoProviderSpec.swift */; };
 		456FE1E72428513200304872 /* ErrorReportableSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 456FE1E62428513200304872 /* ErrorReportableSpec.swift */; };
 		456FE1E924288C6500304872 /* CampaignTriggerAgentSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 456FE1E824288C6500304872 /* CampaignTriggerAgentSpec.swift */; };
@@ -142,6 +143,7 @@
 		45563B02240614AE004EAFD3 /* ReadyCampaignDispatcherSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadyCampaignDispatcherSpec.swift; sourceTree = "<group>"; };
 		45563B0624064D78004EAFD3 /* CampaignRepositorySpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CampaignRepositorySpec.swift; sourceTree = "<group>"; };
 		4557A8B0257E544C00C9D241 /* AccountRepositorySpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountRepositorySpec.swift; sourceTree = "<group>"; };
+		455FEBE127F214640064470D /* UIColorExtensionSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIColorExtensionSpec.swift; sourceTree = "<group>"; };
 		4560062B26FB968B003227FE /* UserInfoProviderSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserInfoProviderSpec.swift; sourceTree = "<group>"; };
 		456FE1E62428513200304872 /* ErrorReportableSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorReportableSpec.swift; sourceTree = "<group>"; };
 		456FE1E824288C6500304872 /* CampaignTriggerAgentSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CampaignTriggerAgentSpec.swift; sourceTree = "<group>"; };
@@ -407,6 +409,7 @@
 				45ADA541247D206B00A9E2A3 /* RouterSpec.swift */,
 				4534947123C6ABF700189A81 /* SerializationSpec.swift */,
 				45EA720425B71FA2001B2049 /* UIApplicationExtensionSpec.swift */,
+				455FEBE127F214640064470D /* UIColorExtensionSpec.swift */,
 				4BBE7EAE274F1A6A0039D2BF /* UIFontExtensionSpec.swift */,
 				45EA720C25B72002001B2049 /* UIViewExtensionSpec.swift */,
 				4538BCF5262AE8FA009952BE /* UserDataCacheSpec.swift */,
@@ -718,6 +721,7 @@
 				45BDFD0724232714004DEA0C /* PublicAPISpec.swift in Sources */,
 				459DE86C2407B5750002F451 /* CustomEventSpec.swift in Sources */,
 				45563B0724064D78004EAFD3 /* CampaignRepositorySpec.swift in Sources */,
+				455FEBE227F214640064470D /* UIColorExtensionSpec.swift in Sources */,
 				456FE1EB2428C51E00304872 /* CommonUtilitySpec.swift in Sources */,
 				4538BAE326282DE4009952BE /* GetConfigResponseSpec.swift in Sources */,
 				C9827558262C423C00476505 /* BackoffSpec.swift in Sources */,

--- a/Sources/RInAppMessaging/Extensions/UIColor+IAM.swift
+++ b/Sources/RInAppMessaging/Extensions/UIColor+IAM.swift
@@ -16,7 +16,7 @@ internal extension UIColor {
         }
     }
 
-    static let buttonBorderDefaultColor = UIColor(hexString: "#D1D1D1")!
+    static let buttonBorderDefaultColor = UIColor(hexString: "#D1D1D1") ?? .lightGray
 
     /// Returns perceived brightness value based on [Darel Rex Finley's HSP Colour Model](http://alienryderflex.com/hsp.html) from 0 to 1.0 (max brightness)
     var brightness: CGFloat {

--- a/Sources/RInAppMessaging/Extensions/UIColor+IAM.swift
+++ b/Sources/RInAppMessaging/Extensions/UIColor+IAM.swift
@@ -33,4 +33,23 @@ internal extension UIColor {
         return brightness > threshold
     }
 
+    /// Returns distance between colors based on the low-cost approximation algorithm from [](https://www.compuphase.com/cmetric.htm)
+    func distance(from: UIColor) -> Int {
+        var (r1, g1, b1) = (CGFloat(0), CGFloat(0), CGFloat(0))
+        var (r2, g2, b2) = (CGFloat(0), CGFloat(0), CGFloat(0))
+        getRed(&r1, green: &g1, blue: &b1, alpha: nil) // works with RGB, HSB, extendedGray
+        from.getRed(&r2, green: &g2, blue: &b2, alpha: nil)
+
+        let rMean = (r1 * 255 + r2 * 255) / 2
+        let dR = r1 * 255 - r2 * 255
+        let dG = g1 * 255 - g2 * 255
+        let dB = b1 * 255 - b2 * 255
+
+        return Int(round(sqrt((2 + rMean / 256) * dR * dR + 4 * dG * dG + (2 + (255 - rMean) / 256) * dB * dB)))
+    }
+
+    func isComparable(to anotherColor: UIColor) -> Bool {
+        let threshold = 15
+        return distance(from: anotherColor) <= threshold
+    }
 }

--- a/Sources/RInAppMessaging/Extensions/UIColor+IAM.swift
+++ b/Sources/RInAppMessaging/Extensions/UIColor+IAM.swift
@@ -1,4 +1,9 @@
 import UIKit
+#if canImport(RSDKUtilsMain)
+import RSDKUtilsMain // SPM version
+#else
+import RSDKUtils
+#endif
 
 /// Extension to `UIColor` class to provide addtional initializers required by InAppMessaging.
 internal extension UIColor {
@@ -10,6 +15,8 @@ internal extension UIColor {
             return white.withAlphaComponent(0.4)
         }
     }
+
+    static let buttonBorderDefaultColor = UIColor(hexString: "#D1D1D1")!
 
     /// Returns perceived brightness value based on [Darel Rex Finley's HSP Colour Model](http://alienryderflex.com/hsp.html) from 0 to 1.0 (max brightness)
     var brightness: CGFloat {

--- a/Sources/RInAppMessaging/Views/Components/ActionButton.swift
+++ b/Sources/RInAppMessaging/Views/Components/ActionButton.swift
@@ -1,4 +1,9 @@
 import UIKit
+#if canImport(RSDKUtilsMain)
+import RSDKUtilsMain // SPM version
+#else
+import RSDKUtils
+#endif
 
 // Button object used in campaigns's message view.
 internal class ActionButton: UIButton {
@@ -8,7 +13,8 @@ internal class ActionButton: UIButton {
         static let minFontSize: CGFloat = 10
         static let labelMargin = UIEdgeInsets(top: 8, left: 8, bottom: 8, right: 8)
         static let cornerRadius: CGFloat = 8
-        static let borderWidth: CGFloat = 0
+        static let borderWidth: CGFloat = 0.5
+        static let borderColor = UIColor(hexString: "#D1D1D1")!
     }
 
     let impression: ImpressionType
@@ -42,8 +48,8 @@ internal class ActionButton: UIButton {
 
         layer.cornerRadius = Constants.cornerRadius
         self.backgroundColor = viewModel.backgroundColor
-        layer.borderColor = viewModel.textColor.cgColor
-        layer.borderWidth = Constants.borderWidth
+        layer.borderColor = Constants.borderColor.cgColor
+        layer.borderWidth = viewModel.shouldDrawBorder ? Constants.borderWidth : 0
     }
 
     private func addLabel() {

--- a/Sources/RInAppMessaging/Views/Components/ActionButton.swift
+++ b/Sources/RInAppMessaging/Views/Components/ActionButton.swift
@@ -1,9 +1,4 @@
 import UIKit
-#if canImport(RSDKUtilsMain)
-import RSDKUtilsMain // SPM version
-#else
-import RSDKUtils
-#endif
 
 // Button object used in campaigns's message view.
 internal class ActionButton: UIButton {
@@ -14,7 +9,6 @@ internal class ActionButton: UIButton {
         static let labelMargin = UIEdgeInsets(top: 8, left: 8, bottom: 8, right: 8)
         static let cornerRadius: CGFloat = 8
         static let borderWidth: CGFloat = 0.5
-        static let borderColor = UIColor(hexString: "#D1D1D1")!
     }
 
     let impression: ImpressionType
@@ -48,8 +42,12 @@ internal class ActionButton: UIButton {
 
         layer.cornerRadius = Constants.cornerRadius
         self.backgroundColor = viewModel.backgroundColor
-        layer.borderColor = Constants.borderColor.cgColor
         layer.borderWidth = viewModel.shouldDrawBorder ? Constants.borderWidth : 0
+        if viewModel.backgroundColor == .white {
+            layer.borderColor = UIColor.buttonBorderDefaultColor.cgColor
+        } else {
+            layer.borderColor = viewModel.textColor.cgColor
+        }
     }
 
     private func addLabel() {

--- a/Sources/RInAppMessaging/Views/Components/ActionButtonViewModel.swift
+++ b/Sources/RInAppMessaging/Views/Components/ActionButtonViewModel.swift
@@ -4,4 +4,5 @@ internal struct ActionButtonViewModel: Equatable {
     let text: String
     let textColor: UIColor
     let backgroundColor: UIColor
+    let shouldDrawBorder: Bool
 }

--- a/Sources/RInAppMessaging/Views/Presenters/FullViewPresenter.swift
+++ b/Sources/RInAppMessaging/Views/Presenters/FullViewPresenter.swift
@@ -10,11 +10,14 @@ internal protocol FullViewPresenterType: BaseViewPresenterType {
 
 internal class FullViewPresenter: BaseViewPresenter, FullViewPresenterType {
     weak var view: FullViewType?
+    private var viewBackgroundColor: UIColor {
+        UIColor(hexString: campaign.data.messagePayload.backgroundColor) ?? .white
+    }
 
     override func viewDidInitialize() {
         let messagePayload = campaign.data.messagePayload
         let viewModel = FullViewModel(image: associatedImage,
-                                      backgroundColor: UIColor(hexString: messagePayload.backgroundColor) ?? .white,
+                                      backgroundColor: viewBackgroundColor,
                                       title: messagePayload.title,
                                       messageBody: messagePayload.messageBody,
                                       header: messagePayload.header,
@@ -38,14 +41,15 @@ internal class FullViewPresenter: BaseViewPresenter, FullViewPresenterType {
 
         var buttonsToAdd = [(ActionButton, ActionButtonViewModel)]()
         for (index, button) in supportedButtons.enumerated() {
+            let backgroundColor = UIColor(hexString: button.buttonBackgroundColor) ?? .white
             buttonsToAdd.append((
                 ActionButton(impression: index == 0 ? ImpressionType.actionOne : ImpressionType.actionTwo,
                              uri: button.buttonBehavior.uri,
                              trigger: button.campaignTrigger),
                 ActionButtonViewModel(text: button.buttonText,
                                       textColor: UIColor(hexString: button.buttonTextColor) ?? .black,
-                                      backgroundColor: UIColor(hexString: button.buttonBackgroundColor) ?? .white)))
-
+                                      backgroundColor: UIColor(hexString: button.buttonBackgroundColor) ?? .white,
+                                      shouldDrawBorder: viewBackgroundColor == backgroundColor)))
         }
 
         view?.addButtons(buttonsToAdd)

--- a/Sources/RInAppMessaging/Views/Presenters/FullViewPresenter.swift
+++ b/Sources/RInAppMessaging/Views/Presenters/FullViewPresenter.swift
@@ -49,7 +49,7 @@ internal class FullViewPresenter: BaseViewPresenter, FullViewPresenterType {
                 ActionButtonViewModel(text: button.buttonText,
                                       textColor: UIColor(hexString: button.buttonTextColor) ?? .black,
                                       backgroundColor: UIColor(hexString: button.buttonBackgroundColor) ?? .white,
-                                      shouldDrawBorder: viewBackgroundColor == backgroundColor)))
+                                      shouldDrawBorder: backgroundColor.isComparable(to: viewBackgroundColor))))
         }
 
         view?.addButtons(buttonsToAdd)

--- a/Tests/Tests/UIColorExtensionSpec.swift
+++ b/Tests/Tests/UIColorExtensionSpec.swift
@@ -27,6 +27,22 @@ class UIColorExtensionsSpec: QuickSpec {
                     expect(UIColor.white.isBright).to(beTrue())
                 }
             }
+
+            context("when calling isComparable method") {
+                it("should return true for the same colors") {
+                    expect(UIColor.white.isComparable(to: .white)).to(beTrue())
+                    expect(UIColor.blue.isComparable(to: .blue)).to(beTrue())
+                }
+                it("should return false for obviously different, contrasting colors") {
+                    expect(UIColor.white.isComparable(to: .black)).to(beFalse())
+                    expect(UIColor.green.isComparable(to: .blue)).to(beFalse())
+                }
+                it("should return true for very similar colors") {
+                    expect(UIColor.black.isComparable(to: UIColor(red: 5/255.0, green: 5/255.0, blue: 5/255.0, alpha: 1))).to(beTrue())
+                    expect(UIColor(red: 1/255.0, green: 2/255.0, blue: 3/255.0, alpha: 1).isComparable(
+                        to: UIColor(red: 1/255.0, green: 3/255.0, blue: 2/255.0, alpha: 1))).to(beTrue())
+                }
+            }
         }
     }
 }

--- a/Tests/Tests/ViewPresenterSpec.swift
+++ b/Tests/Tests/ViewPresenterSpec.swift
@@ -333,10 +333,12 @@ class ViewPresenterSpec: QuickSpec {
                     expect(view.addedButtons.map({ $0.viewModel })).to(elementsEqual([
                         ActionButtonViewModel(text: "button1",
                                               textColor: .blackRGB,
-                                              backgroundColor: .blackRGB),
+                                              backgroundColor: .blackRGB,
+                                              shouldDrawBorder: false),
                         ActionButtonViewModel(text: "button2",
                                               textColor: .whiteRGB,
-                                              backgroundColor: .whiteRGB)
+                                              backgroundColor: .whiteRGB,
+                                              shouldDrawBorder: true)
                     ]))
                 }
 
@@ -358,7 +360,8 @@ class ViewPresenterSpec: QuickSpec {
                     expect(view.addedButtons.map({ $0.viewModel })).to(elementsEqual([
                         ActionButtonViewModel(text: "button1",
                                               textColor: .whiteRGB,
-                                              backgroundColor: .whiteRGB)
+                                              backgroundColor: .whiteRGB,
+                                              shouldDrawBorder: true)
                     ]))
                 }
             }


### PR DESCRIPTION
# Description
Action button should have a border when campaign body has the same background color.
<img src="https://user-images.githubusercontent.com/13205475/160299949-f1bca6a6-12c8-46b7-982c-16b1edcb5861.png" width="200" />

## Links
SDKCF-4859

# Checklist
- [X] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [ ] I wrote/updated tests for new/changed code
- [X] I removed all sensitive data **before every commit**, including API endpoints and keys
- [ ] I ran `fastlane ci` without errors
