### PR TITLE
chore: bump RSDKUtils to 3.0.0, fix imports (SDKCF-5246)

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/rakutentech/ios-sdkutils.git",
         "state": {
           "branch": null,
-          "revision": "5b56df0859c94ec4c253d5554eb568b4e6a4214d",
-          "version": "2.1.0"
+          "revision": "82592c03840b1ced37d1902bd0daef916a754999",
+          "version": "3.0.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
             targets: ["RInAppMessaging"])
     ],
     dependencies: [
-        .package(name: "RSDKUtils", url: "https://github.com/rakutentech/ios-sdkutils.git", .upToNextMajor(from: "2.1.0"))
+        .package(name: "RSDKUtils", url: "https://github.com/rakutentech/ios-sdkutils.git", .upToNextMinor(from: "3.0.0"))
     ],
     targets: [
         .target(

--- a/Podfile
+++ b/Podfile
@@ -6,7 +6,7 @@ secrets = ["RIAM_CONFIG_URL", "RIAM_APP_SUBSCRIPTION_KEY"]
 target 'RInAppMessaging_Example' do
   pod 'RInAppMessaging', :path => '.'
   pod 'SwiftLint', '~> 0.42'
-  pod 'RSDKUtils', '~> 2.1', :testspecs => ['Nimble', 'TestHelpers']
+  pod 'RSDKUtils', '~> 3.0.0', :testspecs => ['Nimble', 'TestHelpers']
 
   abstract_target 'Tests-Common' do
     pod 'Quick'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -8,16 +8,16 @@ PODS:
   - Nimble (9.2.1)
   - Quick (4.0.0)
   - RInAppMessaging (6.2.0-snapshot):
-    - RSDKUtils (~> 2.1)
-  - RSDKUtils (2.1.0):
-    - RSDKUtils/Main (= 2.1.0)
-  - RSDKUtils/Main (2.1.0):
+    - RSDKUtils (~> 3.0.0)
+  - RSDKUtils (3.0.0):
+    - RSDKUtils/Main (= 3.0.0)
+  - RSDKUtils/Main (3.0.0):
     - RSDKUtils/RLogger
-  - RSDKUtils/Nimble (2.1.0):
+  - RSDKUtils/Nimble (3.0.0):
     - Nimble
     - RSDKUtils/Main
-  - RSDKUtils/RLogger (2.1.0)
-  - RSDKUtils/TestHelpers (2.1.0):
+  - RSDKUtils/RLogger (3.0.0)
+  - RSDKUtils/TestHelpers (3.0.0):
     - RSDKUtils/Main
   - Shock (6.0.3):
     - GRMustache.swift (~> 4.0.1)
@@ -40,9 +40,9 @@ DEPENDENCIES:
   - Nimble
   - Quick
   - RInAppMessaging (from `.`)
-  - RSDKUtils (~> 2.1)
-  - RSDKUtils/Nimble (~> 2.1)
-  - RSDKUtils/TestHelpers (~> 2.1)
+  - RSDKUtils (~> 3.0.0)
+  - RSDKUtils/Nimble (~> 3.0.0)
+  - RSDKUtils/TestHelpers (~> 3.0.0)
   - Shock (~> 6.0.0)
   - SwiftLint (~> 0.42)
 
@@ -76,14 +76,14 @@ SPEC CHECKSUMS:
   GRMustache.swift: a6436504284b22b4b05daf5f46f77bd3fe00a9a2
   Nimble: e7e615c0335ee4bf5b0d786685451e62746117d5
   Quick: 6473349e43b9271a8d43839d9ba1c442ed1b7ac4
-  RInAppMessaging: c8389bcfd9b9f385c715d4869e6449be3f1cbab5
-  RSDKUtils: 47d28aac1347d712e6d4db9a1332cae41b17738f
+  RInAppMessaging: 8d7da5c76ebaba4e6e6fcbcafb0636ac02f94c16
+  RSDKUtils: 36d97c9a41b5663ba56e73c626d27034a6c317e5
   Shock: 94c2d3f5f781fe63317c4ee1621dfb2d4cc271d3
   SwiftLint: d41cc46a2ae58ac6d9f26954bc89f1d72e71fdef
   SwiftNIO: 763188229de166e046cc8975383cca388832e992
   SwiftNIOConcurrencyHelpers: 34d2e9d4d2b7886fa765086e845e6b19417be927
   SwiftNIOHTTP1: c0a9ce48ba256f349af4f09648a0e0939b11a65c
 
-PODFILE CHECKSUM: 8bd240bd2189148291411477038ce08d951f86ec
+PODFILE CHECKSUM: f9faf4923b89e833dabb8c93e5d0bc199d0cbe94
 
 COCOAPODS: 1.11.3

--- a/RInAppMessaging.podspec
+++ b/RInAppMessaging.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = '12.0'
   s.swift_versions = ['5.4', '5.5']
 
-  s.dependency 'RSDKUtils', '~> 2.1'
+  s.dependency 'RSDKUtils', '~> 3.0.0'
   s.source_files = 'Sources/RInAppMessaging/**/*.swift'
   s.resource_bundles = { 'RInAppMessagingResources' => ['Sources/RInAppMessaging/Resources/*'] }
 end

--- a/Sources/RInAppMessaging/Utilities/BundleInfo.swift
+++ b/Sources/RInAppMessaging/Utilities/BundleInfo.swift
@@ -53,10 +53,6 @@ internal extension Bundle {
         module
         #else
 
-        if let resourceBundle = bundle(bundleIdSubstring: "RInAppMessagingResources") {
-            return resourceBundle
-        }
-
         guard let sdkBundleURL = sdk?.resourceURL else {
             return nil
         }


### PR DESCRIPTION
# Description
* Updated RSDKUtils to 3.0.0
Main benefits: removed bundle assets workaround, precise error message when `toAfterTimeout()` fails in unit tests.
~* Fixed imports in unit tests (unfortunately not all tests cases work properly in SPM mode)~
~* Added missing unit tests file~

EDIT: Moved last two points to #172

# Checklist
- [X] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [X] I wrote/updated tests for new/changed code
- [X] I removed all sensitive data **before every commit**, including API endpoints and keys
- [] I ran `fastlane ci` without errors
