### PR TITLE
feat: add contexts validation for tooltip campaigns (SDKCF-6028)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### 7.3.0 (in-progress)
 - Features:
 	- Added new API method to close displayed tooltips [SDKCF-6027]
+	- Added contexts validation for tooltip campaigns [SDKCF-6028]
 - Bug fixes:
 	- Fixed an edge case of not readable status bar when campaign message is displayed [SDKCF-5134]
 

--- a/Sources/RInAppMessaging/DependencyManager/MainContainer.swift
+++ b/Sources/RInAppMessaging/DependencyManager/MainContainer.swift
@@ -102,7 +102,7 @@ internal enum MainContainerFactory {
                                campaignRepository: manager.resolve(type: CampaignRepositoryType.self)!)
             }),
             ContainerElement(type: ViewListenerType.self, factory: {
-                ViewListener.instance
+                ViewListener.currentInstance
             })]
 
         // transient containers

--- a/Sources/RInAppMessaging/InAppMessagingModule.swift
+++ b/Sources/RInAppMessaging/InAppMessagingModule.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// Class represents bootstrap behaviour and main functionality of InAppMessaging.
-internal class InAppMessagingModule: ErrorDelegate, CampaignDispatcherDelegate, UserChangeObserver {
+internal class InAppMessagingModule: ErrorDelegate, CampaignDispatcherDelegate, UserChangeObserver, TooltipDispatcherDelegate {
 
     private let configurationManager: ConfigurationManagerType
     private let campaignsListManager: CampaignsListManagerType
@@ -31,7 +31,8 @@ internal class InAppMessagingModule: ErrorDelegate, CampaignDispatcherDelegate, 
          campaignRepository: CampaignRepositoryType,
          router: RouterType,
          randomizer: RandomizerType,
-         displayPermissionService: DisplayPermissionServiceType) {
+         displayPermissionService: DisplayPermissionServiceType,
+         tooltipDispatcher: TooltipDispatcherType) {
 
         self.configurationManager = configurationManager
         self.campaignsListManager = campaignsListManager
@@ -51,6 +52,7 @@ internal class InAppMessagingModule: ErrorDelegate, CampaignDispatcherDelegate, 
         self.router.errorDelegate = self
         self.readyCampaignDispatcher.delegate = self
         self.accountRepository.registerAccountUpdateObserver(self)
+        tooltipDispatcher.delegate = self
     }
 
     // should be called once
@@ -149,6 +151,14 @@ extension InAppMessagingModule {
     }
 
     func shouldShowCampaignMessage(title: String, contexts: [String]) -> Bool {
+        onVerifyContext?(contexts, title) ?? true
+    }
+}
+
+// MARK: - TooltipDispatcherDelegate methods
+extension InAppMessagingModule {
+    
+    func shouldShowTooltip(title: String, contexts: [String]) -> Bool {
         onVerifyContext?(contexts, title) ?? true
     }
 }

--- a/Sources/RInAppMessaging/RInAppMessaging.swift
+++ b/Sources/RInAppMessaging/RInAppMessaging.swift
@@ -79,21 +79,22 @@ import RSDKUtils
             }
 
             guard let configurationManager = dependencyManager.resolve(type: ConfigurationManagerType.self),
-                let campaignsListManager = dependencyManager.resolve(type: CampaignsListManagerType.self),
-                let impressionService = dependencyManager.resolve(type: ImpressionServiceType.self),
-                let eventMatcher = dependencyManager.resolve(type: EventMatcherType.self),
-                let accountRepository = dependencyManager.resolve(type: AccountRepositoryType.self),
-                let readyCampaignDispatcher = dependencyManager.resolve(type: CampaignDispatcherType.self),
-                let campaignTriggerAgent = dependencyManager.resolve(type: CampaignTriggerAgentType.self),
-                let campaignRepository = dependencyManager.resolve(type: CampaignRepositoryType.self),
-                let router = dependencyManager.resolve(type: RouterType.self),
-                let randomizer = dependencyManager.resolve(type: Randomizer.self),
-                let displayPermissionService = dependencyManager.resolve(type: DisplayPermissionServiceType.self),
-                let viewListener = dependencyManager.resolve(type: ViewListenerType.self),
-                let _ = dependencyManager.resolve(type: TooltipManagerType.self) else {
+                  let campaignsListManager = dependencyManager.resolve(type: CampaignsListManagerType.self),
+                  let impressionService = dependencyManager.resolve(type: ImpressionServiceType.self),
+                  let eventMatcher = dependencyManager.resolve(type: EventMatcherType.self),
+                  let accountRepository = dependencyManager.resolve(type: AccountRepositoryType.self),
+                  let readyCampaignDispatcher = dependencyManager.resolve(type: CampaignDispatcherType.self),
+                  let campaignTriggerAgent = dependencyManager.resolve(type: CampaignTriggerAgentType.self),
+                  let campaignRepository = dependencyManager.resolve(type: CampaignRepositoryType.self),
+                  let router = dependencyManager.resolve(type: RouterType.self),
+                  let randomizer = dependencyManager.resolve(type: Randomizer.self),
+                  let displayPermissionService = dependencyManager.resolve(type: DisplayPermissionServiceType.self),
+                  let viewListener = dependencyManager.resolve(type: ViewListenerType.self),
+                  let _ = dependencyManager.resolve(type: TooltipManagerType.self),
+                  let tooltipDispatcher = dependencyManager.resolve(type: TooltipDispatcherType.self) else {
 
-                    assertionFailure("In-App Messaging SDK module initialization failure: Dependencies could not be resolved")
-                    return
+                assertionFailure("In-App Messaging SDK module initialization failure: Dependencies could not be resolved")
+                return
             }
             router.accessibilityCompatibleDisplay = accessibilityCompatibleDisplay
 
@@ -107,7 +108,8 @@ import RSDKUtils
                                                      campaignRepository: campaignRepository,
                                                      router: router,
                                                      randomizer: randomizer,
-                                                     displayPermissionService: displayPermissionService)
+                                                     displayPermissionService: displayPermissionService,
+                                                     tooltipDispatcher: tooltipDispatcher)
             initializedModule?.aggregatedErrorHandler = errorCallback
             initializedModule?.onVerifyContext = onVerifyContext
             initializedModule?.initialize { shouldDeinit in

--- a/Tests/Tests/CampaignsValidatorSpec.swift
+++ b/Tests/Tests/CampaignsValidatorSpec.swift
@@ -42,12 +42,7 @@ class CampaignsValidatorSpec: QuickSpec {
             it("will accept non-test campaigns with matching criteria") {
                 let campaign = TestHelpers.generateCampaign(
                     id: "test", maxImpressions: 2,
-                    triggers: [Trigger(
-                        type: .event,
-                        eventType: .loginSuccessful,
-                        eventName: "testevent",
-                        attributes: []
-                        )])
+                    triggers: [Trigger.loginEventTrigger])
                 campaignRepository.syncWith(list: [campaign, MockedCampaigns.outdatedCampaign],
                                             timestampMilliseconds: 0)
                 let event = LoginSuccessfulEvent()
@@ -70,12 +65,7 @@ class CampaignsValidatorSpec: QuickSpec {
             it("won't accept campaigns with no impressions left") {
                 let campaign = TestHelpers.generateCampaign(
                     id: "test", maxImpressions: 0,
-                    triggers: [Trigger(
-                        type: .event,
-                        eventType: .loginSuccessful,
-                        eventName: "testevent",
-                        attributes: []
-                        )])
+                    triggers: [Trigger.loginEventTrigger])
                 campaignRepository.syncWith(list: [campaign], timestampMilliseconds: 0)
                 eventMatcher.matchAndStore(event: LoginSuccessfulEvent())
                 campaignsValidator.validate(validatedCampaignHandler: validatorHandler.closure)
@@ -92,12 +82,7 @@ class CampaignsValidatorSpec: QuickSpec {
             it("won't accept opted out campaigns") {
                 let campaign = TestHelpers.generateCampaign(
                     id: "test", maxImpressions: 2,
-                    triggers: [Trigger(
-                        type: .event,
-                        eventType: .loginSuccessful,
-                        eventName: "testevent",
-                        attributes: []
-                        )])
+                    triggers: [Trigger.loginEventTrigger])
                 campaignRepository.syncWith(list: [campaign], timestampMilliseconds: 0)
                 eventMatcher.matchAndStore(event: LoginSuccessfulEvent())
                 _ = campaignRepository.optOutCampaign(campaign)
@@ -223,26 +208,14 @@ private enum MockedCampaigns {
 
     static let testCampaign = TestHelpers.generateCampaign(
         id: "test", maxImpressions: 2, test: true,
-        triggers: [Trigger(
-            type: .event,
-            eventType: .loginSuccessful,
-            eventName: "testevent",
-            attributes: []
-        )])
+        triggers: [Trigger.loginEventTrigger])
 
     static let outdatedTestCampaign = Campaign(
         data: CampaignData(
             campaignId: "test",
             maxImpressions: 1,
             type: .modal,
-            triggers: [
-                Trigger(
-                    type: .event,
-                    eventType: .loginSuccessful,
-                    eventName: "testevent",
-                    attributes: []
-                )
-            ],
+            triggers: [Trigger.loginEventTrigger],
             isTest: true,
             infiniteImpressions: false,
             hasNoEndDate: false,
@@ -256,14 +229,7 @@ private enum MockedCampaigns {
             campaignId: "test",
             maxImpressions: 2,
             type: .modal,
-            triggers: [
-                Trigger(
-                    type: .event,
-                    eventType: .loginSuccessful,
-                    eventName: "testevent",
-                    attributes: []
-                )
-            ],
+            triggers: [Trigger.loginEventTrigger],
             isTest: false,
             infiniteImpressions: false,
             hasNoEndDate: false,

--- a/Tests/Tests/Helpers/TestHelpers.swift
+++ b/Tests/Tests/Helpers/TestHelpers.swift
@@ -519,3 +519,10 @@ extension Result {
         }
     }
 }
+
+extension Trigger {
+    static let loginEventTrigger = Trigger(type: .event,
+                                           eventType: .loginSuccessful,
+                                           eventName: "login",
+                                           attributes: [])
+}

--- a/Tests/Tests/InAppMessagingModuleSpec.swift
+++ b/Tests/Tests/InAppMessagingModuleSpec.swift
@@ -54,27 +54,12 @@ class InAppMessagingModuleSpec: QuickSpec {
                                                  campaignRepository: campaignRepository,
                                                  router: router,
                                                  randomizer: randomizer,
-                                                 displayPermissionService: DisplayPermissionServiceMock())
+                                                 displayPermissionService: DisplayPermissionServiceMock(),
+                                                 tooltipDispatcher: TooltipDispatcherMock())
             }
 
             it("is enabled by deafult") {
                 expect(iamModule.isEnabled).to(beTrue())
-            }
-
-            it("will return true for shouldShowCampaignMessage if onVerifyContext is nil") {
-                iamModule.onVerifyContext = nil
-                expect(iamModule.shouldShowCampaignMessage(title: "", contexts: [])).to(beTrue())
-            }
-
-            it("will call onVerifyContext if shouldShowCampaignMessage was called") {
-                var onVerifyContextCalled = false
-                iamModule.onVerifyContext = { _, _ in
-                    onVerifyContextCalled = true
-                    return true
-                }
-                _ = iamModule.shouldShowCampaignMessage(title: "", contexts: [])
-
-                expect(onVerifyContextCalled).to(beTrue())
             }
 
             context("when calling initialize") {
@@ -602,9 +587,44 @@ class InAppMessagingModuleSpec: QuickSpec {
 
                 context("as CampaignDispatcherDelegate") {
 
+                    it("will return true for shouldShowCampaignMessage if onVerifyContext is nil") {
+                        iamModule.onVerifyContext = nil
+                        expect(iamModule.shouldShowCampaignMessage(title: "", contexts: [])).to(beTrue())
+                    }
+
+                    it("will call onVerifyContext if shouldShowCampaignMessage was called") {
+                        var onVerifyContextCalled = false
+                        iamModule.onVerifyContext = { _, _ in
+                            onVerifyContextCalled = true
+                            return true
+                        }
+                        _ = iamModule.shouldShowCampaignMessage(title: "", contexts: [])
+
+                        expect(onVerifyContextCalled).to(beTrue())
+                    }
+
                     it("will refresh list of campaigns when performPing was called") {
                         iamModule.performPing()
                         expect(campaignsListManager.wasRefreshListCalled).to(beTrue())
+                    }
+                }
+
+                context("as TooltipDispatcherDelegate") {
+
+                    it("will return true for shouldShowTooltip if onVerifyContext is nil") {
+                        iamModule.onVerifyContext = nil
+                        expect(iamModule.shouldShowTooltip(title: "", contexts: [])).to(beTrue())
+                    }
+
+                    it("will call onVerifyContext if shouldShowTooltip was called") {
+                        var onVerifyContextCalled = false
+                        iamModule.onVerifyContext = { _, _ in
+                            onVerifyContextCalled = true
+                            return true
+                        }
+                        _ = iamModule.shouldShowTooltip(title: "", contexts: [])
+
+                        expect(onVerifyContextCalled).to(beTrue())
                     }
                 }
 

--- a/Tests/Tests/PublicAPISpec.swift
+++ b/Tests/Tests/PublicAPISpec.swift
@@ -57,10 +57,7 @@ class PublicAPISpec: QuickSpec {
         func generateAndDisplayLoginCampaigns(count: Int, addContexts: Bool) {
             messageMixerService.mockedResponse = TestHelpers.MockResponse.withGeneratedCampaigns(
                 count: count, test: false, delay: 100, addContexts: addContexts,
-                triggers: [Trigger(type: .event,
-                                   eventType: .loginSuccessful,
-                                   eventName: "e1",
-                                   attributes: [])])
+                triggers: [Trigger.loginEventTrigger])
             campaignsListManager.refreshList()
             RInAppMessaging.logEvent(LoginSuccessfulEvent())
         }
@@ -68,10 +65,7 @@ class PublicAPISpec: QuickSpec {
         func generateAndDisplayLoginTooltip(uiElementIdentifier: String, addContexts: Bool) {
             messageMixerService.mockedResponse = TestHelpers.MockResponse.withGeneratedTooltip(
                 uiElementIdentifier: uiElementIdentifier, addContexts: addContexts,
-                triggers: [Trigger(type: .event,
-                                   eventType: .loginSuccessful,
-                                   eventName: "e1",
-                                   attributes: [])])
+                triggers: [Trigger.loginEventTrigger])
             campaignsListManager.refreshList()
             tooltipTargetView.accessibilityIdentifier = uiElementIdentifier
             UIApplication.shared.getKeyWindow()?.addSubview(tooltipTargetView)
@@ -198,10 +192,7 @@ class PublicAPISpec: QuickSpec {
                     }
                     messageMixerService.mockedResponse = TestHelpers.MockResponse.withGeneratedCampaigns(
                         count: 1, test: false, delay: 100, maxImpressions: 2, addContexts: false,
-                        triggers: [Trigger(type: .event,
-                                           eventType: .loginSuccessful,
-                                           eventName: "e1",
-                                           attributes: [])])
+                        triggers: [Trigger.loginEventTrigger])
                 })
                 RInAppMessaging.logEvent(LoginSuccessfulEvent())
                 RInAppMessaging.logEvent(LoginSuccessfulEvent())
@@ -334,7 +325,46 @@ class PublicAPISpec: QuickSpec {
                     expect(contextVerifier.onVerifyContextCallCount).to(equal(2))
                 }
 
-                it("will call the method before showing a message with proper parameters") {
+                it("will show a tooltip if the method returned true") {
+                    contextVerifier.shouldShowCampaign = true
+                    generateAndDisplayLoginTooltip(uiElementIdentifier: "view-id", addContexts: true)
+
+                    expect(UIApplication.shared.getKeyWindow()?.findTooltipView()).toEventuallyNot(beNil())
+                    expect(contextVerifier.onVerifyContextCallCount).to(beGreaterThan(0))
+                    // multiple onVerifyContext calls are possible due to target view tracking logic updates
+                }
+
+                it("will not show a tooltip if the method returned false") {
+                    contextVerifier.shouldShowCampaign = false
+                    generateAndDisplayLoginTooltip(uiElementIdentifier: "view-id", addContexts: true)
+
+                    expect(UIApplication.shared.getKeyWindow()?.findTooltipView()).toAfterTimeout(beNil())
+                    expect(contextVerifier.onVerifyContextCallCount).to(beGreaterThan(0))
+                    // multiple onVerifyContext calls are possible due to target view tracking logic updates
+                }
+
+                it("will call the method before showing a tooltip with expected parameters") {
+                    contextVerifier.shouldShowCampaign = true
+                    tooltipTargetView.accessibilityIdentifier = TooltipViewIdentifierMock
+                    messageMixerService.mockedResponse = PingResponse(
+                        nextPingMilliseconds: Int.max,
+                        currentPingMilliseconds: 0,
+                        data: [
+                            TestHelpers.generateTooltip(id: "1",
+                                                        title: "[Tooltip][ctx1][ctx2] title",
+                                                        targetViewID: tooltipTargetView.accessibilityIdentifier,
+                                                        triggers: [Trigger.loginEventTrigger])
+                        ])
+                    UIApplication.shared.getKeyWindow()?.addSubview(tooltipTargetView)
+                    campaignsListManager.refreshList()
+                    RInAppMessaging.logEvent(LoginSuccessfulEvent())
+
+                    expect(contextVerifier.onVerifyContextCallParameters?.title)
+                        .toEventually(equal("[Tooltip][ctx1][ctx2] title"), timeout: .seconds(2))
+                    expect(contextVerifier.onVerifyContextCallParameters?.contexts).to(contain(["Tooltip", "ctx1", "ctx2"]))
+                }
+
+                it("will call the method before showing a message with expected parameters") {
                     contextVerifier.shouldShowCampaign = true
                     messageMixerService.mockedResponse = PingResponse(
                         nextPingMilliseconds: Int.max,
@@ -342,17 +372,13 @@ class PublicAPISpec: QuickSpec {
                         data: [
                             TestHelpers.generateCampaign(id: "1",
                                                          title: "[ctx1][ctx2] title",
-                                                         triggers: [
-                                                            Trigger(type: .event,
-                                                                    eventType: .loginSuccessful,
-                                                                    eventName: "e1",
-                                                                    attributes: [])])])
+                                                         triggers: [Trigger.loginEventTrigger])
+                        ])
                     campaignsListManager.refreshList()
                     RInAppMessaging.logEvent(LoginSuccessfulEvent())
 
                     expect(contextVerifier.onVerifyContextCallParameters?.title).toEventually(equal("[ctx1][ctx2] title"), timeout: .seconds(2))
-                    expect(contextVerifier.onVerifyContextCallParameters?.contexts)
-                        .toEventually(contain(["ctx1", "ctx2"]), timeout: .seconds(2))
+                    expect(contextVerifier.onVerifyContextCallParameters?.contexts).to(contain(["ctx1", "ctx2"]))
                 }
             }
 
@@ -423,10 +449,7 @@ class PublicAPISpec: QuickSpec {
                 it("will not transfer cached data (sync) from anonymous user") {
                     messageMixerService.mockedResponse = TestHelpers.MockResponse.withGeneratedCampaigns(
                         count: 1, test: false, delay: 100, maxImpressions: 2, addContexts: false,
-                        triggers: [Trigger(type: .event,
-                                           eventType: .loginSuccessful,
-                                           eventName: "e1",
-                                           attributes: [])])
+                        triggers: [Trigger.loginEventTrigger])
                     RInAppMessaging.registerPreference(UserInfoProviderMock()) // anonymous user
                     RInAppMessaging.logEvent(LoginSuccessfulEvent())
 
@@ -446,10 +469,7 @@ class PublicAPISpec: QuickSpec {
                 it("will not transfer cached data (sync) from empty user") {
                     messageMixerService.mockedResponse = TestHelpers.MockResponse.withGeneratedCampaigns(
                         count: 1, test: false, delay: 100, maxImpressions: 2, addContexts: false,
-                        triggers: [Trigger(type: .event,
-                                           eventType: .loginSuccessful,
-                                           eventName: "e1",
-                                           attributes: [])])
+                        triggers: [Trigger.loginEventTrigger])
 
                     let emptyUser = UserInfoProviderMock()
                     emptyUser.userID = ""

--- a/Tests/Tests/PublicAPISpec.swift
+++ b/Tests/Tests/PublicAPISpec.swift
@@ -247,7 +247,7 @@ class PublicAPISpec: QuickSpec {
 
                 it("will start ViewListener when completion was called with shouldDeinit = false") {
                     // init called in `beforeEach`
-                    expect(ViewListener.instance.isListening).to(beTrue())
+                    expect(ViewListener.currentInstance.isListening).to(beTrue())
                 }
 
                 it("will stop ViewListener when completion was called with shouldDeinit = true") {
@@ -255,7 +255,7 @@ class PublicAPISpec: QuickSpec {
                     reinitializeSDK {
                         configurationManager.rolloutPercentage = 0 // triggers deinit
                     }
-                    expect(ViewListener.instance.isListening).toAfterTimeout(beFalse())
+                    expect(ViewListener.currentInstance.isListening).toAfterTimeout(beFalse())
                 }
             }
 

--- a/Tests/Tests/RouterSpec.swift
+++ b/Tests/Tests/RouterSpec.swift
@@ -11,7 +11,9 @@ import class RSDKUtilsMain.TypedDependencyManager
 
 @available(iOS 13.0, *) // Because of UIImage(named:in:with:)
 class RouterSpec: QuickSpec {
+// swiftlint:disable:previous type_body_length
 
+    // swiftlint:disable:next function_body_length
     override func spec() {
 
         describe("Router") {
@@ -170,6 +172,7 @@ class RouterSpec: QuickSpec {
                                               identifier: TooltipViewIdentifierMock,
                                               imageBlob: imageBlob,
                                               becameVisibleHandler: { _ in },
+                                              confirmation: true,
                                               completion: { _ in })
 
                         expect(window.findTooltipView()).toEventuallyNot(beNil())
@@ -183,6 +186,7 @@ class RouterSpec: QuickSpec {
                                               identifier: TooltipViewIdentifierMock,
                                               imageBlob: imageBlob,
                                               becameVisibleHandler: { _ in },
+                                              confirmation: true,
                                               completion: { cancelled in
                             expect(cancelled).to(beTrue())
                             completionCalled = true
@@ -200,6 +204,7 @@ class RouterSpec: QuickSpec {
                                               identifier: TooltipViewIdentifierMock,
                                               imageBlob: imageBlob,
                                               becameVisibleHandler: { _ in },
+                                              confirmation: true,
                                               completion: { _ in })
 
                         expect(window.findTooltipView()).toEventuallyNot(beNil())
@@ -228,212 +233,260 @@ class RouterSpec: QuickSpec {
                     targetView.removeFromSuperview()
                 }
 
-                it("will display a tooltip if all data is valid") {
-                    router.displayTooltip(tooltip,
-                                          targetView: targetView,
-                                          identifier: TooltipViewIdentifierMock,
-                                          imageBlob: imageBlob,
-                                          becameVisibleHandler: { _ in },
-                                          completion: { _ in })
-                    expect(window.findTooltipView()).toEventuallyNot(beNil())
+                context("and display is not confirmed") {
+
+                    it("will not display a tooltip") {
+                        router.displayTooltip(tooltip,
+                                              targetView: targetView,
+                                              identifier: TooltipViewIdentifierMock,
+                                              imageBlob: imageBlob,
+                                              becameVisibleHandler: { _ in },
+                                              confirmation: false,
+                                              completion: { _ in })
+                        expect(window.findTooltipView()).toAfterTimeout(beNil())
+                    }
+
+                    it("will call completion with true flag when tooltip was closed") {
+                        waitUntil { done in
+                            router.displayTooltip(tooltip,
+                                                  targetView: targetView,
+                                                  identifier: TooltipViewIdentifierMock,
+                                                  imageBlob: imageBlob,
+                                                  becameVisibleHandler: { _ in },
+                                                  confirmation: false,
+                                                  completion: { cancelled in
+
+                                expect(cancelled).to(beTrue())
+                                done()
+                            })
+                        }
+                    }
                 }
 
-                it("will call completion when tooltip was closed") {
-                    var completionCalled = false
-                    router.displayTooltip(tooltip,
-                                          targetView: targetView,
-                                          identifier: TooltipViewIdentifierMock,
-                                          imageBlob: imageBlob,
-                                          becameVisibleHandler: { _ in },
-                                          completion: { _ in
-                        completionCalled = true
-                    })
-                    expect(window.findTooltipView()).toEventuallyNot(beNil())
-                    let displayedTooltip = window.findTooltipView()
-                    displayedTooltip?.presenter.didTapExitButton()
-                    expect(completionCalled).toEventually(beTrue())
-                }
+                context("and display is confirmed") {
 
-                it("will not call completion if the tooltip was removed") {
-                    var completionCalled = false
-                    router.displayTooltip(tooltip,
-                                          targetView: targetView,
-                                          identifier: TooltipViewIdentifierMock,
-                                          imageBlob: imageBlob,
-                                          becameVisibleHandler: { _ in },
-                                          completion: { _ in
-                        completionCalled = true
-                    })
-                    expect(window.findTooltipView()).toEventuallyNot(beNil())
-                    let displayedTooltip = window.findTooltipView()!
-                    displayedTooltip.removeFromSuperview()
-                    expect(completionCalled).toAfterTimeout(beFalse())
-                }
+                    it("will display a tooltip if all data is valid") {
+                        router.displayTooltip(tooltip,
+                                              targetView: targetView,
+                                              identifier: TooltipViewIdentifierMock,
+                                              imageBlob: imageBlob,
+                                              becameVisibleHandler: { _ in },
+                                              confirmation: true,
+                                              completion: { _ in })
+                        expect(window.findTooltipView()).toEventuallyNot(beNil())
+                    }
 
-                it("will remove existing tooltip with the same target view") {
-                    router.displayTooltip(tooltip,
-                                          targetView: targetView,
-                                          identifier: TooltipViewIdentifierMock,
-                                          imageBlob: imageBlob,
-                                          becameVisibleHandler: { _ in },
-                                          completion: { _ in })
-                    expect(window.findTooltipView()).toEventuallyNot(beNil())
-                    let displayedTooltip = window.findTooltipView()
-                    expect(displayedTooltip?.superview).toNot(beNil())
+                    it("will call completion with false flag when tooltip was closed") {
+                        var completionCalled = false
+                        router.displayTooltip(tooltip,
+                                              targetView: targetView,
+                                              identifier: TooltipViewIdentifierMock,
+                                              imageBlob: imageBlob,
+                                              becameVisibleHandler: { _ in },
+                                              confirmation: true,
+                                              completion: { cancelled in
+                            expect(cancelled).to(beFalse())
+                            completionCalled = true
+                        })
+                        expect(window.findTooltipView()).toEventuallyNot(beNil())
+                        let displayedTooltip = window.findTooltipView()
+                        displayedTooltip?.presenter.didTapExitButton()
+                        expect(completionCalled).toEventually(beTrue())
+                    }
 
-                    router.displayTooltip(tooltip,
-                                          targetView: targetView,
-                                          identifier: TooltipViewIdentifierMock,
-                                          imageBlob: imageBlob,
-                                          becameVisibleHandler: { _ in },
-                                          completion: { _ in })
-                    expect(displayedTooltip?.superview).toEventually(beNil())
-                }
+                    it("will not call completion if the tooltip was removed") {
+                        var completionCalled = false
+                        router.displayTooltip(tooltip,
+                                              targetView: targetView,
+                                              identifier: TooltipViewIdentifierMock,
+                                              imageBlob: imageBlob,
+                                              becameVisibleHandler: { _ in },
+                                              confirmation: true,
+                                              completion: { _ in
+                            completionCalled = true
+                        })
+                        expect(window.findTooltipView()).toEventuallyNot(beNil())
+                        let displayedTooltip = window.findTooltipView()!
+                        displayedTooltip.removeFromSuperview()
+                        expect(completionCalled).toAfterTimeout(beFalse())
+                    }
 
-                it("will not display a tooltip if identifier does not match") {
-                    router.displayTooltip(tooltip,
-                                          targetView: targetView,
-                                          identifier: "invalid.id",
-                                          imageBlob: "image".data(using: .ascii)!,
-                                          becameVisibleHandler: { _ in },
-                                          completion: { _ in })
-                    expect(window.findTooltipView()).toAfterTimeout(beNil())
-                }
+                    it("will remove existing tooltip with the same target view") {
+                        router.displayTooltip(tooltip,
+                                              targetView: targetView,
+                                              identifier: TooltipViewIdentifierMock,
+                                              imageBlob: imageBlob,
+                                              becameVisibleHandler: { _ in },
+                                              confirmation: true,
+                                              completion: { _ in })
+                        expect(window.findTooltipView()).toEventuallyNot(beNil())
+                        let displayedTooltip = window.findTooltipView()
+                        expect(displayedTooltip?.superview).toNot(beNil())
 
-                it("will report an error if image data is invalid") {
-                    router.displayTooltip(tooltip,
-                                          targetView: targetView,
-                                          identifier: TooltipViewIdentifierMock,
-                                          imageBlob: "image".data(using: .ascii)!,
-                                          becameVisibleHandler: { _ in },
-                                          completion: { _ in })
-                    expect(errorDelegate.wasErrorReceived).toEventually(beTrue())
-                }
+                        router.displayTooltip(tooltip,
+                                              targetView: targetView,
+                                              identifier: TooltipViewIdentifierMock,
+                                              imageBlob: imageBlob,
+                                              becameVisibleHandler: { _ in },
+                                              confirmation: true,
+                                              completion: { _ in })
+                        expect(displayedTooltip?.superview).toEventually(beNil())
+                    }
 
-                it("will not display a tooltip if image data is invalid") {
-                    router.displayTooltip(tooltip,
-                                          targetView: targetView,
-                                          identifier: TooltipViewIdentifierMock,
-                                          imageBlob: "image".data(using: .ascii)!,
-                                          becameVisibleHandler: { _ in },
-                                          completion: { _ in })
-                    expect(window.findTooltipView()).toAfterTimeout(beNil())
-                }
+                    it("will not display a tooltip if identifier does not match") {
+                        router.displayTooltip(tooltip,
+                                              targetView: targetView,
+                                              identifier: "invalid.id",
+                                              imageBlob: "image".data(using: .ascii)!,
+                                              becameVisibleHandler: { _ in },
+                                              confirmation: true,
+                                              completion: { _ in })
+                        expect(window.findTooltipView()).toAfterTimeout(beNil())
+                    }
 
-                it("will report an error if targetView has no superview") {
-                    targetView.removeFromSuperview()
-                    router.displayTooltip(tooltip,
-                                          targetView: targetView,
-                                          identifier: TooltipViewIdentifierMock,
-                                          imageBlob: imageBlob,
-                                          becameVisibleHandler: { _ in },
-                                          completion: { _ in })
-                    expect(errorDelegate.wasErrorReceived).toEventually(beTrue())
-                }
+                    it("will report an error if image data is invalid") {
+                        router.displayTooltip(tooltip,
+                                              targetView: targetView,
+                                              identifier: TooltipViewIdentifierMock,
+                                              imageBlob: "image".data(using: .ascii)!,
+                                              becameVisibleHandler: { _ in },
+                                              confirmation: true,
+                                              completion: { _ in })
+                        expect(errorDelegate.wasErrorReceived).toEventually(beTrue())
+                    }
 
-                it("will not display a toolti if targetView has no superview") {
-                    targetView.removeFromSuperview()
-                    router.displayTooltip(tooltip,
-                                          targetView: targetView,
-                                          identifier: TooltipViewIdentifierMock,
-                                          imageBlob: imageBlob,
-                                          becameVisibleHandler: { _ in },
-                                          completion: { _ in })
-                    expect(window.findTooltipView()).toAfterTimeout(beNil())
-                }
+                    it("will not display a tooltip if image data is invalid") {
+                        router.displayTooltip(tooltip,
+                                              targetView: targetView,
+                                              identifier: TooltipViewIdentifierMock,
+                                              imageBlob: "image".data(using: .ascii)!,
+                                              becameVisibleHandler: { _ in },
+                                              confirmation: true,
+                                              completion: { _ in })
+                        expect(window.findTooltipView()).toAfterTimeout(beNil())
+                    }
 
-                it("will insert a tooltip in the same UIScrollView type view as the targetView") {
-                    let scrollView = UIScrollViewSubclass()
-                    scrollView.addSubview(targetView)
-                    window.addSubview(scrollView)
-                    router.displayTooltip(tooltip,
-                                          targetView: targetView,
-                                          identifier: TooltipViewIdentifierMock,
-                                          imageBlob: imageBlob,
-                                          becameVisibleHandler: { _ in },
-                                          completion: { _ in })
-                    expect(window.findTooltipView()).toEventuallyNot(beNil())
-                    let displayedTooltip = window.findTooltipView()
-                    expect(displayedTooltip?.superview).to(beIdenticalTo(scrollView))
+                    it("will report an error if targetView has no superview") {
+                        targetView.removeFromSuperview()
+                        router.displayTooltip(tooltip,
+                                              targetView: targetView,
+                                              identifier: TooltipViewIdentifierMock,
+                                              imageBlob: imageBlob,
+                                              becameVisibleHandler: { _ in },
+                                              confirmation: true,
+                                              completion: { _ in })
+                        expect(errorDelegate.wasErrorReceived).toEventually(beTrue())
+                    }
 
-                    scrollView.removeFromSuperview()
-                }
+                    it("will not display a tooltip if targetView has no superview") {
+                        targetView.removeFromSuperview()
+                        router.displayTooltip(tooltip,
+                                              targetView: targetView,
+                                              identifier: TooltipViewIdentifierMock,
+                                              imageBlob: imageBlob,
+                                              becameVisibleHandler: { _ in },
+                                              confirmation: true,
+                                              completion: { _ in })
+                        expect(window.findTooltipView()).toAfterTimeout(beNil())
+                    }
 
-                it("will insert a tooltip below existing campaign view") {
-                    let campaign = TestHelpers.generateCampaign(id: "test", type: .modal)
-                    router.displayCampaign(campaign, associatedImageData: nil, confirmation: true, completion: { _ in })
+                    it("will insert a tooltip in the same UIScrollView type view as the targetView") {
+                        let scrollView = UIScrollViewSubclass()
+                        scrollView.addSubview(targetView)
+                        window.addSubview(scrollView)
+                        router.displayTooltip(tooltip,
+                                              targetView: targetView,
+                                              identifier: TooltipViewIdentifierMock,
+                                              imageBlob: imageBlob,
+                                              becameVisibleHandler: { _ in },
+                                              confirmation: true,
+                                              completion: { _ in })
+                        expect(window.findTooltipView()).toEventuallyNot(beNil())
+                        let displayedTooltip = window.findTooltipView()
+                        expect(displayedTooltip?.superview).to(beIdenticalTo(scrollView))
 
-                    router.displayTooltip(tooltip,
-                                          targetView: targetView,
-                                          identifier: TooltipViewIdentifierMock,
-                                          imageBlob: imageBlob,
-                                          becameVisibleHandler: { _ in },
-                                          completion: { _ in })
-                    expect(window.findTooltipView()).toEventuallyNot(beNil())
-                    expect(window.findIAMView()).toEventuallyNot(beNil())
-                    let displayedTooltip = window.findTooltipView()!
-                    let displayedCampaign = window.findIAMView()!
+                        scrollView.removeFromSuperview()
+                    }
 
-                    expect(displayedTooltip.superview).to(beIdenticalTo(displayedCampaign.superview))
-                    let tooltipIndex = displayedTooltip.superview?.subviews.firstIndex(of: displayedTooltip)
-                    let campaignIndex = displayedTooltip.superview?.subviews.firstIndex(of: displayedCampaign)
-                    expect(campaignIndex).to(beGreaterThan(tooltipIndex))
-                }
+                    it("will insert a tooltip below existing campaign view") {
+                        let campaign = TestHelpers.generateCampaign(id: "test", type: .modal)
+                        router.displayCampaign(campaign, associatedImageData: nil, confirmation: true, completion: { _ in })
 
-                it("will update tooltip's position if target view's frame has changed") {
-                    router.displayTooltip(tooltip,
-                                          targetView: targetView,
-                                          identifier: TooltipViewIdentifierMock,
-                                          imageBlob: imageBlob,
-                                          becameVisibleHandler: { _ in },
-                                          completion: { _ in })
-                    expect(window.findTooltipView()).toEventuallyNot(beNil())
-                    let displayedTooltip = window.findTooltipView()!
-                    let lastTooltipPosition = displayedTooltip.frame.origin
-                    let translation = CGAffineTransform(translationX: 40, y: 40)
-                    targetView.frame.origin = targetView.frame.origin.applying(translation)
+                        router.displayTooltip(tooltip,
+                                              targetView: targetView,
+                                              identifier: TooltipViewIdentifierMock,
+                                              imageBlob: imageBlob,
+                                              becameVisibleHandler: { _ in },
+                                              confirmation: true,
+                                              completion: { _ in })
+                        expect(window.findTooltipView()).toEventuallyNot(beNil())
+                        expect(window.findIAMView()).toEventuallyNot(beNil())
+                        let displayedTooltip = window.findTooltipView()!
+                        let displayedCampaign = window.findIAMView()!
 
-                    expect(displayedTooltip.frame.origin).toEventually(equal(lastTooltipPosition.applying(translation)))
-                }
+                        expect(displayedTooltip.superview).to(beIdenticalTo(displayedCampaign.superview))
+                        let tooltipIndex = displayedTooltip.superview?.subviews.firstIndex(of: displayedTooltip)
+                        let campaignIndex = displayedTooltip.superview?.subviews.firstIndex(of: displayedCampaign)
+                        expect(campaignIndex).to(beGreaterThan(tooltipIndex))
+                    }
 
-                // To be confirmed
-//                it("will remove the tooltip if targeted view changes its identifier") {
-//                    router.displayTooltip(tooltip,
-//                                          targetView: targetView,
-//                                          identifier: TooltipViewIdentifierMock,
-//                                          imageBlob: imageData,
-//                                          becameVisibleHandler: { _ in },
-//                                          completion: { })
-//                    expect(window.findTooltipView()).toEventuallyNot(beNil())
-//                    let displayedTooltip = window.findTooltipView()!
-//                    router.viewDidUpdateIdentifier(from: TooltipViewIdentifierMock, to: "another.identifier", view: targetView)
-//                    expect(displayedTooltip.superview).toEventually(beNil())
-//                }
-//
-//                it("will remove the tooltip if targeted view changes its identifier to nil") {
-//                    router.displayTooltip(tooltip,
-//                                          targetView: targetView,
-//                                          identifier: TooltipViewIdentifierMock,
-//                                          imageBlob: imageData,
-//                                          becameVisibleHandler: { _ in },
-//                                          completion: { })
-//                    expect(window.findTooltipView()).toEventuallyNot(beNil())
-//                    let displayedTooltip = window.findTooltipView()!
-//                    router.viewDidUpdateIdentifier(from: TooltipViewIdentifierMock, to: nil, view: targetView)
-//                    expect(displayedTooltip.superview).toEventually(beNil())
-//                }
+                    it("will update tooltip's position if target view's frame has changed") {
+                        router.displayTooltip(tooltip,
+                                              targetView: targetView,
+                                              identifier: TooltipViewIdentifierMock,
+                                              imageBlob: imageBlob,
+                                              becameVisibleHandler: { _ in },
+                                              confirmation: true,
+                                              completion: { _ in })
+                        expect(window.findTooltipView()).toEventuallyNot(beNil())
+                        let displayedTooltip = window.findTooltipView()!
+                        let lastTooltipPosition = displayedTooltip.frame.origin
+                        let translation = CGAffineTransform(translationX: 40, y: 40)
+                        targetView.frame.origin = targetView.frame.origin.applying(translation)
 
-                it("will remove the tooltip if targeted view gets removed from superview") {
-                    router.displayTooltip(tooltip,
-                                          targetView: targetView,
-                                          identifier: TooltipViewIdentifierMock,
-                                          imageBlob: imageBlob,
-                                          becameVisibleHandler: { _ in },
-                                          completion: { _ in })
-                    expect(window.findTooltipView()).toEventuallyNot(beNil())
-                    let displayedTooltip = window.findTooltipView()!
-                    router.viewDidGetRemovedFromSuperview(targetView, identifier: TooltipViewIdentifierMock)
-                    expect(displayedTooltip.superview).toEventually(beNil())
+                        expect(displayedTooltip.frame.origin).toEventually(equal(lastTooltipPosition.applying(translation)))
+                    }
+
+                    // To be confirmed
+    //                it("will remove the tooltip if targeted view changes its identifier") {
+    //                    router.displayTooltip(tooltip,
+    //                                          targetView: targetView,
+    //                                          identifier: TooltipViewIdentifierMock,
+    //                                          imageBlob: imageData,
+    //                                          becameVisibleHandler: { _ in },
+    //                                          completion: { })
+    //                    expect(window.findTooltipView()).toEventuallyNot(beNil())
+    //                    let displayedTooltip = window.findTooltipView()!
+    //                    router.viewDidUpdateIdentifier(from: TooltipViewIdentifierMock, to: "another.identifier", view: targetView)
+    //                    expect(displayedTooltip.superview).toEventually(beNil())
+    //                }
+    //
+    //                it("will remove the tooltip if targeted view changes its identifier to nil") {
+    //                    router.displayTooltip(tooltip,
+    //                                          targetView: targetView,
+    //                                          identifier: TooltipViewIdentifierMock,
+    //                                          imageBlob: imageData,
+    //                                          becameVisibleHandler: { _ in },
+    //                                          completion: { })
+    //                    expect(window.findTooltipView()).toEventuallyNot(beNil())
+    //                    let displayedTooltip = window.findTooltipView()!
+    //                    router.viewDidUpdateIdentifier(from: TooltipViewIdentifierMock, to: nil, view: targetView)
+    //                    expect(displayedTooltip.superview).toEventually(beNil())
+    //                }
+
+                    it("will remove the tooltip if targeted view gets removed from superview") {
+                        router.displayTooltip(tooltip,
+                                              targetView: targetView,
+                                              identifier: TooltipViewIdentifierMock,
+                                              imageBlob: imageBlob,
+                                              becameVisibleHandler: { _ in },
+                                              confirmation: true,
+                                              completion: { _ in })
+                        expect(window.findTooltipView()).toEventuallyNot(beNil())
+                        let displayedTooltip = window.findTooltipView()!
+                        router.viewDidGetRemovedFromSuperview(targetView, identifier: TooltipViewIdentifierMock)
+                        expect(displayedTooltip.superview).toEventually(beNil())
+                    }
                 }
             }
         }

--- a/Tests/Tests/ViewListenerSpec.swift
+++ b/Tests/Tests/ViewListenerSpec.swift
@@ -14,11 +14,19 @@ class ViewListenerSpec: QuickSpec {
     override func spec() {
         describe("ViewListener") {
 
-            let viewListener = ViewListener.instance
-            let window = UIApplication.shared.getKeyWindow()!
+            var viewListener: ViewListener {
+                ViewListener.currentInstance
+            }
+            var window: UIWindow!
+
+            beforeEach {
+                window = UIWindow()
+                ViewListener.reinitialize(windowGetter: { return window })
+            }
 
             afterEach {
-                viewListener.stopListening()
+                // restore default implementation
+                ViewListener.reinitialize(windowGetter: UIApplication.shared.getKeyWindow)
             }
 
             it("will not crash when startListening is called multiple times") {
@@ -147,7 +155,6 @@ class ViewListenerSpec: QuickSpec {
                 }
 
                 it("will not get notified when view without identifier moved to window") {
-                    assert(observer.wasViewDidMoveToWindowCalled == false)
                     view.accessibilityIdentifier = nil
                     view.didMoveToWindow()
                     expect(observer.wasViewDidMoveToWindowCalled).toAfterTimeout(beFalse())

--- a/Tests/Tests/ViewListenerSpec.swift
+++ b/Tests/Tests/ViewListenerSpec.swift
@@ -124,6 +124,8 @@ class ViewListenerSpec: QuickSpec {
                     viewListener.startListening()
                     // wait for iterateOverDisplayedViews to finish
                     expect(observer.wasViewDidMoveToWindowCalled).toEventually(beTrue())
+                    observer = ViewListenerObserverObject() // reset
+                    viewListener.addObserver(observer)
                 }
 
                 afterEach {
@@ -140,60 +142,52 @@ class ViewListenerSpec: QuickSpec {
                 }
 
                 it("will get notified when view moved to window") {
-                    observer.wasViewDidMoveToWindowCalled = false
                     view.didMoveToWindow()
                     expect(observer.wasViewDidMoveToWindowCalled).toEventually(beTrue())
                 }
 
                 it("will not get notified when view without identifier moved to window") {
-                    observer.wasViewDidMoveToWindowCalled = false
+                    assert(observer.wasViewDidMoveToWindowCalled == false)
                     view.accessibilityIdentifier = nil
                     view.didMoveToWindow()
                     expect(observer.wasViewDidMoveToWindowCalled).toAfterTimeout(beFalse())
                 }
 
                 it("will not get notified when view with empty identifier moved to window") {
-                    observer.wasViewDidMoveToWindowCalled = false
                     view.accessibilityIdentifier = ""
                     view.didMoveToWindow()
                     expect(observer.wasViewDidMoveToWindowCalled).toAfterTimeout(beFalse())
                 }
 
                 it("will get notified when view moved to superview") {
-                    observer.wasViewDidChangeSuperviewCalled = false
                     view.didMoveToSuperview()
                     expect(observer.wasViewDidChangeSuperviewCalled).toEventually(beTrue())
                 }
 
                 it("will not get notified when view without identifier moved to superview") {
-                    observer.wasViewDidChangeSuperviewCalled = false
                     view.accessibilityIdentifier = nil
                     view.didMoveToSuperview()
                     expect(observer.wasViewDidChangeSuperviewCalled).toAfterTimeout(beFalse())
                 }
 
                 it("will not get notified when view with empty identifier moved to superview") {
-                    observer.wasViewDidChangeSuperviewCalled = false
                     view.accessibilityIdentifier = ""
                     view.didMoveToSuperview()
                     expect(observer.wasViewDidChangeSuperviewCalled).toAfterTimeout(beFalse())
                 }
 
                 it("will get notified when view got removed from superview") {
-                    observer.wasViewDidGetRemovedFromSuperview = false
                     view.removeFromSuperview()
                     expect(observer.wasViewDidGetRemovedFromSuperview).toEventually(beTrue())
                 }
 
                 it("will not get notified when view without identifier got removed from superview") {
-                    observer.wasViewDidGetRemovedFromSuperview = false
                     view.accessibilityIdentifier = nil
                     view.removeFromSuperview()
                     expect(observer.wasViewDidGetRemovedFromSuperview).toAfterTimeout(beFalse())
                 }
 
                 it("will not get notified when view with empty identifier got removed from superview") {
-                    observer.wasViewDidGetRemovedFromSuperview = false
                     view.accessibilityIdentifier = ""
                     view.removeFromSuperview()
                     expect(observer.wasViewDidGetRemovedFromSuperview).toAfterTimeout(beFalse())


### PR DESCRIPTION
# Description
Added contexts validation for tooltip campaigns. The same API is used as for normal campaigns.
`[Tooltip]` string-markup in the title is also considered a context

## Links
SDKCF-6028

# Checklist
- [X] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [X] I wrote/updated tests for new/changed code
- [X] I removed all sensitive data **before every commit**, including API endpoints and keys
- [X] I ran `fastlane ci` without errors
