### PR TITLE
build: fix swift package build script

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -52,7 +52,7 @@ platform :ios do
 
   lane :build_swift_package do
     Dir.chdir("..") do
-      ios_version = sh 'xcodebuild -showBuildSettings | grep "IPHONEOS_DEPLOYMENT_TARGET =" | tr -d "IPHONEOS_DEPLOYMENT_TARGET ="'
+      ios_version = sh 'xcodebuild -showBuildSettings 2>/dev/null | grep "IPHONEOS_DEPLOYMENT_TARGET =" | tr -d "IPHONEOS_DEPLOYMENT_TARGET ="'
       sh "swift build -Xswiftc '-sdk' -Xswiftc `xcrun --sdk iphonesimulator --show-sdk-path` -Xswiftc '-target' -Xswiftc 'x86_64-apple-ios#{ios_version}-simulator'"
     end
   end


### PR DESCRIPTION
# Description
Fixes a problem in `build_swift_package` lane when `tr` input contains content from stderr 

# Checklist
- [X] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [ ] I wrote/updated tests for new/changed code
- [X] I removed all sensitive data **before every commit**, including API endpoints and keys
- [ ] I ran `fastlane ci` without errors
