### PR TITLE
improve: add warning when calling `registerPreference()` on uninitialized module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 	- Enable triggers validation for test campaigns [SDKCF-5776]
 	- Refactor for Xcode 14 compatibility [SDCFK-5611]
 	- Integrated with Emerge Tools [SDKCF-5346]
+	- Added a warning when `registerPreference()` is called before `configure()`
 - Bug fixes:
 	- Fixed Opt-out message visibility on a dark background [SDKCF-5620]
 	- Fixed an issue when test campaigns were not displayed [SDKCF-5636]

--- a/Sources/RInAppMessaging/RInAppMessaging.swift
+++ b/Sources/RInAppMessaging/RInAppMessaging.swift
@@ -117,6 +117,7 @@ import RSDKUtils
 
     /// Log the event name passed in and also pass the event name to the view controller to display a matching campaign.
     /// - Parameter event: The Event object to log.
+    /// - Warning: ⚠️ Calling this method prior to `configure()` has no effect.
     @objc public static func logEvent(_ event: Event) {
         inAppQueue.async {
             notifyIfModuleNotInitialized()
@@ -129,9 +130,11 @@ import RSDKUtils
     /// Registered object should be updated to reflect current user session state.
     /// Should only be called once unless new `UserInfoProvider` object has been created.
     /// - Note: This method creates a strong reference to provided object.
+    /// - Warning: ⚠️ Calling this method prior to `configure()` has no effect.
     /// - Parameter provider: object that will always contain up-to-date user information.
     @objc public static func registerPreference(_ provider: UserInfoProvider) {
         inAppQueue.async {
+            notifyIfModuleNotInitialized()
             initializedModule?.registerPreference(provider)
         }
     }

--- a/Tests/Tests/PublicAPISpec.swift
+++ b/Tests/Tests/PublicAPISpec.swift
@@ -118,7 +118,8 @@ class PublicAPISpec: QuickSpec {
 
                 RInAppMessaging.closeMessage(clearQueuedCampaigns: true) // 1st error sent
                 RInAppMessaging.logEvent(LoginSuccessfulEvent()) // 2nd error sent
-                expect(errorReceiver.totalErrorNumber).toEventually(equal(2))
+                RInAppMessaging.registerPreference(UserInfoProviderMock()) // 3rd error sent
+                expect(errorReceiver.totalErrorNumber).toEventually(equal(3))
             }
 
             it("won't reinitialize module if config was called more than once") {


### PR DESCRIPTION
# Description
Added a warning to prevent users from calling `registerPreference()` on uninitialized/deinitialized module (usually - before calling `configure()`)

# Checklist
- [X] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [X] I wrote/updated tests for new/changed code
- [X] I removed all sensitive data **before every commit**, including API endpoints and keys
- [X] I ran `fastlane ci` without errors
