### PR TITLE
ci: fix sha reference in Emerge GH workflow (SDKCF-5346)

### DIFF
--- a/.github/workflows/emerge_tools.yml
+++ b/.github/workflows/emerge_tools.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Wait for build to succeed
         uses: lewagon/wait-on-check-action@v1.1.1
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
           check-name: 'Bitrise'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           wait-interval: 10
@@ -29,7 +29,7 @@ jobs:
           route: GET /repos/{owner}/{repo}/commits/{sha}/check-runs
           owner: rakutentech
           repo: ios-inappmessaging
-          sha: ${{ github.event.pull_request.head.sha }}
+          sha: ${{ github.event.pull_request.head.sha || github.sha }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Store check runs data in a file


### PR DESCRIPTION
# Description
The `emerge-tool` workflow is also executed after a push to master branch.
`github.event.pull_request.head.sha` is not a correct way to get commit sha on `push` trigger.

## Links
SDKCF-5346

# Checklist
- [X] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [ ] I wrote/updated tests for new/changed code
- [X] I removed all sensitive data **before every commit**, including API endpoints and keys
- [ ] I ran `fastlane ci` without errors
