### PR TITLE
fix: retain impressionsLeft value for test campaigns (SDKCF-5027)

### DIFF
--- a/Sources/RInAppMessaging/EventMatcher.swift
+++ b/Sources/RInAppMessaging/EventMatcher.swift
@@ -53,7 +53,6 @@ internal class EventMatcher: EventMatcherType {
 
         campaignRepository.list.forEach { campaign in
             guard let campaignTriggers = campaign.data.triggers else {
-                Logger.debug("campaign (\(campaign.id)) has no triggers.")
                 return
             }
             guard isEventMatchingOneOfTriggers(event: event, triggers: campaignTriggers) else {

--- a/Sources/RInAppMessaging/Models/Responses/PingResponse.swift
+++ b/Sources/RInAppMessaging/Models/Responses/PingResponse.swift
@@ -43,7 +43,10 @@ internal struct Campaign: Codable, Hashable {
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         let decodedData = try container.decode(CampaignData.self, forKey: .data)
-        let maxImpressions = decodedData.infiniteImpressions ? Int.max : decodedData.maxImpressions
+        var maxImpressions = decodedData.infiniteImpressions ? Int.max : decodedData.maxImpressions
+        if decodedData.isTest {
+            maxImpressions = 1
+        }
         impressionsLeft = (try? container.decode(Int.self, forKey: .impressionsLeft)) ?? maxImpressions
         isOptedOut = (try? container.decode(Bool.self, forKey: .isOptedOut)) ?? false
         self.data = decodedData

--- a/Sources/RInAppMessaging/Repositories/CampaignRepository.swift
+++ b/Sources/RInAppMessaging/Repositories/CampaignRepository.swift
@@ -69,18 +69,9 @@ internal class CampaignRepository: CampaignRepositoryType {
     func syncWith(list: [Campaign], timestampMilliseconds: Int64) {
         lastSyncInMilliseconds = timestampMilliseconds
         let oldList = campaigns.get()
-        var updatedList = [Campaign]()
-
-        let (testCampaigns, newCampaigns) = list.reduce(into: ([Campaign](), [Campaign]())) { partialResult, campaign in
-            if campaign.data.isTest {
-                partialResult.0.append(campaign)
-            } else {
-                partialResult.1.append(campaign)
-            }
-        }
 
         let retainImpressionsLeftValue = true // Left for feature flag functionality
-        newCampaigns.forEach { newCampaign in
+        let updatedList: [Campaign] = list.map { newCampaign in
             var updatedCampaign = newCampaign
             if let oldCampaign = oldList.first(where: { $0.id == newCampaign.id }) {
                 updatedCampaign = Campaign.updatedCampaign(updatedCampaign, asOptedOut: oldCampaign.isOptedOut)
@@ -94,10 +85,10 @@ internal class CampaignRepository: CampaignRepositoryType {
                     updatedCampaign = Campaign.updatedCampaign(updatedCampaign, withImpressionLeft: newImpressionsLeft)
                 }
             }
-            updatedList.append(updatedCampaign)
+            return updatedCampaign
         }
-        campaigns.set(value: updatedList + testCampaigns)
-        saveDataToCache(updatedList + testCampaigns)
+        campaigns.set(value: updatedList)
+        saveDataToCache(updatedList)
     }
 
     @discardableResult

--- a/Tests/Tests/CampaignRepositorySpec.swift
+++ b/Tests/Tests/CampaignRepositorySpec.swift
@@ -73,13 +73,13 @@ class CampaignRepositorySpec: QuickSpec {
                     expect(firstPersistedCampaign?.impressionsLeft).to(equal(2))
                 }
 
-                it("will not persist impressionsLeft value for test campaigns") {
+                it("will persist impressionsLeft value for test campaigns") {
                     campaignRepository.syncWith(list: [testCampaign], timestampMilliseconds: 0)
                     campaignRepository.decrementImpressionsLeftInCampaign(id: testCampaign.id)
                     expect(firstPersistedCampaign?.impressionsLeft).to(equal(2))
 
                     campaignRepository.syncWith(list: [testCampaign], timestampMilliseconds: 0)
-                    expect(firstPersistedCampaign?.impressionsLeft).to(equal(3))
+                    expect(firstPersistedCampaign?.impressionsLeft).to(equal(2))
                 }
 
                 it("will persist isOptedOut value") {

--- a/Tests/Tests/Payloads/ping_success.json
+++ b/Tests/Tests/Payloads/ping_success.json
@@ -111,6 +111,70 @@
                     }
                 }
             }
+        },
+        {
+            "campaignData": {
+                "campaignId": "testId1",
+                "maxImpressions": 5,
+                "type": 1,
+                "isTest": true,
+                "isCampaignDismissable": true,
+                "hasNoEndDate": false,
+                "infiniteImpressions": true,
+                "triggers": [
+                    {
+                        "type": 1,
+                        "eventType": 1,
+                        "eventName": "Launch the App Event",
+                        "attributes": []
+                    }
+                ],
+                "messagePayload": {
+                    "title": "Campaign with image test-1",
+                    "messageBody": "body",
+                    "header": "ABC DEF GHI ",
+                    "titleColor": "#000000",
+                    "headerColor": "#000000",
+                    "messageBodyColor": "#000000",
+                    "backgroundColor": "#ffffff",
+                    "frameColor": "#ffffff",
+                    "resource": {
+                        "cropType": 2
+                    },
+                    "messageSettings": {
+                        "displaySettings": {
+                            "slideFrom": 1,
+                            "endTimeMillis": 1582873200000,
+                            "orientation": 1,
+                            "textAlign": 2,
+                            "optOut": true,
+                            "delay": 3000,
+                            "html": false
+                        },
+                        "controlSettings": {
+                            "buttons": [
+                                {
+                                    "buttonText": "Cancel",
+                                    "buttonTextColor": "#1d1d1d",
+                                    "buttonBackgroundColor": "#f76b6b",
+                                    "buttonBehavior": {
+                                        "action": 3
+                                    }
+                                },
+                                {
+                                    "buttonText": "Portal",
+                                    "buttonTextColor": "#1d1d1d",
+                                    "buttonBackgroundColor": "#ffffff",
+                                    "buttonBehavior": {
+                                        "action": 1,
+                                        "uri": "https://rakuten.co.jp"
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
         }
     ]
 }

--- a/Tests/Tests/SerializationSpec.swift
+++ b/Tests/Tests/SerializationSpec.swift
@@ -27,6 +27,12 @@ class SerializationSpec: QuickSpec {
                 expect(campaign.impressionsLeft).to(equal(Int.max))
             }
 
+            it("should always set impressionsLeft to 1 for test campaigns (ignore infiniteImpressions and maxImpressions)") {
+                let pingResponse: PingResponse = TestHelpers.getJSONModel(fileName: "ping_success")
+                let campaign = pingResponse.data[2]
+                expect(campaign.impressionsLeft).to(equal(1))
+            }
+
             it("should return true for isOutdated even if endTimeMillis is in the past") {
                 let campaign = MockedCampaigns.outdatedCampaignWithNoEndDate
                 expect(campaign.isOutdated).to(beFalse())

--- a/Tests/UITests/FullScreenViewSpec.swift
+++ b/Tests/UITests/FullScreenViewSpec.swift
@@ -48,7 +48,7 @@ class FullScreenViewSpec: QuickSpec {
                     launchAppIfNecessary(context: "full-text-only")
                     if !iamView.exists {
                         app.buttons["login_successful"].tap()
-                        expect(iamView.exists).toEventually(beTrue(), timeout: .seconds(2))
+                        expect(iamView.exists).toEventually(beTrue(), timeout: .seconds(5))
                     }
                 }
 


### PR DESCRIPTION
# Description
In the previous SDKCF-5027 PR I forgot to update sync method in CampaignRepository to retain cached `impressionsLeft` value in test campaigns.

EDIT: Added logic to ignore maxImpressions and infiniteImpressions values

## Links
SDKCF-5027

# Checklist
- [X] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [X] I wrote/updated tests for new/changed code
- [X] I removed all sensitive data **before every commit**, including API endpoints and keys
- [ ] I ran `fastlane ci` without errors
