### PR TITLE
improve: accept any form of `[Tooltip]` title prefix (SDKCF-5638)

### DIFF
--- a/Sample/ping.json
+++ b/Sample/ping.json
@@ -17,7 +17,7 @@
                     }
                 ],
                 "messagePayload": {
-                    "title": "[ToolTip] tooltip 1",
+                    "title": "[Tooltip] tooltip 1",
                     "messageBody": "{\"UIElement\" : \"tooltip.test.1\", \"position\": \"bottom-right\"}",
                     "header": "Test Campaign",
                     "titleColor": "#000000",
@@ -61,7 +61,7 @@
                     }
                 ],
                 "messagePayload": {
-                    "title": "[ToolTip] tooltip 2",
+                    "title": "[Tooltip] tooltip 2",
                     "messageBody": "{\"UIElement\" : \"tooltip.test.2\", \"position\": \"bottom-center\"}",
                     "header": "Test Campaign",
                     "titleColor": "#000000",
@@ -105,7 +105,7 @@
                     }
                 ],
                 "messagePayload": {
-                    "title": "[ToolTip] tooltip 3",
+                    "title": "[Tooltip] tooltip 3",
                     "messageBody": "{\"UIElement\" : \"tooltip.test.3\", \"position\": \"bottom-left\"}",
                     "header": "Test Campaign",
                     "titleColor": "#000000",
@@ -149,7 +149,7 @@
                     }
                 ],
                 "messagePayload": {
-                    "title": "[ToolTip] tooltip 4",
+                    "title": "[Tooltip] tooltip 4",
                     "messageBody": "{\"UIElement\" : \"tooltip.test.4\", \"position\": \"left\"}",
                     "header": "Test Campaign",
                     "titleColor": "#000000",
@@ -193,7 +193,7 @@
                     }
                 ],
                 "messagePayload": {
-                    "title": "[ToolTip] tooltip 5",
+                    "title": "[Tooltip] tooltip 5",
                     "messageBody": "{\"UIElement\" : \"tooltip.test.5\", \"position\": \"top-left\"}",
                     "header": "Test Campaign",
                     "titleColor": "#000000",
@@ -237,7 +237,7 @@
                     }
                 ],
                 "messagePayload": {
-                    "title": "[ToolTip] tooltip 6",
+                    "title": "[Tooltip] tooltip 6",
                     "messageBody": "{\"UIElement\" : \"tooltip.test.6\", \"position\": \"top-center\"}",
                     "header": "Test Campaign",
                     "titleColor": "#000000",
@@ -281,7 +281,7 @@
                     }
                 ],
                 "messagePayload": {
-                    "title": "[ToolTip] tooltip 7",
+                    "title": "[Tooltip] tooltip 7",
                     "messageBody": "{\"UIElement\" : \"tooltip.test.7\", \"position\": \"top-right\"}",
                     "header": "Test Campaign",
                     "titleColor": "#000000",
@@ -325,7 +325,7 @@
                     }
                 ],
                 "messagePayload": {
-                    "title": "[ToolTip] tooltip 8",
+                    "title": "[Tooltip] tooltip 8",
                     "messageBody": "{\"UIElement\" : \"tooltip.test.8\", \"position\": \"right\"}",
                     "header": "Test Campaign",
                     "titleColor": "#000000",

--- a/Sources/RInAppMessaging/Models/Responses/PingResponse.swift
+++ b/Sources/RInAppMessaging/Models/Responses/PingResponse.swift
@@ -61,7 +61,7 @@ internal struct Campaign: Codable, Hashable {
         data.campaignId
     }
     var isTooltip: Bool {
-        data.messagePayload.title.hasPrefix("[ToolTip]") && tooltipData != nil
+        data.messagePayload.title.lowercased().hasPrefix("[tooltip]") && tooltipData != nil
     }
     var isOutdated: Bool {
         let endTimeMilliseconds = data.messagePayload.messageSettings.displaySettings.endTimeMilliseconds

--- a/Tests/Tests/Helpers/TestHelpers.swift
+++ b/Tests/Tests/Helpers/TestHelpers.swift
@@ -123,7 +123,7 @@ struct TestHelpers {
                 triggers: triggers,
                 isTest: isTest,
                 messagePayload: MessagePayload(
-                    title: "[ToolTip] title",
+                    title: "[Tooltip] title",
                     messageBody: """
                     {\"UIElement\" : \"\(targetViewID ?? TooltipViewIdentifierMock)\", \"position\": \"top-center\", \"auto-disappear\": \(autoCloseSeconds), \"redirectURL\": \"\(redirectURL)\"}
                     """, // swiftlint:disable:previous line_length

--- a/Tests/Tests/SerializationSpec.swift
+++ b/Tests/Tests/SerializationSpec.swift
@@ -97,8 +97,8 @@ class SerializationSpec: QuickSpec {
         describe("Tooltip") {
             context("isTooltip") {
 
-                it("will return true if body contains valid JSON data and title starts with '[ToolTip]'") {
-                    let tooltip = generateTooltip(title: "[ToolTip] t1",
+                it("will return true if body contains valid JSON data") {
+                    let tooltip = generateTooltip(title: "[Tooltip] t1",
                                                   imageURL: "image.url",
                                                   body: """
                         {\"UIElement\" : \"view\", \"position\": \"top-center\", \"auto-disappear\": 2, \"redirectURL\": \"url\"}
@@ -107,7 +107,7 @@ class SerializationSpec: QuickSpec {
                 }
 
                 it("will return true if body contains only required JSON data") {
-                    let tooltip = generateTooltip(title: "[ToolTip] t1",
+                    let tooltip = generateTooltip(title: "[Tooltip] t1",
                                                   imageURL: "image.url",
                                                   body: """
                         {\"UIElement\" : \"view\", \"position\": \"top-center\"}
@@ -116,7 +116,7 @@ class SerializationSpec: QuickSpec {
                 }
 
                 it("will return false if there's no imageUrl") {
-                    let tooltip = generateTooltip(title: "[ToolTip] t1",
+                    let tooltip = generateTooltip(title: "[Tooltip] t1",
                                                   imageURL: nil,
                                                   body: """
                         {\"UIElement\" : \"view\", \"position\": \"top-center\"}
@@ -124,8 +124,8 @@ class SerializationSpec: QuickSpec {
                     expect(tooltip.isTooltip).to(beFalse())
                 }
 
-                it("will return false if title doesn't start with '[ToolTip]'") {
-                    let tooltip = generateTooltip(title: "[Tooltip] t1",
+                it("will return false if title doesn't start with '[Tooltip]'") {
+                    let tooltip = generateTooltip(title: "[ctx] t1",
                                                   imageURL: "image.url",
                                                   body: """
                         {\"UIElement\" : \"view\", \"position\": \"top-center\"}
@@ -133,15 +133,26 @@ class SerializationSpec: QuickSpec {
                     expect(tooltip.isTooltip).to(beFalse())
                 }
 
+                it("will accept '[Tooltip]' prefix in any form (case insensitive)") {
+                    ["[ToolTip]", "[tooltip]", "[tOOltip]"].forEach { titlePrefix in
+                        let tooltip = generateTooltip(title: "\(titlePrefix) t1",
+                                                      imageURL: "image.url",
+                                                      body: """
+                            {\"UIElement\" : \"view\", \"position\": \"top-center\"}
+                            """)
+                        expect(tooltip.isTooltip).to(beTrue())
+                    }
+                }
+
                 it("will return false if body doesn't contain valid JSON data") {
-                    let tooltip = generateTooltip(title: "[ToolTip] t1",
+                    let tooltip = generateTooltip(title: "[Tooltip] t1",
                                                   imageURL: "image.url",
                                                   body: "\"UIElement\" : \"view\"")
                     expect(tooltip.isTooltip).to(beFalse())
                 }
 
                 it("will return false if body doesn't contain required JSON fields") {
-                    let tooltip = generateTooltip(title: "[ToolTip] t1",
+                    let tooltip = generateTooltip(title: "[Tooltip] t1",
                                                   imageURL: "image.url",
                                                   body: "{\"UIElement\" : \"view\"}")
                     expect(tooltip.isTooltip).to(beFalse())


### PR DESCRIPTION
# Description
The SDK is currently set to expect '[ToolTip]' prefix in campaign title using case sensitive comparison. Customers often put '[Tooltip]' in the title instead of expected '[ToolTip]' which causes tooltip campaign to display incorrectly (i.e. as a standard campaign).
'Tooltip' is a proper dictionary form so it should be accepted as well as other forms with different letter case

## Links
SDKCF-5638
PR to be merged first - https://github.com/rakutentech/ios-inappmessaging/pull/209

# Checklist
- [X] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [X] I wrote/updated tests for new/changed code
- [X] I removed all sensitive data **before every commit**, including API endpoints and keys
- [ ] I ran `fastlane ci` without errors
