### PR TITLE
fix: fix image spacing when exit button is hidden (SDKCF-5003)

### DIFF
--- a/Sources/RInAppMessaging/Resources/FullView.xib
+++ b/Sources/RInAppMessaging/Resources/FullView.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -36,35 +36,35 @@
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="9fo-EW-lL9">
-                    <rect key="frame" x="0.0" y="23.5" width="414" height="584"/>
+                    <rect key="frame" x="0.0" y="20.5" width="414" height="590"/>
                     <subviews>
                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="sQ8-dx-V3p">
-                            <rect key="frame" x="0.0" y="0.0" width="414" height="584"/>
+                            <rect key="frame" x="0.0" y="0.0" width="414" height="590"/>
                             <subviews>
                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="LBu-gO-Kcj">
-                                    <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="414" height="50"/>
                                     <subviews>
-                                        <view contentMode="scaleToFill" placeholderIntrinsicWidth="25" placeholderIntrinsicHeight="25" translatesAutoresizingMaskIntoConstraints="NO" id="ZII-OX-pA4" customClass="ExitButton" customModule="RInAppMessaging">
-                                            <rect key="frame" x="389" y="0.0" width="25" height="25"/>
+                                        <view contentMode="scaleToFill" placeholderIntrinsicWidth="44" placeholderIntrinsicHeight="44" translatesAutoresizingMaskIntoConstraints="NO" id="ZII-OX-pA4" customClass="ExitButton" customModule="RInAppMessaging">
+                                            <rect key="frame" x="370" y="0.0" width="44" height="50"/>
                                             <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         </view>
                                     </subviews>
                                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                     <constraints>
                                         <constraint firstItem="ZII-OX-pA4" firstAttribute="top" secondItem="LBu-gO-Kcj" secondAttribute="top" id="39c-xm-st0"/>
-                                        <constraint firstAttribute="height" constant="44" id="asb-ck-C1h"/>
+                                        <constraint firstAttribute="height" secondItem="ZII-OX-pA4" secondAttribute="height" id="QOb-kS-rDu"/>
                                         <constraint firstAttribute="trailing" secondItem="ZII-OX-pA4" secondAttribute="trailing" id="m2u-Xf-tSy"/>
                                     </constraints>
                                 </view>
                                 <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="d8e-45-aEu">
-                                    <rect key="frame" x="0.0" y="44" width="414" height="200"/>
+                                    <rect key="frame" x="0.0" y="50" width="414" height="200"/>
                                     <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                     <constraints>
                                         <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="200" id="pkt-zd-Nz9"/>
                                     </constraints>
                                 </view>
                                 <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" showsHorizontalScrollIndicator="NO" contentInsetAdjustmentBehavior="never" translatesAutoresizingMaskIntoConstraints="NO" id="R2i-po-Za0">
-                                    <rect key="frame" x="0.0" y="44" width="414" height="426"/>
+                                    <rect key="frame" x="0.0" y="50" width="414" height="426"/>
                                     <subviews>
                                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="kFe-rN-o5K">
                                             <rect key="frame" x="0.0" y="0.0" width="414" height="146"/>
@@ -109,7 +109,7 @@
                                     </constraints>
                                 </scrollView>
                                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="IpI-Mq-vby">
-                                    <rect key="frame" x="0.0" y="470" width="414" height="96"/>
+                                    <rect key="frame" x="0.0" y="476" width="414" height="96"/>
                                     <subviews>
                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="wrt-M2-rbv" userLabel="Spacer">
                                             <rect key="frame" x="0.0" y="0.0" width="414" height="16"/>
@@ -138,7 +138,7 @@
                                     </subviews>
                                 </stackView>
                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="QTR-Lw-dcX" userLabel="Spacer">
-                                    <rect key="frame" x="0.0" y="566" width="414" height="18"/>
+                                    <rect key="frame" x="0.0" y="572" width="414" height="18"/>
                                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                     <constraints>
                                         <constraint firstAttribute="height" constant="18" id="ITU-je-EpF"/>


### PR DESCRIPTION
# Description
For campaigns without X button:
* image only - hide the space on top
* text with image - keep the space on top (margin)
* text only - keep the space on top (margin)

## Links
SDKCF-5003

# Checklist
- [X] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [ ] I wrote/updated tests for new/changed code
- [X] I removed all sensitive data **before every commit**, including API endpoints and keys
- [X] I ran `fastlane ci` without errors
