### PR TITLE
ci: integrate Emerge tool (SDKCF-5346)

### DIFF
--- a/.github/workflows/emerge_tools.yml
+++ b/.github/workflows/emerge_tools.yml
@@ -1,0 +1,74 @@
+name: Emerge
+on: 
+  pull_request_target:
+    branches: [ master, main ]
+  push:
+    branches: [ master, main ]
+permissions:
+  actions: read
+  checks: read
+  contents: read
+  pull-requests: read
+
+jobs:
+  upload-to-emerge:
+    runs-on: ubuntu-latest
+    name: Upload artifact to Emerge tools
+    steps:
+      - name: Wait for build to succeed
+        uses: lewagon/wait-on-check-action@v1.1.1
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          check-name: 'Bitrise'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 10
+      - name: Get check runs data
+        uses: octokit/request-action@v2.x
+        id: get_check_runs
+        with:
+          route: GET /repos/{owner}/{repo}/commits/{sha}/check-runs
+          owner: rakutentech
+          repo: ios-inappmessaging
+          sha: ${{ github.event.pull_request.head.sha }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Store check runs data in a file
+        uses: jsdaniell/create-json@1.1.2
+        with:
+          name: 'checks.json'
+          json: ${{ steps.get_check_runs.outputs.data }}
+      - name: Extract Bitrise build SLUG
+        uses: sergeysova/jq-action@v2
+        id: get_build_slug
+        with:
+          cmd: jq ".check_runs[] | select(.name==\"Bitrise\") | .external_id" checks.json -r
+      - name: Download artifact
+        env:
+          BITRISE_API_TOKEN: ${{ secrets.BITRISE_API_TOKEN }}
+          BITRISE_BUILD_SLUG: ${{ steps.get_build_slug.outputs.value }}
+          BITRISE_APP_SLUG: ${{ secrets.BITRISE_APP_SLUG }}
+        shell: bash
+        run: |
+          # Based on https://gist.github.com/Marchuck/de230ed681428d47ce1276c14788ef9a#file-print_out_artifact_urls-sh
+          access_token=$BITRISE_API_TOKEN
+          app_slug=$BITRISE_APP_SLUG
+          build_slug=$BITRISE_BUILD_SLUG
+
+          bitrise_api_url="https://api.bitrise.io/v0.1"
+          the_url="$bitrise_api_url/apps/$app_slug/builds/$build_slug/artifacts"
+
+          artifacts_array=$(curl -s -H "Authorization: $access_token" $the_url)
+          artifact=$(echo ${artifacts_array} | jq -r ".data[0]")
+          artifact_slug=$(echo ${artifact} | jq -r '.slug')
+          artifact_url="$the_url/$artifact_slug"
+
+          artifact_metadata_response=$(curl -s -H "Authorization: $access_token" ${artifact_url})
+          artifact_name=$(echo ${artifact_metadata_response} | jq -r '.data .title')
+          artifact_download_url=$(echo ${artifact_metadata_response} | jq -r '.data .expiring_download_url')
+
+          curl -sS -H "Authorization: $access_token" "$artifact_download_url" -o artifact.zip
+      - name: Upload artifact to Emerge
+        uses: imaginaris/emerge-upload-action@main
+        with:
+          artifact_path: ./artifact.zip
+          emerge_api_key: ${{ secrets.EMERGE_API_KEY }}


### PR DESCRIPTION
# Description
Added GitHub Action workflow that triggers `emerge-upload-action`.
In order to support pull requests from forks, I used a modified `emerge-upload-action` that supports `pull_request_target` trigger (used in forked repo PRs).
I created a PR to merge my changes into the original repo:
https://github.com/EmergeTools/emerge-upload-action/pull/3

The workflow should be generic enough to use with other GH projects.

## Links
SDKCF-5346

# Checklist
- [X] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [ ] I wrote/updated tests for new/changed code
- [X] I removed all sensitive data **before every commit**, including API endpoints and keys
- [ ] I ran `fastlane ci` without errors
