### PR TITLE
SDKCF-5611 fix Xcode 14 explicit use of self error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Improvements:
 	- Updated information sent to Analytics [SDKCF-5252]
 	- Display impression analytics event is now sent when campaign message appears [SDKCF-5252]
+	- Refactor for Xcode 14 compatibility [SDCFK-5611]
 - Bug fixes:
 	- Fixed issues with unit tests on Xcode 13.3 [SDKCF-5124]
 

--- a/Sources/RInAppMessaging/CampaignDispatcher.swift
+++ b/Sources/RInAppMessaging/CampaignDispatcher.swift
@@ -123,7 +123,7 @@ internal class CampaignDispatcher: CampaignDispatcherType, TaskSchedulable {
 
         router.displayCampaign(campaign, associatedImageData: imageBlob, confirmation: {
             let contexts = campaign.contexts
-            guard let delegate = delegate, !contexts.isEmpty, !campaign.data.isTest else {
+            guard let delegate = self.delegate, !contexts.isEmpty, !campaign.data.isTest else {
                 return true
             }
             let shouldShow = delegate.shouldShowCampaignMessage(title: campaignTitle,


### PR DESCRIPTION
>Reference to property 'delegate' in closure requires explicit use of 'self' to make capture semantics explicit

New error popped up in Xcode 14

# Description
Describe the changes in this pull request.
Explain your rationale of technical decisions you made (unless discussed before).

## Links
Add links to github/jira issues, design documents and other relevant resources (e.g. previous discussions, platform/tool documentation etc.)

# Checklist
- [ ] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [ ] I wrote/updated tests for new/changed code
- [ ] I removed all sensitive data **before every commit**, including API endpoints and keys
- [ ] I ran `fastlane ci` without errors
