### PR TITLE
fix: decrement impressionLeft only after campaign is closed

### DIFF
--- a/Sources/RInAppMessaging/CampaignDispatcher.swift
+++ b/Sources/RInAppMessaging/CampaignDispatcher.swift
@@ -119,7 +119,6 @@ internal class CampaignDispatcher: CampaignDispatcherType, TaskSchedulable {
     }
 
     private func displayCampaign(_ campaign: Campaign, imageBlob: Data? = nil) {
-        campaignRepository.decrementImpressionsLeftInCampaign(id: campaign.id)
         let campaignTitle = campaign.data.messagePayload.title
 
         router.displayCampaign(campaign, associatedImageData: imageBlob, confirmation: {
@@ -139,8 +138,8 @@ internal class CampaignDispatcher: CampaignDispatcherType, TaskSchedulable {
     }
 
     private func commitCampaignDisplay(_ campaign: Campaign, cancelled: Bool) {
-        if cancelled {
-            campaignRepository.incrementImpressionsLeftInCampaign(id: campaign.id)
+        if !cancelled {
+            campaignRepository.decrementImpressionsLeftInCampaign(id: campaign.id)
         }
         guard !queuedCampaignIDs.isEmpty else {
             isDispatching = false

--- a/Sources/RInAppMessaging/Repositories/CampaignRepository.swift
+++ b/Sources/RInAppMessaging/Repositories/CampaignRepository.swift
@@ -53,10 +53,10 @@ internal class CampaignRepository: CampaignRepositoryType {
     private(set) var lastSyncInMilliseconds: Int64?
 
     var list: [Campaign] {
-        return campaigns.get()
+        campaigns.get()
     }
     var resourcesToLock: [LockableResource] {
-        return [campaigns]
+        [campaigns]
     }
 
     init(userDataCache: UserDataCacheable, accountRepository: AccountRepositoryType) {

--- a/Tests/Tests/ReadyCampaignDispatcherSpec.swift
+++ b/Tests/Tests/ReadyCampaignDispatcherSpec.swift
@@ -190,12 +190,12 @@ class ReadyCampaignDispatcherSpec: QuickSpec {
                                 expect(delegate.wasPingCalled).toEventually(beTrue())
                             }
 
-                            it("will restore impressions left value (cancelled display)") {
+                            it("will not decrement impressions left value (cancelled display)") {
                                 let campaign = TestHelpers.generateCampaign(id: "test", title: "[ctx] title")
                                 campaignRepository.list = [campaign]
                                 dispatcher.addToQueue(campaignID: campaign.id)
                                 dispatcher.dispatchAllIfNeeded()
-                                expect(campaignRepository.incrementImpressionsCalls).toAfterTimeout(equal(1))
+                                expect(campaignRepository.decrementImpressionsCalls).toAfterTimeout(equal(0))
                             }
                         }
                     }
@@ -351,22 +351,24 @@ class ReadyCampaignDispatcherSpec: QuickSpec {
                     expect(campaignRepository.decrementImpressionsCalls).toAfterTimeout(equal(1))
                 }
 
-                it("will restore impressions left value if contexts were rejected") {
+                it("will not decrement or increment impressions left value if contexts were rejected") {
                     delegate.shouldShowCampaign = false
                     let campaign = TestHelpers.generateCampaign(id: "test", title: "[ctx] title")
                     campaignRepository.list = [campaign]
                     dispatcher.addToQueue(campaignID: campaign.id)
                     dispatcher.dispatchAllIfNeeded()
-                    expect(campaignRepository.incrementImpressionsCalls).toAfterTimeout(equal(1))
+                    expect(campaignRepository.decrementImpressionsCalls).toAfterTimeout(equal(0))
+                    expect(campaignRepository.incrementImpressionsCalls).to(equal(0))
                 }
 
-                it("will not increment impressions left value if contexts were approved") {
+                it("will decrement impressions left value if contexts were approved") {
                     delegate.shouldShowCampaign = true
                     let campaign = TestHelpers.generateCampaign(id: "test", title: "[ctx] title")
                     campaignRepository.list = [campaign]
                     dispatcher.addToQueue(campaignID: campaign.id)
                     dispatcher.dispatchAllIfNeeded()
-                    expect(campaignRepository.incrementImpressionsCalls).toAfterTimeout(equal(0))
+                    expect(campaignRepository.decrementImpressionsCalls).toAfterTimeout(equal(1))
+                    expect(campaignRepository.incrementImpressionsCalls).to(equal(0))
                 }
 
                 it("will dispatch remaining campaigns") {


### PR DESCRIPTION
# Description
Previously the campaign's `impressionLeft` value was decremented just after display probably to avoid some race condition. With the current display logic we can safely perform decrement operation after closing the campaign.

# Checklist
- [X] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [X] I wrote/updated tests for new/changed code
- [X] I removed all sensitive data **before every commit**, including API endpoints and keys
- [X] I ran `fastlane ci` without errors
