### PR TITLE
fix: do not reject outdated test campaigns (SDKCF-5636)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Bug fixes:
 	- Fixed issues with unit tests on Xcode 13.3 [SDKCF-5124]
 	- Fixed Opt-out message visibility on a dark background [SDKCF-5620]
+	- Fixed an issue when test campaigns were not displayed [SDKCF-5636]
 
 ### 7.0.0 (2022-05-13)
 - **Breaking changes:**

--- a/Sources/RInAppMessaging/CampaignsValidator.swift
+++ b/Sources/RInAppMessaging/CampaignsValidator.swift
@@ -31,19 +31,18 @@ internal struct CampaignsValidator: CampaignsValidatorType {
     func validate(validatedCampaignHandler: (_ campaign: Campaign, _ events: Set<Event>) -> Void) {
 
         for campaign in campaignRepository.list {
-            guard campaign.impressionsLeft > 0,
-                !campaign.isOutdated else {
-                    // campaign is not ready
-                    continue
+            guard campaign.impressionsLeft > 0 else {
+                continue
             }
-
             guard !campaign.data.isTest else {
                 validatedCampaignHandler(campaign, [])
                 // test campaign triggers are always satisfied
                 continue
             }
-            guard !campaign.isOptedOut else { continue }
-
+            
+            guard !campaign.isOptedOut, !campaign.isOutdated else {
+                continue
+            }
             guard let campaignTriggers = campaign.data.triggers else {
                 Logger.debug("campaign (\(campaign.id)) has no triggers.")
                 continue

--- a/Tests/Tests/CampaignsValidatorSpec.swift
+++ b/Tests/Tests/CampaignsValidatorSpec.swift
@@ -25,14 +25,13 @@ class CampaignsValidatorSpec: QuickSpec {
             it("will accept test campaign (not looking at triggers)") {
                 campaignRepository.syncWith(list: [MockedCampaigns.testCampaign], timestampMilliseconds: 0)
                 campaignsValidator.validate(validatedCampaignHandler: validatorHandler.closure)
-                expect(validatorHandler.validatedElements).to(elementsEqual(
-                    [ValidatorHandler.Element(MockedCampaigns.testCampaign, [])]))
+                expect(validatorHandler.validatedCampaigns).to(elementsEqual([MockedCampaigns.testCampaign]))
             }
 
-            it("will not accept outdated test campaign") {
+            it("will accept outdated test campaign") {
                 campaignRepository.syncWith(list: [MockedCampaigns.outdatedTestCampaign], timestampMilliseconds: 0)
                 campaignsValidator.validate(validatedCampaignHandler: validatorHandler.closure)
-                expect(validatorHandler.validatedElements).to(beEmpty())
+                expect(validatorHandler.validatedCampaigns).to(contain(MockedCampaigns.outdatedTestCampaign))
             }
 
             it("will not accept test campaign with impressionLeft < 1") {
@@ -80,7 +79,7 @@ class CampaignsValidatorSpec: QuickSpec {
                 campaignRepository.syncWith(list: [MockedCampaigns.outdatedCampaign], timestampMilliseconds: 0)
                 eventMatcher.matchAndStore(event: LoginSuccessfulEvent())
                 campaignsValidator.validate(validatedCampaignHandler: validatorHandler.closure)
-                expect(validatorHandler.validatedCampaigns).toEventuallyNot(contain(MockedCampaigns.outdatedCampaign))
+                expect(validatorHandler.validatedCampaigns).toNot(contain(MockedCampaigns.outdatedCampaign))
             }
 
             it("won't accept opted out campaigns") {


### PR DESCRIPTION
# Description
Test campaigns can have `endTimeMillis` with a value of 0. The SDK treats those campaigns as outdated and does not display them.
The fix disables date validation for test campaigns.

## Links
SDKCF-5636

# Checklist
- [X] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [X] I wrote/updated tests for new/changed code
- [X] I removed all sensitive data **before every commit**, including API endpoints and keys
- [X] I ran `fastlane ci` without errors
