### PR TITLE
build: fix unreachable config url in integration tests

### DIFF
--- a/Sample/AppDelegate.swift
+++ b/Sample/AppDelegate.swift
@@ -15,7 +15,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         if !AppDelegate.isTestEnvironment {
             // To mock API using ping.json file, uncomment the line below and enable `RIAM_CONFIG_URL` override in Example-Debug.xcconfig
-            MockServerHelper.setupForSampleApp()
+            // MockServerHelper.setupForSampleApp()
         }
         if !AppDelegate.isTestEnvironment || CommandLine.arguments.contains("--uitesting") {
             RInAppMessaging.configure()

--- a/Sample/Example-Debug.xcconfig
+++ b/Sample/Example-Debug.xcconfig
@@ -6,4 +6,4 @@
 // override secrets
 
 // uncomment below line to use mocked server
-RIAM_CONFIG_URL=http:/$()/localhost:6789/config
+// RIAM_CONFIG_URL=http:/$()/localhost:6789/config


### PR DESCRIPTION
# Description
Fixed integration tests error: `Code=-1004 "Could not connect to the server."` during config endpoint request.
`RIAM_CONFIG_URL` override in Debug.xcconfig file is only useful for manual testing in Sample app.

## Links
https://app.bitrise.io/build/d6dc2c39-31f0-4a2f-a9f2-4681312d4562

# Checklist
- [X] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [ ] I wrote/updated tests for new/changed code
- [X] I removed all sensitive data **before every commit**, including API endpoints and keys
- [ ] I ran `fastlane ci` without errors
