### PR TITLE
fix: fix incorrect status bar overlay color when app is in background (SDKCF-5134)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### 7.3.0 (in-progress)
+- Bug fixes:
+	- Fixed an edge case of not readable status bar when campaign message is displayed [SDKCF-5134]
+
 ### 7.2.0 (2022-09-23)
 - Features:
 	- Added Push Primer feature [SDKCF-5631]

--- a/Sources/RInAppMessaging/Extensions/UIApplication+IAM.swift
+++ b/Sources/RInAppMessaging/Extensions/UIApplication+IAM.swift
@@ -18,7 +18,7 @@ extension UIApplication {
     func getCurrentStatusBarStyle() -> UIStatusBarStyle? {
         if #available(iOS 13.0, *),
            let keyScene = connectedScenes
-                .filter({ $0.activationState == .foregroundActive })
+                .filter({ $0.activationState != .unattached })
                 .compactMap({ $0 as? UIWindowScene })
                 .first {
 


### PR DESCRIPTION
# Description
In some apps, when app enters background, views are laid out again.
This makes the IAM SDK to reload status bar overlay view in displayed campaign.
Previously the code ignored non-foreground scenes when checking for current `statusBarStyle` which made statusbar overlay color to turn white when app re-enters foreground.

## Links
SDKCF-5134

# Checklist
- [X] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [ ] I wrote/updated tests for new/changed code
- [X] I removed all sensitive data **before every commit**, including API endpoints and keys
- [ ] I ran `fastlane ci` without errors
