### PR TITLE
fix: fix empty space on top of image-only modal campaigns (SDKCF-5133)

### DIFF
--- a/Sources/RInAppMessaging/Views/FullView.swift
+++ b/Sources/RInAppMessaging/Views/FullView.swift
@@ -272,15 +272,11 @@ internal class FullView: UIView, FullViewType, RichContentBrowsable {
     }
 
     private func updateUIComponentsVisibility(viewModel: FullViewModel) {
-        let shouldHideBody = (viewModel.isHTML || !viewModel.hasText) &&
-            !viewModel.showOptOut &&
-            !viewModel.showButtons
-
         buttonsContainer.isHidden = !viewModel.showButtons
         optOutView.isHidden = !viewModel.showOptOut
         optOutAndButtonsSpacer.isHidden = buttonsContainer.isHidden || optOutView.isHidden
         controlsView.isHidden = buttonsContainer.isHidden && optOutView.isHidden
-        bodyView.isHidden = shouldHideBody
+        bodyView.isHidden = viewModel.isHTML || !viewModel.hasText
     }
 
     private func setupWebView(withHtmlString htmlString: String) {


### PR DESCRIPTION
# Description
The empty space was caused by empty body message stack view which was not hidden when buttons (or opt out check) was present. The issue was caused by an outdated logic in FullView.swift

## Links
SDKCF-5133

# Checklist
- [X] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [ ] I wrote/updated tests for new/changed code
- [X] I removed all sensitive data **before every commit**, including API endpoints and keys
- [ ] I ran `fastlane ci` without errors
