### PR TITLE
fix: fix color comparison (SDKCF-4859)

### DIFF
--- a/Sources/RInAppMessaging/Extensions/UIColor+IAM.swift
+++ b/Sources/RInAppMessaging/Extensions/UIColor+IAM.swift
@@ -52,4 +52,14 @@ internal extension UIColor {
         let threshold = 15
         return distance(from: anotherColor) <= threshold
     }
+
+    func isRGBAEqual(to anotherColor: UIColor) -> Bool {
+        var rgba1: (r: CGFloat, g: CGFloat, b: CGFloat, a: CGFloat) = (0, 0, 0, 0)
+        var rgba2: (r: CGFloat, g: CGFloat, b: CGFloat, a: CGFloat) = (0, 0, 0, 0)
+
+        getRed(&rgba1.r, green: &rgba1.g, blue: &rgba1.b, alpha: &rgba1.a)
+        anotherColor.getRed(&rgba2.r, green: &rgba2.g, blue: &rgba2.b, alpha: &rgba2.a)
+
+        return rgba1 == rgba2
+    }
 }

--- a/Sources/RInAppMessaging/Views/Components/ActionButton.swift
+++ b/Sources/RInAppMessaging/Views/Components/ActionButton.swift
@@ -43,7 +43,7 @@ internal class ActionButton: UIButton {
         layer.cornerRadius = Constants.cornerRadius
         self.backgroundColor = viewModel.backgroundColor
         layer.borderWidth = viewModel.shouldDrawBorder ? Constants.borderWidth : 0
-        if viewModel.backgroundColor == .white {
+        if viewModel.backgroundColor.isRGBAEqual(to: .white) {
             layer.borderColor = UIColor.buttonBorderDefaultColor.cgColor
         } else {
             layer.borderColor = viewModel.textColor.cgColor

--- a/Tests/Tests/UIColorExtensionSpec.swift
+++ b/Tests/Tests/UIColorExtensionSpec.swift
@@ -33,14 +33,39 @@ class UIColorExtensionsSpec: QuickSpec {
                     expect(UIColor.white.isComparable(to: .white)).to(beTrue())
                     expect(UIColor.blue.isComparable(to: .blue)).to(beTrue())
                 }
+
                 it("should return false for obviously different, contrasting colors") {
                     expect(UIColor.white.isComparable(to: .black)).to(beFalse())
                     expect(UIColor.green.isComparable(to: .blue)).to(beFalse())
                 }
+
                 it("should return true for very similar colors") {
                     expect(UIColor.black.isComparable(to: UIColor(red: 5/255.0, green: 5/255.0, blue: 5/255.0, alpha: 1))).to(beTrue())
                     expect(UIColor(red: 1/255.0, green: 2/255.0, blue: 3/255.0, alpha: 1).isComparable(
                         to: UIColor(red: 1/255.0, green: 3/255.0, blue: 2/255.0, alpha: 1))).to(beTrue())
+                }
+            }
+
+            context("when calling isRGBAEqual method") {
+                it("should return true for the same colors") {
+                    expect(UIColor.white.isRGBAEqual(to: .white)).to(beTrue())
+                }
+
+                it("should return true for the same colors but in different color spaces") {
+                    let grayscaleColor = UIColor(white: 0.2, alpha: 0.8)
+                    let rgbColor = UIColor(red: 0.2, green: 0.2, blue: 0.2, alpha: 0.8)
+                    let hsvColor = UIColor(hue: 0, saturation: 0, brightness: 0.2, alpha: 0.8)
+
+                    expect(grayscaleColor.isRGBAEqual(to: rgbColor)).to(beTrue())
+                    expect(rgbColor.isRGBAEqual(to: hsvColor)).to(beTrue())
+                }
+
+                it("should return false for different colors") {
+                    expect(UIColor.green.isRGBAEqual(to: .blue)).to(beFalse())
+                }
+
+                it("should return false for the same colors but with different alpha falue") {
+                    expect(UIColor.white.isRGBAEqual(to: .white.withAlphaComponent(0.3))).to(beFalse())
                 }
             }
         }


### PR DESCRIPTION
# Description
`==` operator or `isEqualTo(:)` method don't work well when comparing two colors from different color spaces

## Links
SDKCF-4859

# Checklist
- [X] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [X] I wrote/updated tests for new/changed code
- [X] I removed all sensitive data **before every commit**, including API endpoints and keys
- [X] I ran `fastlane ci` without errors
