### PR TITLE
ci: use the new version of official `emerge-upload-action`

### DIFF
--- a/.github/workflows/emerge_tools.yml
+++ b/.github/workflows/emerge_tools.yml
@@ -68,7 +68,7 @@ jobs:
 
           curl -sS -H "Authorization: $access_token" "$artifact_download_url" -o artifact.zip
       - name: Upload artifact to Emerge
-        uses: imaginaris/emerge-upload-action@main
+        uses: EmergeTools/emerge-upload-action@v1.0.3
         with:
           artifact_path: ./artifact.zip
           emerge_api_key: ${{ secrets.EMERGE_API_KEY }}


### PR DESCRIPTION
# Description
emerge-upload-action v1.0.3 has been released containing my fix for PRs from forked repos.
https://github.com/EmergeTools/emerge-upload-action/releases/tag/v1.0.3

# Checklist
- [X] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [ ] I wrote/updated tests for new/changed code
- [X] I removed all sensitive data **before every commit**, including API endpoints and keys
- [ ] I ran `fastlane ci` without errors
