### PR TITLE
ci: use github action to create an archive for Emerge tools

### DIFF
--- a/.github/workflows/emerge_tools.yml
+++ b/.github/workflows/emerge_tools.yml
@@ -17,6 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
+          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
       - uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/emerge_tools.yml
+++ b/.github/workflows/emerge_tools.yml
@@ -1,9 +1,9 @@
 name: Emerge
 on: 
   pull_request_target:
-    branches: [ master, main, emerge_parallel ]
+    branches: [ master, main ]
   push:
-    branches: [ master, main, emerge_parallel ]
+    branches: [ master, main ]
 permissions:
   actions: read
   checks: read

--- a/.github/workflows/emerge_tools.yml
+++ b/.github/workflows/emerge_tools.yml
@@ -15,60 +15,16 @@ jobs:
     runs-on: ubuntu-latest
     name: Upload artifact to Emerge tools
     steps:
-      - name: Wait for build to succeed
-        uses: lewagon/wait-on-check-action@v1.1.1
+      - name: Archive Sample app
+        uses: maierj/fastlane-action@v2.2.0
         with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
-          check-name: 'Bitrise'
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          wait-interval: 10
-      - name: Get check runs data
-        uses: octokit/request-action@v2.x
-        id: get_check_runs
-        with:
-          route: GET /repos/{owner}/{repo}/commits/{sha}/check-runs
-          owner: rakutentech
-          repo: ios-inappmessaging
-          sha: ${{ github.event.pull_request.head.sha || github.sha }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Store check runs data in a file
-        uses: jsdaniell/create-json@1.1.2
-        with:
-          name: 'checks.json'
-          json: ${{ steps.get_check_runs.outputs.data }}
-      - name: Extract Bitrise build SLUG
-        uses: sergeysova/jq-action@v2
-        id: get_build_slug
-        with:
-          cmd: jq ".check_runs[] | select(.name==\"Bitrise\") | .external_id" checks.json -r
-      - name: Download artifact
-        env:
-          BITRISE_API_TOKEN: ${{ secrets.BITRISE_API_TOKEN }}
-          BITRISE_BUILD_SLUG: ${{ steps.get_build_slug.outputs.value }}
-          BITRISE_APP_SLUG: ${{ secrets.BITRISE_APP_SLUG }}
+          lane: 'archive'
+      - name: Compress artifact
         shell: bash
         run: |
-          # Based on https://gist.github.com/Marchuck/de230ed681428d47ce1276c14788ef9a#file-print_out_artifact_urls-sh
-          access_token=$BITRISE_API_TOKEN
-          app_slug=$BITRISE_APP_SLUG
-          build_slug=$BITRISE_BUILD_SLUG
-
-          bitrise_api_url="https://api.bitrise.io/v0.1"
-          the_url="$bitrise_api_url/apps/$app_slug/builds/$build_slug/artifacts"
-
-          artifacts_array=$(curl -s -H "Authorization: $access_token" $the_url)
-          artifact=$(echo ${artifacts_array} | jq -r ".data[0]")
-          artifact_slug=$(echo ${artifact} | jq -r '.slug')
-          artifact_url="$the_url/$artifact_slug"
-
-          artifact_metadata_response=$(curl -s -H "Authorization: $access_token" ${artifact_url})
-          artifact_name=$(echo ${artifact_metadata_response} | jq -r '.data .title')
-          artifact_download_url=$(echo ${artifact_metadata_response} | jq -r '.data .expiring_download_url')
-
-          curl -sS -H "Authorization: $access_token" "$artifact_download_url" -o artifact.zip
+          zip -r artifact.zip ./artifacts/*.xcarchive
       - name: Upload artifact to Emerge
-        uses: EmergeTools/emerge-upload-action@v1.0.3
+        uses: imaginaris/emerge-upload-action@main
         with:
           artifact_path: ./artifact.zip
           emerge_api_key: ${{ secrets.EMERGE_API_KEY }}

--- a/.github/workflows/emerge_tools.yml
+++ b/.github/workflows/emerge_tools.yml
@@ -15,7 +15,9 @@ jobs:
     runs-on: macos-12
     name: Upload artifact to Emerge tools
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: '2.7.3'

--- a/.github/workflows/emerge_tools.yml
+++ b/.github/workflows/emerge_tools.yml
@@ -15,6 +15,10 @@ jobs:
     runs-on: macos-12
     name: Upload artifact to Emerge tools
     steps:
+      - uses: actions/checkout@v2
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '2.7.3'
       - name: Archive Sample app
         uses: maierj/fastlane-action@v2.2.0
         with:

--- a/.github/workflows/emerge_tools.yml
+++ b/.github/workflows/emerge_tools.yml
@@ -1,7 +1,7 @@
 name: Emerge
 on: 
   pull_request_target:
-    branches: [ master, main ]
+    branches: [ master, main, emerge_parallel ]
   push:
     branches: [ master, main ]
 permissions:

--- a/.github/workflows/emerge_tools.yml
+++ b/.github/workflows/emerge_tools.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   upload-to-emerge:
-    runs-on: ubuntu-latest
+    runs-on: macos-12
     name: Upload artifact to Emerge tools
     steps:
       - name: Archive Sample app

--- a/.github/workflows/emerge_tools.yml
+++ b/.github/workflows/emerge_tools.yml
@@ -32,7 +32,7 @@ jobs:
           cd artifacts
           zip -r artifact.zip *.xcarchive
       - name: Upload artifact to Emerge
-        uses: imaginaris/emerge-upload-action@main
+        uses: EmergeTools/emerge-upload-action@v1.0.3
         with:
           artifact_path: ./artifacts/artifact.zip
           emerge_api_key: ${{ secrets.EMERGE_API_KEY }}

--- a/.github/workflows/emerge_tools.yml
+++ b/.github/workflows/emerge_tools.yml
@@ -3,7 +3,7 @@ on:
   pull_request_target:
     branches: [ master, main, emerge_parallel ]
   push:
-    branches: [ master, main ]
+    branches: [ master, main, emerge_parallel ]
 permissions:
   actions: read
   checks: read
@@ -28,9 +28,10 @@ jobs:
       - name: Compress artifact
         shell: bash
         run: |
-          zip -r artifact.zip ./artifacts/*.xcarchive
+          cd artifacts
+          zip -r artifact.zip *.xcarchive
       - name: Upload artifact to Emerge
         uses: imaginaris/emerge-upload-action@main
         with:
-          artifact_path: ./artifact.zip
+          artifact_path: ./artifacts/artifact.zip
           emerge_api_key: ${{ secrets.EMERGE_API_KEY }}

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -6,17 +6,7 @@ platform :ios do
   lane :ci do |options|
     tests(options)
     coverage
-
-    # Create an archive
-    # Take config URL from env variable or set a dummy one
-    config_url = ENV['RIAM_CONFIG_URL'] || 'http://localhost:6789/config'
-    xcodebuild(
-      archive: true,
-      archive_path: "./artifacts/RInAppMessaging.xcarchive",
-      scheme: ENV['REM_FL_SAMPLE_SCHEME'],
-      workspace: ENV['REM_FL_SAMPLE_WORKSPACE'],
-      xcargs: "CODE_SIGN_IDENTITY='' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO RIAM_CONFIG_URL=#{config_url}",
-    )
+    archive
   end
 
   desc "Run tests"
@@ -79,5 +69,21 @@ platform :ios do
       include_test_targets: false,
       json_report: true
     )  
+  end
+
+  desc "Archive Sample app"
+  lane :archive do
+    cocoapods(repo_update: ENV['REM_FL_CP_REPO_UPDATE'] || false)
+
+    # Take config URL from env variable or set a dummy one
+    config_url = ENV['RIAM_CONFIG_URL'] || 'http://localhost:6789/config'
+
+    xcodebuild(
+      archive: true,
+      archive_path: "./artifacts/RInAppMessaging.xcarchive",
+      scheme: ENV['REM_FL_SAMPLE_SCHEME'],
+      workspace: ENV['REM_FL_SAMPLE_WORKSPACE'],
+      xcargs: "CODE_SIGN_IDENTITY='' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO RIAM_CONFIG_URL=#{config_url}",
+    )
   end
 end


### PR DESCRIPTION
# Description
This improvements runs `fastlane archive` on Github runner in parallel with other checks instead of waiting for Bitrise to finish building an artifact.

The goal was to reduce total waiting time of Github PR checks. This improvement will actually slightly increase waiting time by 1-2 mins since Bitrise is able to build the artifact faster.
The reason this PR is worth merging is than now the workflow is much simpler and robust, and doesn't require Bitrise API token which improves security.
The workflow now requires a macOS runner.

Test PR: https://github.com/rakutentech/ios-inappmessaging/pull/202

# Checklist
- [X] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [ ] I wrote/updated tests for new/changed code
- [X] I removed all sensitive data **before every commit**, including API endpoints and keys
- [ ] I ran `fastlane ci` without errors
