### PR TITLE
fix: fix opt out message being not visible on a dark background (SDKCF-5620)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 	- Display impression analytics event is now sent when campaign message appears [SDKCF-5252]
 - Bug fixes:
 	- Fixed issues with unit tests on Xcode 13.3 [SDKCF-5124]
+	- Fixed Opt-out message visibility on a dark background [SDKCF-5620]
 
 ### 7.0.0 (2022-05-13)
 - **Breaking changes:**

--- a/RInAppMessaging.xcodeproj/project.pbxproj
+++ b/RInAppMessaging.xcodeproj/project.pbxproj
@@ -39,6 +39,7 @@
 		45563B03240614AE004EAFD3 /* ReadyCampaignDispatcherSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45563B02240614AE004EAFD3 /* ReadyCampaignDispatcherSpec.swift */; };
 		45563B0724064D78004EAFD3 /* CampaignRepositorySpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45563B0624064D78004EAFD3 /* CampaignRepositorySpec.swift */; };
 		4557A8B1257E544C00C9D241 /* AccountRepositorySpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4557A8B0257E544C00C9D241 /* AccountRepositorySpec.swift */; };
+		455A7D4B2889D8550059F291 /* OptOutMessageViewSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 455A7D4A2889D8550059F291 /* OptOutMessageViewSpec.swift */; };
 		455FEBE227F214640064470D /* UIColorExtensionSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 455FEBE127F214640064470D /* UIColorExtensionSpec.swift */; };
 		4560062C26FB968B003227FE /* UserInfoProviderSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4560062B26FB968B003227FE /* UserInfoProviderSpec.swift */; };
 		456FE1E72428513200304872 /* ErrorReportableSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 456FE1E62428513200304872 /* ErrorReportableSpec.swift */; };
@@ -148,6 +149,7 @@
 		45563B02240614AE004EAFD3 /* ReadyCampaignDispatcherSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadyCampaignDispatcherSpec.swift; sourceTree = "<group>"; };
 		45563B0624064D78004EAFD3 /* CampaignRepositorySpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CampaignRepositorySpec.swift; sourceTree = "<group>"; };
 		4557A8B0257E544C00C9D241 /* AccountRepositorySpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountRepositorySpec.swift; sourceTree = "<group>"; };
+		455A7D4A2889D8550059F291 /* OptOutMessageViewSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OptOutMessageViewSpec.swift; sourceTree = "<group>"; };
 		455FEBE127F214640064470D /* UIColorExtensionSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIColorExtensionSpec.swift; sourceTree = "<group>"; };
 		4560062B26FB968B003227FE /* UserInfoProviderSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserInfoProviderSpec.swift; sourceTree = "<group>"; };
 		456FE1E62428513200304872 /* ErrorReportableSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorReportableSpec.swift; sourceTree = "<group>"; };
@@ -423,6 +425,7 @@
 				45D4DA4E240F5597009B9B37 /* ViewPresenterSpec.swift */,
 				456FE1EC2429C4D200304872 /* ViewSpec.swift */,
 				4537DBAB28037BF60038E0D2 /* ViewModelSpec.swift */,
+				455A7D4A2889D8550059F291 /* OptOutMessageViewSpec.swift */,
 				607FACE91AFB9204008FA782 /* Supporting Files */,
 			);
 			name = Tests;
@@ -729,6 +732,7 @@
 				45AFB308246CFB640080D21B /* LocaleSpec.swift in Sources */,
 				4516601D23CD740300310181 /* MainContainerSpec.swift in Sources */,
 				459B228224528A7D00D218CE /* DisplayPermissionServiceSpec.swift in Sources */,
+				455A7D4B2889D8550059F291 /* OptOutMessageViewSpec.swift in Sources */,
 				45BDFD0724232714004DEA0C /* PublicAPISpec.swift in Sources */,
 				459DE86C2407B5750002F451 /* CustomEventSpec.swift in Sources */,
 				45563B0724064D78004EAFD3 /* CampaignRepositorySpec.swift in Sources */,

--- a/Sources/RInAppMessaging/Views/Components/OptOutMessageView.swift
+++ b/Sources/RInAppMessaging/Views/Components/OptOutMessageView.swift
@@ -11,9 +11,19 @@ internal class OptOutMessageView: UIView {
         static let overflowMargin: CGFloat = 8
     }
 
-    private let checkbox = Checkbox()
+    let checkbox = Checkbox()
+    let optOutMessage = UILabel()
+
     var isChecked: Bool {
-        return checkbox.isChecked
+        checkbox.isChecked
+    }
+    var useBrightColors = false {
+        didSet {
+            optOutMessage.textColor = useBrightColors ? .white : .black
+            checkbox.uncheckedBorderColor = useBrightColors ? .white : .black
+            checkbox.checkedBorderColor = useBrightColors ? .white : .black
+            checkbox.checkmarkColor = useBrightColors ? .white : .black
+        }
     }
 
     override init(frame: CGRect) {
@@ -32,10 +42,8 @@ internal class OptOutMessageView: UIView {
     }
 
     private func commonInit() {
-        let optOutMessage = UILabel()
         optOutMessage.text = "optOut_message".localized
         optOutMessage.font = .systemFont(ofSize: Constants.fontSize)
-        optOutMessage.textColor = .black
         optOutMessage.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(tapAction)))
         optOutMessage.isUserInteractionEnabled = true
         optOutMessage.adjustsFontSizeToFitWidth = true
@@ -44,14 +52,13 @@ internal class OptOutMessageView: UIView {
         optOutMessage.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
 
         checkbox.borderStyle = .square
-        checkbox.uncheckedBorderColor = .black
-        checkbox.checkedBorderColor = .black
-        checkbox.checkmarkColor = .black
         checkbox.checkmarkStyle = .tick
         checkbox.borderLineWidth = 1
         checkbox.useHapticFeedback = false
         checkbox.accessibilityIdentifier = "optOutCheckbox"
         checkbox.translatesAutoresizingMaskIntoConstraints = false
+
+        useBrightColors = false
 
         let container = UIView()
         container.translatesAutoresizingMaskIntoConstraints = false

--- a/Sources/RInAppMessaging/Views/FullView.swift
+++ b/Sources/RInAppMessaging/Views/FullView.swift
@@ -142,6 +142,7 @@ internal class FullView: UIView, FullViewType, RichContentBrowsable {
         createMessageBody(viewModel: viewModel)
 
         backgroundView.backgroundColor = uiConstants.backgroundColor ?? viewModel.backgroundColor
+        optOutView.useBrightColors = !viewModel.backgroundColor.isBright
 
         exitButton.invertedColors = viewModel.backgroundColor.isBright
         exitButton.isHidden = !viewModel.isDismissable

--- a/Tests/Tests/OptOutMessageViewSpec.swift
+++ b/Tests/Tests/OptOutMessageViewSpec.swift
@@ -1,0 +1,47 @@
+import Quick
+import Nimble
+import WebKit
+@testable import RInAppMessaging
+
+final class OptOutMessageViewSpec: QuickSpec {
+
+    override func spec() {
+        describe("OptOutMessageView") {
+
+            var optOutView: OptOutMessageView!
+
+            beforeEach {
+                optOutView = OptOutMessageView()
+            }
+
+            context("when setting useBrightColors") {
+
+                context("and the value is true") {
+                    beforeEach {
+                        optOutView.useBrightColors = true
+                    }
+
+                    it("will set all UI elements to white") {
+                        expect(optOutView.optOutMessage.textColor).to(equal(.white))
+                        expect(optOutView.checkbox.uncheckedBorderColor).to(equal(.white))
+                        expect(optOutView.checkbox.checkedBorderColor).to(equal(.white))
+                        expect(optOutView.checkbox.checkmarkColor).to(equal(.white))
+                    }
+                }
+
+                context("and the value is false") {
+                    beforeEach {
+                        optOutView.useBrightColors = false
+                    }
+
+                    it("will set all UI elements to black") {
+                        expect(optOutView.optOutMessage.textColor).to(equal(.black))
+                        expect(optOutView.checkbox.uncheckedBorderColor).to(equal(.black))
+                        expect(optOutView.checkbox.checkedBorderColor).to(equal(.black))
+                        expect(optOutView.checkbox.checkmarkColor).to(equal(.black))
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
# Description
Opt-out message is now using the same logic as exit button to change color to black/white depending on background color.

## Links
SDKCF-5620

# Checklist
- [X] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [X] I wrote/updated tests for new/changed code
- [X] I removed all sensitive data **before every commit**, including API endpoints and keys
- [X] I ran `fastlane ci` without errors
