### PR TITLE
feat: add option to set sub-ID and config URL in runtime (SDKCF-5614)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,9 @@
 ### 7.2.0 (in-progress)
 - Features:
 	- Added Push Primer feature [SDKCF-5631]
+	- Added a possibility to set subscription ID and config URL in runtime [SDKCF-5614]
 - Improvements:
-    - Enable triggers validation for test campaigns [SDKCF-5776]
+	- Enable triggers validation for test campaigns [SDKCF-5776]
 	- Refactor for Xcode 14 compatibility [SDCFK-5611]
 	- Integrated with Emerge Tools [SDKCF-5346]
 - Bug fixes:

--- a/README.md
+++ b/README.md
@@ -47,13 +47,24 @@ Choose `RInAppMessaging` product for your target. If you want to link other targ
 
 **Note:** Currently we do not host any public APIs but you can create your own APIs and configure the SDK to use those.
 
-To use the module you must set the following values in your app's `Info.plist`:
+To use the module you must set your app's subscription key and a config endpoint URL using one of the provided methods:
+
+### Build-time configuration<a name="build-time-config"></a>
+Add the following entries in your app's `Info.plist`:
 
 | Key     | Value     |
 | :---:   | :---:     |
 | `InAppMessagingAppSubscriptionID` | your\_subscription\_key |
 | `InAppMessagingConfigurationURL` | Endpoint for fetching the configuration |
 
+### Runtime configuration
+Provide a value for `subscriptionID` and `configurationURL` parameters when calling `RInAppMessaging.configure` method. 
+```swift
+RInAppMessaging.configure(subscriptionID: "your_subscription_key",
+                          configurationURL: "Endpoint for fetching the configuration")
+```
+
+⚠️ The runtime configuration values take precedence over build-time configuration.
 
 ## **Enable and disable the SDK remotely**
 We recommend, as good engineering practice, that you integrate with a remote config service so that you can fetch a feature flag, e.g. `Enable_IAM_SDK`, and use its value to dynamically enable/disable the SDK without making an app release. There are many remote config services on the market, both free and paid.
@@ -74,12 +85,14 @@ This method initializes the SDK and should be placed in your AppDelegate's `didF
 import RInAppMessaging
 
 func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
-    RInAppMessaging.configure()
+    RInAppMessaging.configure(subscriptionID: "runtime-config-subscription-id",
+                              configurationURL: "runtime.config.url")
     return true
 }
 ```
 
 **Note**: 
+* `subscriptionID` and `configurationURL` parameters are optional if you set their values in Info.plist (See [build-time configuration](#build-time-config))
 * You can wrap the call to `configure()` in an `if <enable IAM-SDK boolean value> == true` condition to control enabling/disabling the SDK. 
 * If `configure()` is not called, subsequent calls to other public API SDK functions have no effect.
 

--- a/Sources/RInAppMessaging/RInAppMessaging.swift
+++ b/Sources/RInAppMessaging/RInAppMessaging.swift
@@ -53,16 +53,16 @@ import RSDKUtils
 
     /// Function to be called by host application to start a new thread that
     /// configures Rakuten InAppMessaging SDK.
-    /// - Parameter subscriptionKeyOverride: **[TEST PURPOSES ONLY]** a subscription key to be used instead of the one set in Info.plist
-    /// - Parameter configurationURLOverride: **[TEST PURPOSES ONLY]** a configuration URL to be used instead of the one set in Info.plist
-    @objc public static func configure(subscriptionIDOverride: String? = nil,
-                                       configurationURLOverride: String? = nil) {
+    /// - Parameter subscriptionKey: your app's subscription key. (This setting will override the `InAppMessagingAppSubscriptionID` value in Info.plist)
+    /// - Parameter configurationURL: a configuration URL. (This setting will override the `InAppMessagingConfigurationURL` value in Info.plist)
+    @objc public static func configure(subscriptionID: String? = nil,
+                                       configurationURL: String? = nil) {
         guard initializedModule == nil else {
             return
         }
 
-        BundleInfo.configurationURLOverride = configurationURLOverride
-        BundleInfo.subscriptionIDOverride = subscriptionIDOverride
+        BundleInfo.configurationURLOverride = configurationURL
+        BundleInfo.subscriptionIDOverride = subscriptionID
 
         let dependencyManager = TypedDependencyManager()
         let mainContainer = MainContainerFactory.create(dependencyManager: dependencyManager)

--- a/Sources/RInAppMessaging/RInAppMessaging.swift
+++ b/Sources/RInAppMessaging/RInAppMessaging.swift
@@ -53,10 +53,16 @@ import RSDKUtils
 
     /// Function to be called by host application to start a new thread that
     /// configures Rakuten InAppMessaging SDK.
-    @objc public static func configure() {
+    /// - Parameter subscriptionKeyOverride: **[TEST PURPOSES ONLY]** a subscription key to be used instead of the one set in Info.plist
+    /// - Parameter configurationURLOverride: **[TEST PURPOSES ONLY]** a configuration URL to be used instead of the one set in Info.plist
+    @objc public static func configure(subscriptionIDOverride: String? = nil,
+                                       configurationURLOverride: String? = nil) {
         guard initializedModule == nil else {
             return
         }
+
+        BundleInfo.configurationURLOverride = configurationURLOverride
+        BundleInfo.subscriptionIDOverride = subscriptionIDOverride
 
         let dependencyManager = TypedDependencyManager()
         let mainContainer = MainContainerFactory.create(dependencyManager: dependencyManager)

--- a/Sources/RInAppMessaging/Utilities/BundleInfo.swift
+++ b/Sources/RInAppMessaging/Utilities/BundleInfo.swift
@@ -7,6 +7,9 @@ import RSDKUtils
 
 internal class BundleInfo {
 
+    static var subscriptionIDOverride: String?
+    static var configurationURLOverride: String?
+
     class var bundle: Bundle {
         .main
     }
@@ -30,10 +33,12 @@ internal class BundleInfo {
     }
 
     class var inAppSubscriptionId: String? {
+        subscriptionIDOverride ??
         bundle.infoDictionary?[Constants.Info.subscriptionIDKey] as? String
     }
 
     class var inAppConfigurationURL: String? {
+        configurationURLOverride ??
         bundle.infoDictionary?[Constants.Info.configurationURLKey] as? String
     }
 

--- a/Tests/Tests/BundleSpec.swift
+++ b/Tests/Tests/BundleSpec.swift
@@ -14,6 +14,7 @@ class BundleSpec: QuickSpec {
             beforeEach {
                 bundleMock = BundleMock()
                 bundleInfo.bundleMock = bundleMock
+                bundleInfo.reset()
             }
 
             it("should return expected applicationId") {
@@ -32,14 +33,42 @@ class BundleSpec: QuickSpec {
                 expect(bundleInfo.inAppSdkVersion).to(match(semverRegex))
             }
 
-            it("should return expected inAppSubscriptionId") {
-                bundleMock.infoDictionaryMock[Constants.Info.subscriptionIDKey] = "sub-id"
-                expect(bundleInfo.inAppSubscriptionId).to(equal("sub-id"))
+            context("when calling inAppSubscriptionId") {
+
+                context("and subscriptionIDOverride is nil") {
+                    it("should return the value from Info.plist") {
+                        bundleMock.infoDictionaryMock[Constants.Info.subscriptionIDKey] = "sub-id"
+                        expect(bundleInfo.inAppSubscriptionId).to(equal("sub-id"))
+                    }
+                }
+
+                context("and subscriptionIDOverride is not nil") {
+                    beforeEach {
+                        bundleInfo.subscriptionIDOverride = "another-sub-id"
+                    }
+                    it("should return subscriptionIDOverride value") {
+                        expect(bundleInfo.inAppSubscriptionId).to(equal("another-sub-id"))
+                    }
+                }
             }
 
-            it("should return expected inAppConfigurationURL") {
-                bundleMock.infoDictionaryMock[Constants.Info.configurationURLKey] = "http://config.url"
-                expect(bundleInfo.inAppConfigurationURL).to(equal("http://config.url"))
+            context("when calling inAppConfigurationURL") {
+
+                context("and subscriptionIDOverride is nil") {
+                    it("should return the value from Info.plist") {
+                        bundleMock.infoDictionaryMock[Constants.Info.configurationURLKey] = "http://config.url"
+                        expect(bundleInfo.inAppConfigurationURL).to(equal("http://config.url"))
+                    }
+                }
+
+                context("and subscriptionIDOverride is not nil") {
+                    beforeEach {
+                        bundleInfo.configurationURLOverride = "http://config.alt"
+                    }
+                    it("should return subscriptionIDOverride value") {
+                        expect(bundleInfo.inAppConfigurationURL).to(equal("http://config.alt"))
+                    }
+                }
             }
 
             it("should return expected customFontNameTitle") {
@@ -70,6 +99,11 @@ class BundleInfoMocked: BundleInfo {
     static var bundleMock: BundleMock!
     override class var bundle: Bundle {
         bundleMock
+    }
+
+    static func reset() {
+        subscriptionIDOverride = nil
+        configurationURLOverride = nil
     }
 }
 


### PR DESCRIPTION
# Description
Added an option to set configurationURL and subscription ID in `configure()` API method.
Those settings will override values set in Info.plist
This feature is meant to be used for test purposes only - that's why it's not mentioned in the README.

## Links
SDKCF-5614

# Checklist
- [X] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [X] I wrote/updated tests for new/changed code
- [X] I removed all sensitive data **before every commit**, including API endpoints and keys
- [X] I ran `fastlane ci` without errors
