### PR TITLE
improve: handle missing config url in release mode to avoid a crash, add config url fallback value for sample app archive

### DIFF
--- a/RInAppMessaging.xcodeproj/xcshareddata/xcschemes/UITests.xcscheme
+++ b/RInAppMessaging.xcodeproj/xcshareddata/xcschemes/UITests.xcscheme
@@ -92,7 +92,7 @@
       buildConfiguration = "Debug">
    </AnalyzeAction>
    <ArchiveAction
-      buildConfiguration = "Release"
+      buildConfiguration = "UITests"
       revealArchiveInOrganizer = "YES">
    </ArchiveAction>
 </Scheme>

--- a/Sources/RInAppMessaging/ConfigurationManager.swift
+++ b/Sources/RInAppMessaging/ConfigurationManager.swift
@@ -10,7 +10,7 @@ internal protocol ConfigurationManagerType: ErrorReportable {
 }
 
 internal class ConfigurationManager: ConfigurationManagerType, TaskSchedulable {
-    private let configurationService: ConfigurationServiceType
+    private let configurationService: ConfigurationServiceType?
     private let configurationRepository: ConfigurationRepositoryType
     private let reachability: ReachabilityType?
     private let resumeQueue: DispatchQueue
@@ -24,7 +24,7 @@ internal class ConfigurationManager: ConfigurationManagerType, TaskSchedulable {
     weak var errorDelegate: ErrorDelegate?
 
     init(reachability: ReachabilityType?,
-         configurationService: ConfigurationServiceType,
+         configurationService: ConfigurationServiceType?,
          configurationRepository: ConfigurationRepositoryType,
          resumeQueue: DispatchQueue) {
 
@@ -39,6 +39,11 @@ internal class ConfigurationManager: ConfigurationManagerType, TaskSchedulable {
     }
 
     func fetchAndSaveConfigData(completion: @escaping (ConfigData) -> Void) {
+        guard let configurationService = configurationService else {
+            reportError(description: "Configuration URL in Info.plist is missing. IAM SDK will be disabled.", data: nil)
+            completion(ConfigData(rolloutPercentage: 0, endpoints: nil))
+            return
+        }
         let retryHandler: () -> Void = { [weak self] in
             self?.fetchAndSaveConfigData(completion: completion)
         }

--- a/Sources/RInAppMessaging/DependencyManager/MainContainer.swift
+++ b/Sources/RInAppMessaging/DependencyManager/MainContainer.swift
@@ -36,7 +36,7 @@ internal enum MainContainerFactory {
             }),
             ContainerElement(type: ConfigurationManagerType.self, factory: {
                 ConfigurationManager(reachability: manager.resolve(type: ReachabilityType.self),
-                                     configurationService: manager.resolve(type: ConfigurationServiceType.self)!,
+                                     configurationService: manager.resolve(type: ConfigurationServiceType.self),
                                      configurationRepository: manager.resolve(type: ConfigurationRepositoryType.self)!,
                                      resumeQueue: RInAppMessaging.inAppQueue)
             }),

--- a/Tests/Tests/ConfigurationManagerSpec.swift
+++ b/Tests/Tests/ConfigurationManagerSpec.swift
@@ -28,6 +28,30 @@ class ConfigurationManagerSpec: QuickSpec {
 
             context("fetchAndSaveConfigData") {
 
+                context("when configurationService is nil (when config URL is missing)") {
+                    beforeEach {
+                        configurationManager = ConfigurationManager(reachability: reachability,
+                                                                    configurationService: nil,
+                                                                    configurationRepository: configurationRepository,
+                                                                    resumeQueue: DispatchQueue(label: "iam.test.request"))
+                        configurationManager.errorDelegate = errorDelegate
+                    }
+
+                    it("should report an error") {
+                        configurationManager.fetchAndSaveConfigData(completion: { _ in })
+                        expect(errorDelegate.wasErrorReceived).to(beTrue())
+                    }
+
+                    it("should call completion with rolloutPercentage 0") {
+                        waitUntil { done in
+                            configurationManager.fetchAndSaveConfigData(completion: { configData in
+                                expect(configData.rolloutPercentage).to(equal(0))
+                                done()
+                            })
+                        }
+                    }
+                }
+
                 context("when connection is not available") {
                     beforeEach {
                         reachability.connectionStub = .unavailable

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -8,12 +8,14 @@ platform :ios do
     coverage
 
     # Create an archive
+    # Take config URL from env variable or set a dummy one
+    config_url = ENV['RIAM_CONFIG_URL'] || 'http://localhost:6789/config'
     xcodebuild(
       archive: true,
       archive_path: "./artifacts/RInAppMessaging.xcarchive",
       scheme: ENV['REM_FL_SAMPLE_SCHEME'],
       workspace: ENV['REM_FL_SAMPLE_WORKSPACE'],
-      xcargs: "CODE_SIGN_IDENTITY='' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO",
+      xcargs: "CODE_SIGN_IDENTITY='' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO RIAM_CONFIG_URL=#{config_url}",
     )
   end
 


### PR DESCRIPTION
# Description
In Debug mode missing config URL throws an assertion. In release mode, ConfigurationService cannot be initialized which causes a crash because ConfigurationManager init in `MainContainerFactory` force unwraps the reference.
This PR fixes this issue by properly handling nil values and disabling the SDK in the end.

Added a dummy config url to set in sample app archives in case RIAM_CONFIG_URL is not set (PR builds)
(This PR fixes the issue with Emerge Performance Analysis tool)

# Checklist
- [X] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [X] I wrote/updated tests for new/changed code
- [X] I removed all sensitive data **before every commit**, including API endpoints and keys
- [X] I ran `fastlane ci` without errors
