### PR TITLE
feat: add new API method to close displayed tooltips (SDKCF-6027)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## Changelog
 
 ### 7.3.0 (in-progress)
+- Features:
+	- Added new API method to close displayed tooltips [SDKCF-6027]
 - Bug fixes:
 	- Fixed an edge case of not readable status bar when campaign message is displayed [SDKCF-5134]
 

--- a/Sources/RInAppMessaging/InAppMessagingModule.swift
+++ b/Sources/RInAppMessaging/InAppMessagingModule.swift
@@ -116,6 +116,10 @@ internal class InAppMessagingModule: ErrorDelegate, CampaignDispatcherDelegate, 
         router.discardDisplayedCampaign()
     }
 
+    func closeTooltip(with uiElementIdentifier: String) {
+        router.discardDisplayedTooltip(with: uiElementIdentifier)
+    }
+
     // visible for testing
     func checkUserChanges() {
         if accountRepository.updateUserInfo() {

--- a/Sources/RInAppMessaging/RInAppMessaging.swift
+++ b/Sources/RInAppMessaging/RInAppMessaging.swift
@@ -159,6 +159,19 @@ import RSDKUtils
         }
     }
 
+    /// Close currently displayed tooltip that's bound to a UI element with given identifier.
+    ///
+    /// This method should be called when app needs to force-close displayed tooltip without user action.
+    /// Tooltip's impressions won't be sent (i.e. the message won't be counted as displayed)
+    /// - Parameter uiElementIdentifier: accessibilityIdentifier of UI element that displayed tooltip is attached to.
+    ///                                  (a.k.a. `UIElement` parameter in tooltip JSON payload)
+    @objc public static func closeTooltip(with uiElementIdentifier: String) {
+        inAppQueue.async {
+            notifyIfModuleNotInitialized()
+            initializedModule?.closeTooltip(with: uiElementIdentifier)
+        }
+    }
+
     private static func notifyIfModuleNotInitialized() {
         guard initializedModule == nil else {
             return

--- a/Sources/RInAppMessaging/Router.swift
+++ b/Sources/RInAppMessaging/Router.swift
@@ -79,7 +79,7 @@ internal class Router: RouterType, ViewListenerObserver {
         displayQueue.sync {
             DispatchQueue.main.async {
                 let displayedToolip = self.displayedTooltips[uiElementIdentifier]
-                displayedToolip?.presenter.onDismiss(true)
+                displayedToolip?.presenter.onDismiss?(true)
                 displayedToolip?.removeFromSuperview()
             }
         }

--- a/Sources/RInAppMessaging/Router.swift
+++ b/Sources/RInAppMessaging/Router.swift
@@ -25,10 +25,17 @@ internal protocol RouterType: ErrorReportable {
                         identifier: String,
                         imageBlob: Data,
                         becameVisibleHandler: @escaping (_ tooltipView: TooltipView) -> Void,
-                        completion: @escaping () -> Void)
-
+                        completion: @escaping (_ cancelled: Bool) -> Void)
+    
     /// Removes displayed campaign view from the stack
     func discardDisplayedCampaign()
+
+    /// Removes all tooltips attached to a view with matching uiElementIdentifier
+    func discardDisplayedTooltip(with uiElementIdentifier: String)
+
+    /// Checks if given tooltip is already displayed.
+    /// - Returns: true if the tooltip is currently displayed. `displayTooltip()` shouldn't be called in this case.
+    func isDisplayingTooltip(with uiElementIdentifier: String) -> Bool
 }
 
 /// Handles all the displaying logic of the SDK.
@@ -65,6 +72,27 @@ internal class Router: RouterType, ViewListenerObserver {
                 presentedView.onDismiss?(true)
                 presentedView.removeFromSuperview()
             }
+        }
+    }
+
+    func discardDisplayedTooltip(with uiElementIdentifier: String) {
+        displayQueue.sync {
+            DispatchQueue.main.async {
+                let displayedToolip = self.displayedTooltips[uiElementIdentifier]
+                displayedToolip?.presenter.onDismiss(true)
+                displayedToolip?.removeFromSuperview()
+            }
+        }
+    }
+
+    func isDisplayingTooltip(with uiElementIdentifier: String) -> Bool {
+        let result = {
+            return self.displayedTooltips[uiElementIdentifier] != nil
+        }
+        if Thread.current == .main {
+            return result()
+        } else {
+            return DispatchQueue.main.sync(execute: result)
         }
     }
 
@@ -149,7 +177,7 @@ internal class Router: RouterType, ViewListenerObserver {
                         identifier: String,
                         imageBlob: Data,
                         becameVisibleHandler: @escaping (_ tooltipView: TooltipView) -> Void,
-                        completion: @escaping () -> Void) {
+                        completion: @escaping (_ cancelled: Bool) -> Void) {
 
         guard let presenter = self.dependencyManager.resolve(type: TooltipPresenterType.self) else {
             Logger.debug("Error: TooltipPresenterType couldn't be resolved")
@@ -157,6 +185,7 @@ internal class Router: RouterType, ViewListenerObserver {
             return
         }
         guard let tooltipData = tooltip.tooltipData else {
+            completion(true)
             return
         }
 
@@ -166,6 +195,7 @@ internal class Router: RouterType, ViewListenerObserver {
 
             guard let image = UIImage(data: imageBlob) else {
                 self.reportError(description: "Invalid image data for tooltip targeting \(tooltipData.bodyData.uiElementIdentifier)", data: nil)
+                completion(true)
                 return
             }
 
@@ -173,15 +203,16 @@ internal class Router: RouterType, ViewListenerObserver {
             let tooltipView = TooltipView(presenter: presenter)
 
             presenter.set(view: tooltipView, dataModel: tooltip, image: image)
-            presenter.onClose = { [weak self] in
+            presenter.onDismiss = { [weak self] cancelled in
                 self?.displayedTooltips[identifier]?.removeFromSuperview()
                 self?.displayedTooltips[identifier] = nil
-                completion()
+                completion(cancelled)
             }
 
             let superview = self.findParentViewForTooltip(targetView)
             guard superview != targetView else {
                 self.reportError(description: "Cannot find suitable view for tooltip targeting \(tooltipData.bodyData.uiElementIdentifier)", data: targetView)
+                completion(true)
                 return
             }
 

--- a/Sources/RInAppMessaging/Views/Presenters/TooltipPresenter.swift
+++ b/Sources/RInAppMessaging/Views/Presenters/TooltipPresenter.swift
@@ -2,7 +2,7 @@ import UIKit
 
 internal protocol TooltipPresenterType: ImpressionTrackable {
     var tooltip: Campaign? { get }
-    var onDismiss: (_ cancelled: Bool) -> Void { get set }
+    var onDismiss: ((_ cancelled: Bool) -> Void)? { get set }
 
     func set(view: TooltipView, dataModel: Campaign, image: UIImage)
     func didTapExitButton()
@@ -13,7 +13,7 @@ internal protocol TooltipPresenterType: ImpressionTrackable {
 internal class TooltipPresenter: TooltipPresenterType {
 
     var impressions: [Impression] = []
-    var onDismiss: (_ cancelled: Bool) -> Void = { _ in }
+    var onDismiss: ((_ cancelled: Bool) -> Void)?
     private(set) var impressionService: ImpressionServiceType
     private(set) var tooltip: Campaign?
     private weak var view: TooltipView?
@@ -53,7 +53,7 @@ internal class TooltipPresenter: TooltipPresenterType {
     }
 
     func dismiss() {
-        onDismiss(false)
+        onDismiss?(false)
         view?.removeFromSuperview()
     }
 

--- a/Sources/RInAppMessaging/Views/TooltipView.swift
+++ b/Sources/RInAppMessaging/Views/TooltipView.swift
@@ -242,6 +242,7 @@ internal class TooltipView: UIView {
 
     override func removeFromSuperview() {
         super.removeFromSuperview()
+        autoCloseTimer?.invalidate()
         exitButton.removeFromSuperview()
     }
 

--- a/Tests/Tests/Helpers/SharedMocks.swift
+++ b/Tests/Tests/Helpers/SharedMocks.swift
@@ -572,7 +572,7 @@ final class ViewListenerMock: ViewListenerType {
 
 final class TooltipPresenterMock: TooltipPresenterType {
     var tooltip: Campaign?
-    var onDismiss: (Bool) -> Void = { _ in }
+    var onDismiss: ((Bool) -> Void)?
     var impressions: [Impression] = []
     var impressionService: ImpressionServiceType = ImpressionServiceMock()
 

--- a/Tests/Tests/Helpers/TestHelpers.swift
+++ b/Tests/Tests/Helpers/TestHelpers.swift
@@ -75,9 +75,10 @@ struct TestHelpers {
     }
 
     static func generateTooltip(id: String,
+                                title: String = "[Tooltip] title",
                                 isTest: Bool = false,
                                 targetViewID: String? = nil,
-                                maxImpressions: Int = 1,
+                                maxImpressions: Int = 2,
                                 autoCloseSeconds: Int = 0,
                                 redirectURL: String = "",
                                 triggers: [Trigger] = []) -> Campaign {
@@ -92,7 +93,7 @@ struct TestHelpers {
                 hasNoEndDate: true,
                 isCampaignDismissable: true,
                 messagePayload: MessagePayload(
-                    title: "[Tooltip] title",
+                    title: title,
                     messageBody: """
                     {\"UIElement\" : \"\(targetViewID ?? TooltipViewIdentifierMock)\", \"position\": \"top-center\", \"auto-disappear\": \(autoCloseSeconds), \"redirectURL\": \"\(redirectURL)\"}
                     """, // swiftlint:disable:previous line_length
@@ -103,7 +104,7 @@ struct TestHelpers {
                     backgroundColor: "#ffffff",
                     frameColor: "color5",
                     resource: Resource(
-                        imageUrl: "https://example.com/cat.jpg", // "https://picsum.photos/100"
+                        imageUrl: Bundle.unitTests?.url(forResource: "test-image", withExtension: "png")!.absoluteString,
                         cropType: .fill),
                     messageSettings: MessageSettings(
                         displaySettings: DisplaySettings(
@@ -148,6 +149,22 @@ struct TestHelpers {
                 nextPingMilliseconds: Int.max,
                 currentPingMilliseconds: 0,
                 data: campaigns)
+        }
+
+        static func withGeneratedTooltip(uiElementIdentifier: String,
+                                         maxImpressions: Int = 2,
+                                         addContexts: Bool = false,
+                                         triggers: [Trigger] = []) -> PingResponse {
+            let title = addContexts ? "[Tooltip][ctx] testTitle" : "[Tooltip] testTitle"
+            let tooltip = generateTooltip(id: "tooltip-id",
+                                          title: title,
+                                          targetViewID: uiElementIdentifier,
+                                          triggers: triggers)
+
+            return PingResponse(
+                nextPingMilliseconds: Int.max,
+                currentPingMilliseconds: 0,
+                data: [tooltip])
         }
 
         static let stringTypeWithEqualsOperator: PingResponse = {

--- a/Tests/Tests/InAppMessagingModuleSpec.swift
+++ b/Tests/Tests/InAppMessagingModuleSpec.swift
@@ -650,6 +650,14 @@ class InAppMessagingModuleSpec: QuickSpec {
                     }
                 }
             }
+
+            context("when calling closeTooltip()") {
+                it("will tell router to discard displayed tooltip with matching identifier") {
+                    let tooltipID = "tooltip-target-id"
+                    iamModule.closeTooltip(with: tooltipID)
+                    expect(router.lastIdentifierOfDiscardedTooltip).to(equal(tooltipID))
+                }
+            }
         }
     }
 }

--- a/Tests/Tests/TooltipDispatcherSpec.swift
+++ b/Tests/Tests/TooltipDispatcherSpec.swift
@@ -111,11 +111,6 @@ class TooltipDispatcherSpec: QuickSpec {
                     expect(router.lastDisplayedTooltip).toEventuallyNot(beNil())
                 }
 
-                it("will decrement impressionsLeft when tooltip was closed") {
-                    router.completeDisplayingTooltip()
-                    expect(campaignRepository.decrementImpressionsCalls).toEventually(equal(1))
-                }
-
                 it("will not decrement impressionsLeft when before tooltip is closed") {
                     expect(campaignRepository.decrementImpressionsCalls).toAfterTimeout(equal(0))
                 }
@@ -140,6 +135,30 @@ class TooltipDispatcherSpec: QuickSpec {
                     expect(tooltipView.startedAutoDisappearing).toAfterTimeout(beFalse())
 
                     anotherTargetView.removeFromSuperview()
+                }
+            }
+
+            context("after dispatching") {
+                beforeEach {
+                    let tooltip = TestHelpers.generateTooltip(id: "test", autoCloseSeconds: 10)
+                    dispatcher.setNeedsDisplay(tooltip: tooltip)
+                    dispatcher.viewDidMoveToWindow(targetView, identifier: TooltipViewIdentifierMock)
+                    expect(router.lastDisplayedTooltip).toEventuallyNot(beNil())
+                }
+
+                it("will decrement impressionsLeft") {
+                    router.completeDisplayingTooltip(cancelled: false)
+                    expect(campaignRepository.decrementImpressionsCalls).to(equal(1))
+                }
+
+                it("will not decrement impressionsLeft when display was cancelled") {
+                    router.completeDisplayingTooltip(cancelled: true)
+                    expect(campaignRepository.decrementImpressionsCalls).toAfterTimeout(equal(0))
+                }
+
+                it("will remove the tooltip from queue") {
+                    router.completeDisplayingTooltip(cancelled: false)
+                    expect(dispatcher.queuedTooltips).toNot(contain(tooltip))
                 }
             }
         }

--- a/Tests/Tests/TooltipDispatcherSpec.swift
+++ b/Tests/Tests/TooltipDispatcherSpec.swift
@@ -148,7 +148,7 @@ class TooltipDispatcherSpec: QuickSpec {
 
                 it("will decrement impressionsLeft") {
                     router.completeDisplayingTooltip(cancelled: false)
-                    expect(campaignRepository.decrementImpressionsCalls).to(equal(1))
+                    expect(campaignRepository.decrementImpressionsCalls).toEventually(equal(1))
                 }
 
                 it("will not decrement impressionsLeft when display was cancelled") {
@@ -158,7 +158,7 @@ class TooltipDispatcherSpec: QuickSpec {
 
                 it("will remove the tooltip from queue") {
                     router.completeDisplayingTooltip(cancelled: false)
-                    expect(dispatcher.queuedTooltips).toNot(contain(tooltip))
+                    expect(dispatcher.queuedTooltips).toEventuallyNot(contain(tooltip))
                 }
             }
         }

--- a/Tests/Tests/TooltipPresenterSpec.swift
+++ b/Tests/Tests/TooltipPresenterSpec.swift
@@ -49,13 +49,13 @@ class TooltipPresenterSpec: QuickSpec {
                     presenter.set(view: TooltipViewMock(), dataModel: tooltip, image: UIImage())
                 }
 
-                it("will call onClose") {
-                    var wasOnCloseCalled = false
-                    presenter.onClose = {
-                        wasOnCloseCalled = true
+                it("will call onDismiss") {
+                    var wasOnDismissCalled = false
+                    presenter.onDismiss = { _ in
+                        wasOnDismissCalled = true
                     }
                     presenter.didTapExitButton()
-                    expect(wasOnCloseCalled).to(beTrue())
+                    expect(wasOnDismissCalled).to(beTrue())
                 }
 
                 it("will log exit impression") {
@@ -76,13 +76,13 @@ class TooltipPresenterSpec: QuickSpec {
                     presenter.set(view: TooltipViewMock(), dataModel: tooltip, image: UIImage())
                 }
 
-                it("will call onClose") {
-                    var wasOnCloseCalled = false
-                    presenter.onClose = {
-                        wasOnCloseCalled = true
+                it("will call onDismiss") {
+                    var wasOnDismissCalled = false
+                    presenter.onDismiss = { _ in
+                        wasOnDismissCalled = true
                     }
                     presenter.didTapImage()
-                    expect(wasOnCloseCalled).to(beTrue())
+                    expect(wasOnDismissCalled).to(beTrue())
                 }
 
                 it("will log clickContent impression") {
@@ -101,13 +101,13 @@ class TooltipPresenterSpec: QuickSpec {
                         presenter.set(view: TooltipViewMock(), dataModel: tooltip, image: UIImage())
                     }
 
-                    it("will not call onClose") {
-                        var wasOnCloseCalled = false
-                        presenter.onClose = {
-                            wasOnCloseCalled = true
+                    it("will not call onDismiss") {
+                        var wasOnDismissCalled = false
+                        presenter.onDismiss = { _ in
+                            wasOnDismissCalled = true
                         }
                         presenter.didTapImage()
-                        expect(wasOnCloseCalled).to(beFalse())
+                        expect(wasOnDismissCalled).to(beFalse())
                     }
 
                     it("will not log clickContent impression") {
@@ -119,6 +119,30 @@ class TooltipPresenterSpec: QuickSpec {
                         presenter.didTapImage()
                         expect(impressionService.sentImpressions).to(beNil())
                     }
+                }
+            }
+
+            context("when calling dismiss()") {
+
+                var view: TooltipViewMock!
+
+                beforeEach {
+                    view = TooltipViewMock()
+                    presenter.set(view: view, dataModel: tooltip, image: UIImage())
+                }
+
+                it("will call onDismiss") {
+                    var wasOnDismissCalled = false
+                    presenter.onDismiss = { _ in
+                        wasOnDismissCalled = true
+                    }
+                    presenter.dismiss()
+                    expect(wasOnDismissCalled).to(beTrue())
+                }
+
+                it("will remove view from superview") {
+                    presenter.dismiss()
+                    expect(view.didCallRemoveFromSuperview).to(beTrue())
                 }
             }
         }


### PR DESCRIPTION
# Description
Added new `closeTooltip()` API method for closing displayed tooltip with given identifier
The method works in a similar way to `closeMessage()`

## Links
SDKCF-6027

# Checklist
- [X] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [X] I wrote/updated tests for new/changed code
- [X] I removed all sensitive data **before every commit**, including API endpoints and keys
- [X] I ran `fastlane ci` without errors
