### PR TITLE
build: use Swiftlint 0.48 to keep support of Xcode 12

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -5,7 +5,7 @@ secrets = ["RIAM_CONFIG_URL", "RIAM_APP_SUBSCRIPTION_KEY"]
 
 target 'RInAppMessaging_Example' do
   pod 'RInAppMessaging', :path => '.'
-  pod 'SwiftLint', '~> 0.42'
+  pod 'SwiftLint', '~> 0.48.0' # Version 0.49+ requires macOS 12 and Swift 5.6
   pod 'RSDKUtils', '~> 3.0.0', :testspecs => ['Nimble', 'TestHelpers']
   pod 'Shock', '~> 6.1.2'
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -23,7 +23,7 @@ PODS:
   - Shock (6.1.3):
     - GRMustache.swift (~> 4.0.1)
     - SwiftNIOHTTP1 (~> 2.40.0)
-  - SwiftLint (0.49.1)
+  - SwiftLint (0.48.0)
   - SwiftNIO (2.40.0):
     - _NIODataStructures (= 2.40.0)
     - CNIOAtomics (= 2.40.0)
@@ -75,7 +75,7 @@ DEPENDENCIES:
   - RSDKUtils/Nimble (~> 3.0.0)
   - RSDKUtils/TestHelpers (~> 3.0.0)
   - Shock (~> 6.1.2)
-  - SwiftLint (~> 0.42)
+  - SwiftLint (~> 0.48.0)
 
 SPEC REPOS:
   trunk:
@@ -115,7 +115,7 @@ SPEC CHECKSUMS:
   RInAppMessaging: a2222cac79bdb4d59a02e73bc3d4c6a2858f49bb
   RSDKUtils: 36d97c9a41b5663ba56e73c626d27034a6c317e5
   Shock: 34def30d5e729f6c1eea2a5b5c2d024b875af86c
-  SwiftLint: 32ee33ded0636d0905ef6911b2b67bbaeeedafa5
+  SwiftLint: 284cea64b6187c5d6bd83e9a548a64104d546447
   SwiftNIO: 829958aab300642625091f82fc2f49cb7cf4ef24
   SwiftNIOConcurrencyHelpers: 697370136789b1074e4535eaae75cbd7f900370e
   SwiftNIOCore: 473fdfe746534d7aa25766916459eeaf6f92ef49
@@ -123,6 +123,6 @@ SPEC CHECKSUMS:
   SwiftNIOHTTP1: ef56706550a1dc135ea69d65215b9941e643c23b
   SwiftNIOPosix: b49af4bdbecaadfadd5c93dfe28594d6722b75e4
 
-PODFILE CHECKSUM: 9e922fb3ca31e623e3b88023d57a4c75f174d52b
+PODFILE CHECKSUM: 30fb706261fb06341d27739c9d7037679aba8741
 
 COCOAPODS: 1.11.3


### PR DESCRIPTION
# Description
Swiftlint 0.48 is the last version to support macOS 11 and Xcode 12

# Checklist
- [X] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [ ] I wrote/updated tests for new/changed code
- [X] I removed all sensitive data **before every commit**, including API endpoints and keys
- [ ] I ran `fastlane ci` without errors
