### PR TITLE
feat: add option to enable/disable Tooltip feature (SDKCF-6075)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Features:
 	- Added new API method to close displayed tooltips [SDKCF-6027]
 	- Added contexts validation for tooltip campaigns [SDKCF-6028]
+	- Added a feature flag to enable/disable the Tooltip feature [SDKCF-6075]
 - Bug fixes:
 	- Fixed an edge case of not readable status bar when campaign message is displayed [SDKCF-5134]
 

--- a/README.md
+++ b/README.md
@@ -273,6 +273,15 @@ The process can be considered as successful when `application(_:didRegisterForRe
 
 [How to set up your app for registering with APNS](https://developer.apple.com/documentation/usernotifications/registering_your_app_with_apns)
 
+### **Tooltip Campaigns**
+Tooltip feature is currently in beta testing; its features and behaviour might change in the future.
+Please refer to the internal guide for more information.
+
+To enable tooltips you must set `enableTooltipFeature` flag to true when calling `configure()`
+```swift
+RInAppMessaging.configure(enableTooltipFeature: true)
+```
+
 ## **Build/Run Example Application and Unit Tests**
 
 * Clone or fork the repo

--- a/RInAppMessaging.xcodeproj/project.pbxproj
+++ b/RInAppMessaging.xcodeproj/project.pbxproj
@@ -24,7 +24,7 @@
 		45357AF7245AD49E007D8FDC /* HttpRequestableSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45357AF6245AD49E007D8FDC /* HttpRequestableSpec.swift */; };
 		4537DBAC28037BF60038E0D2 /* ViewModelSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4537DBAB28037BF60038E0D2 /* ViewModelSpec.swift */; };
 		4537DBAE2804C8260038E0D2 /* legacy_ping.json in Resources */ = {isa = PBXBuildFile; fileRef = 4537DBAD2804C8260038E0D2 /* legacy_ping.json */; };
-		4538BAE326282DE4009952BE /* GetConfigResponseSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4538BAE226282DE4009952BE /* GetConfigResponseSpec.swift */; };
+		4538BAE326282DE4009952BE /* ConfigEndpointResponseSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4538BAE226282DE4009952BE /* ConfigEndpointResponseSpec.swift */; };
 		4538BCF6262AE8FA009952BE /* UserDataCacheSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4538BCF5262AE8FA009952BE /* UserDataCacheSpec.swift */; };
 		453D242926A0DE5100FB9E6A /* ModalViewSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 453D242826A0DE5100FB9E6A /* ModalViewSpec.swift */; };
 		453D243226A172F600FB9E6A /* modal-text-only.json in Resources */ = {isa = PBXBuildFile; fileRef = 453D243126A172F600FB9E6A /* modal-text-only.json */; };
@@ -138,7 +138,7 @@
 		45357AF6245AD49E007D8FDC /* HttpRequestableSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HttpRequestableSpec.swift; sourceTree = "<group>"; };
 		4537DBAB28037BF60038E0D2 /* ViewModelSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ViewModelSpec.swift; sourceTree = "<group>"; };
 		4537DBAD2804C8260038E0D2 /* legacy_ping.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = legacy_ping.json; sourceTree = "<group>"; };
-		4538BAE226282DE4009952BE /* GetConfigResponseSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetConfigResponseSpec.swift; sourceTree = "<group>"; };
+		4538BAE226282DE4009952BE /* ConfigEndpointResponseSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigEndpointResponseSpec.swift; sourceTree = "<group>"; };
 		4538BCF5262AE8FA009952BE /* UserDataCacheSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDataCacheSpec.swift; sourceTree = "<group>"; };
 		453D242626A0DE5100FB9E6A /* UITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = UITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		453D242826A0DE5100FB9E6A /* ModalViewSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModalViewSpec.swift; sourceTree = "<group>"; };
@@ -417,7 +417,7 @@
 				459B228124528A7D00D218CE /* DisplayPermissionServiceSpec.swift */,
 				456FE1E62428513200304872 /* ErrorReportableSpec.swift */,
 				459DE86924074F720002F451 /* EventMatcherSpec.swift */,
-				4538BAE226282DE4009952BE /* GetConfigResponseSpec.swift */,
+				4538BAE226282DE4009952BE /* ConfigEndpointResponseSpec.swift */,
 				45A86D0E2669877F00D0C43F /* HeaderAttributesBuilderSpec.swift */,
 				45357AF6245AD49E007D8FDC /* HttpRequestableSpec.swift */,
 				4557A8B0257E544C00C9D241 /* AccountRepositorySpec.swift */,
@@ -768,7 +768,7 @@
 				45563B0724064D78004EAFD3 /* CampaignRepositorySpec.swift in Sources */,
 				455FEBE227F214640064470D /* UIColorExtensionSpec.swift in Sources */,
 				456FE1EB2428C51E00304872 /* CommonUtilitySpec.swift in Sources */,
-				4538BAE326282DE4009952BE /* GetConfigResponseSpec.swift in Sources */,
+				4538BAE326282DE4009952BE /* ConfigEndpointResponseSpec.swift in Sources */,
 				C9827558262C423C00476505 /* BackoffSpec.swift in Sources */,
 				45ADA53E247CFE9E00A9E2A3 /* ConfigurationRepositorySpec.swift in Sources */,
 				45EA720D25B72002001B2049 /* UIViewExtensionSpec.swift in Sources */,

--- a/SampleSPM/SampleSPM.xcodeproj/project.pbxproj
+++ b/SampleSPM/SampleSPM.xcodeproj/project.pbxproj
@@ -65,7 +65,7 @@
 		D234A71E291C62CE0086AC80 /* ViewPresenterSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D234A6F0291C62C90086AC80 /* ViewPresenterSpec.swift */; };
 		D234A71F291C62CE0086AC80 /* HeaderAttributesBuilderSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D234A6F1291C62CA0086AC80 /* HeaderAttributesBuilderSpec.swift */; };
 		D234A720291C62CE0086AC80 /* CustomEventSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D234A6F2291C62CA0086AC80 /* CustomEventSpec.swift */; };
-		D234A721291C62CF0086AC80 /* GetConfigResponseSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D234A6F3291C62CA0086AC80 /* GetConfigResponseSpec.swift */; };
+		D234A721291C62CF0086AC80 /* ConfigEndpointResponseSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D234A6F3291C62CA0086AC80 /* ConfigEndpointResponseSpec.swift */; };
 		D234A722291C62CF0086AC80 /* CustomAttributeSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D234A6F4291C62CA0086AC80 /* CustomAttributeSpec.swift */; };
 		D234A723291C62CF0086AC80 /* EventMatcherSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D234A6F5291C62CA0086AC80 /* EventMatcherSpec.swift */; };
 		D234A724291C62CF0086AC80 /* PublicAPISpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D234A6F6291C62CA0086AC80 /* PublicAPISpec.swift */; };
@@ -189,7 +189,7 @@
 		D234A6F0291C62C90086AC80 /* ViewPresenterSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ViewPresenterSpec.swift; sourceTree = "<group>"; };
 		D234A6F1291C62CA0086AC80 /* HeaderAttributesBuilderSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HeaderAttributesBuilderSpec.swift; sourceTree = "<group>"; };
 		D234A6F2291C62CA0086AC80 /* CustomEventSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CustomEventSpec.swift; sourceTree = "<group>"; };
-		D234A6F3291C62CA0086AC80 /* GetConfigResponseSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GetConfigResponseSpec.swift; sourceTree = "<group>"; };
+		D234A6F3291C62CA0086AC80 /* ConfigEndpointResponseSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConfigEndpointResponseSpec.swift; sourceTree = "<group>"; };
 		D234A6F4291C62CA0086AC80 /* CustomAttributeSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CustomAttributeSpec.swift; sourceTree = "<group>"; };
 		D234A6F5291C62CA0086AC80 /* EventMatcherSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EventMatcherSpec.swift; sourceTree = "<group>"; };
 		D234A6F6291C62CA0086AC80 /* PublicAPISpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PublicAPISpec.swift; sourceTree = "<group>"; };
@@ -453,7 +453,7 @@
 				D234A703291C62CC0086AC80 /* DisplayPermissionServiceSpec.swift */,
 				D234A6FB291C62CB0086AC80 /* ErrorReportableSpec.swift */,
 				D234A6F5291C62CA0086AC80 /* EventMatcherSpec.swift */,
-				D234A6F3291C62CA0086AC80 /* GetConfigResponseSpec.swift */,
+				D234A6F3291C62CA0086AC80 /* ConfigEndpointResponseSpec.swift */,
 				D234A6F1291C62CA0086AC80 /* HeaderAttributesBuilderSpec.swift */,
 				D234A6EC291C62C90086AC80 /* HttpRequestableSpec.swift */,
 				D234A6EB291C62C90086AC80 /* ImpressionServiceSpec.swift */,
@@ -800,7 +800,7 @@
 				D234A734291C62CF0086AC80 /* CommonUtilitySpec.swift in Sources */,
 				D234A719291C62CE0086AC80 /* ImpressionServiceSpec.swift in Sources */,
 				D234A722291C62CF0086AC80 /* CustomAttributeSpec.swift in Sources */,
-				D234A721291C62CF0086AC80 /* GetConfigResponseSpec.swift in Sources */,
+				D234A721291C62CF0086AC80 /* ConfigEndpointResponseSpec.swift in Sources */,
 				D234A730291C62CF0086AC80 /* KeyHasherSpec.swift in Sources */,
 				D234A745291C62CF0086AC80 /* SerializationSpec.swift in Sources */,
 				D234A71A291C62CE0086AC80 /* HttpRequestableSpec.swift in Sources */,

--- a/Sources/RInAppMessaging/CampaignsListManager.swift
+++ b/Sources/RInAppMessaging/CampaignsListManager.swift
@@ -9,6 +9,7 @@ internal class CampaignsListManager: CampaignsListManagerType, TaskSchedulable {
     private var campaignRepository: CampaignRepositoryType
     private let campaignTriggerAgent: CampaignTriggerAgentType
     private let messageMixerService: MessageMixerServiceType
+    private let configurationRepository: ConfigurationRepositoryType
 
     weak var errorDelegate: ErrorDelegate?
     var scheduledTask: DispatchWorkItem?
@@ -19,11 +20,13 @@ internal class CampaignsListManager: CampaignsListManagerType, TaskSchedulable {
 
     init(campaignRepository: CampaignRepositoryType,
          campaignTriggerAgent: CampaignTriggerAgentType,
-         messageMixerService: MessageMixerServiceType) {
+         messageMixerService: MessageMixerServiceType,
+         configurationRepository: ConfigurationRepositoryType) {
 
         self.campaignRepository = campaignRepository
         self.campaignTriggerAgent = campaignTriggerAgent
         self.messageMixerService = messageMixerService
+        self.configurationRepository = configurationRepository
     }
 
     deinit {
@@ -59,7 +62,8 @@ internal class CampaignsListManager: CampaignsListManagerType, TaskSchedulable {
 
         CommonUtility.lock(resourcesIn: [campaignRepository]) {
             campaignRepository.syncWith(list: decodedResponse.data,
-                                        timestampMilliseconds: decodedResponse.currentPingMilliseconds)
+                                        timestampMilliseconds: decodedResponse.currentPingMilliseconds,
+                                        ignoreTooltips: !configurationRepository.isTooltipFeatureEnabled)
         }
         campaignTriggerAgent.validateAndTriggerCampaigns()
 

--- a/Sources/RInAppMessaging/ConfigurationManager.swift
+++ b/Sources/RInAppMessaging/ConfigurationManager.swift
@@ -68,6 +68,12 @@ internal class ConfigurationManager: ConfigurationManagerType, TaskSchedulable {
             responseStateMachine.push(state: .error)
 
             switch error {
+            case .missingOrInvalidConfigURL:
+                reportError(
+                    description: "Invalid Configuration URL: \(configurationRepository.getConfigEndpointURLString() ?? "<empty>"). SDK will be disabled.",
+                    data: error)
+                completion(ConfigEndpointData(rolloutPercentage: 0, endpoints: nil))
+
             case .tooManyRequestsError:
                 scheduleRetryWithRandomizedBackoff(retryHandler: retryHandler)
 

--- a/Sources/RInAppMessaging/ConfigurationManager.swift
+++ b/Sources/RInAppMessaging/ConfigurationManager.swift
@@ -6,7 +6,8 @@ import RSDKUtils
 #endif
 
 internal protocol ConfigurationManagerType: ErrorReportable {
-    func fetchAndSaveConfigData(completion: @escaping (ConfigData) -> Void)
+    func fetchAndSaveConfigData(completion: @escaping (ConfigEndpointData) -> Void)
+    func saveIAMModuleConfiguration(_ config: InAppMessagingModuleConfiguration)
 }
 
 internal class ConfigurationManager: ConfigurationManagerType, TaskSchedulable {
@@ -38,10 +39,10 @@ internal class ConfigurationManager: ConfigurationManagerType, TaskSchedulable {
         scheduledTask?.cancel()
     }
 
-    func fetchAndSaveConfigData(completion: @escaping (ConfigData) -> Void) {
+    func fetchAndSaveConfigData(completion: @escaping (ConfigEndpointData) -> Void) {
         guard let configurationService = configurationService else {
             reportError(description: "Configuration URL in Info.plist is missing. IAM SDK will be disabled.", data: nil)
-            completion(ConfigData(rolloutPercentage: 0, endpoints: nil))
+            completion(ConfigEndpointData(rolloutPercentage: 0, endpoints: nil))
             return
         }
         let retryHandler: () -> Void = { [weak self] in
@@ -60,7 +61,7 @@ internal class ConfigurationManager: ConfigurationManagerType, TaskSchedulable {
             responseStateMachine.push(state: .success)
             retryDelayMS = Constants.Retry.Default.initialRetryDelayMS
 
-            configurationRepository.saveConfiguration(configData)
+            configurationRepository.saveRemoteConfiguration(configData)
             completion(configData)
 
         case .failure(let error):
@@ -72,16 +73,16 @@ internal class ConfigurationManager: ConfigurationManagerType, TaskSchedulable {
 
             case .missingOrInvalidSubscriptionId:
                 reportError(description: "Config request error: Missing or invalid Subscription ID. SDK will be disabled.", data: error)
-                completion(ConfigData(rolloutPercentage: 0, endpoints: nil))
+                completion(ConfigEndpointData(rolloutPercentage: 0, endpoints: nil))
 
             case .unknownSubscriptionId:
                 reportError(description: "Config request error: Unknown Subscription ID. SDK will be disabled.", data: error)
-                completion(ConfigData(rolloutPercentage: 0, endpoints: nil))
+                completion(ConfigEndpointData(rolloutPercentage: 0, endpoints: nil))
 
             case .internalServerError(let code):
                 guard responseStateMachine.consecutiveErrorCount <= Constants.Retry.retryCount else {
                     reportError(description: "Config request error: Response Code \(code): Internal server error", data: nil)
-                    completion(ConfigData(rolloutPercentage: 0, endpoints: nil))
+                    completion(ConfigEndpointData(rolloutPercentage: 0, endpoints: nil))
                     return
                 }
                 scheduleRetryWithRandomizedBackoff(retryHandler: retryHandler)
@@ -89,11 +90,11 @@ internal class ConfigurationManager: ConfigurationManagerType, TaskSchedulable {
 
             case .invalidRequestError(let code):
                 reportError(description: "Config request error: Response Code \(code): Invalid request error", data: nil)
-                completion(ConfigData(rolloutPercentage: 0, endpoints: nil))
+                completion(ConfigEndpointData(rolloutPercentage: 0, endpoints: nil))
 
             case .jsonDecodingError(let decodingError):
                 reportError(description: "Config request error: Failed to parse json", data: decodingError)
-                completion(ConfigData(rolloutPercentage: 0, endpoints: nil))
+                completion(ConfigEndpointData(rolloutPercentage: 0, endpoints: nil))
 
             default:
                 reportError(description: "Error calling config server. Retrying in \(retryDelayMS)ms", data: error)
@@ -102,6 +103,10 @@ internal class ConfigurationManager: ConfigurationManagerType, TaskSchedulable {
                 retryDelayMS.increaseBackOff()
             }
         }
+    }
+
+    func saveIAMModuleConfiguration(_ config: InAppMessagingModuleConfiguration) {
+        configurationRepository.saveIAMModuleConfiguration(config)
     }
 
     private func scheduleRetryWithRandomizedBackoff(retryHandler: @escaping () -> Void) {

--- a/Sources/RInAppMessaging/DependencyManager/MainContainer.swift
+++ b/Sources/RInAppMessaging/DependencyManager/MainContainer.swift
@@ -10,16 +10,12 @@ internal enum MainContainerFactory {
 
     private typealias ContainerElement = TypedDependencyManager.ContainerElement
 
-    static func create(dependencyManager manager: TypedDependencyManager, configURL: String?) -> TypedDependencyManager.Container {
+    static func create(dependencyManager manager: TypedDependencyManager, configURL: URL) -> TypedDependencyManager.Container {
 
         var elements = [
             ContainerElement(type: CommonUtility.self, factory: { CommonUtility() }),
             ContainerElement(type: ReachabilityType.self, factory: {
-                guard let configURL = URL(string: configURL ?? "") else {
-                    assertionFailure("Invalid Configuration URL: \(configURL ?? "<empty>")")
-                    return nil
-                }
-                return Reachability(url: configURL)
+                Reachability(url: configURL)
             }),
             ContainerElement(type: ConfigurationRepositoryType.self, factory: {
                 ConfigurationRepository()

--- a/Sources/RInAppMessaging/DependencyManager/MainContainer.swift
+++ b/Sources/RInAppMessaging/DependencyManager/MainContainer.swift
@@ -10,23 +10,13 @@ internal enum MainContainerFactory {
 
     private typealias ContainerElement = TypedDependencyManager.ContainerElement
 
-    private static func getValidConfigURL() -> URL? {
-        guard !Environment.isUnitTestEnvironment else {
-            return URL(string: "https://config.test")
-        }
-        guard let configURLString = BundleInfo.inAppConfigurationURL, !configURLString.isEmpty else {
-            return nil
-        }
-        return URL(string: configURLString)
-    }
-
-    static func create(dependencyManager manager: TypedDependencyManager) -> TypedDependencyManager.Container {
+    static func create(dependencyManager manager: TypedDependencyManager, configURL: String?) -> TypedDependencyManager.Container {
 
         var elements = [
             ContainerElement(type: CommonUtility.self, factory: { CommonUtility() }),
             ContainerElement(type: ReachabilityType.self, factory: {
-                guard let configURL = getValidConfigURL() else {
-                    assertionFailure("Configuration URL in Info.plist is missing")
+                guard let configURL = URL(string: configURL ?? "") else {
+                    assertionFailure("Invalid Configuration URL: \(configURL ?? "<empty>")")
                     return nil
                 }
                 return Reachability(url: configURL)
@@ -54,13 +44,7 @@ internal enum MainContainerFactory {
                 AccountRepository(userDataCache: manager.resolve(type: UserDataCacheable.self)!)
             }),
             ContainerElement(type: ConfigurationServiceType.self, factory: {
-                guard let configURL = getValidConfigURL() else {
-                    assertionFailure("Configuration URL in Info.plist is missing")
-                    return nil
-                }
-                let configurationRepository = manager.resolve(type: ConfigurationRepositoryType.self)!
-                return ConfigurationService(configURL: configURL,
-                                            sessionConfiguration: configurationRepository.defaultHttpSessionConfiguration)
+                ConfigurationService(configurationRepository: manager.resolve(type: ConfigurationRepositoryType.self)!)
             }),
             ContainerElement(type: DisplayPermissionServiceType.self, factory: {
                 DisplayPermissionService(
@@ -90,7 +74,8 @@ internal enum MainContainerFactory {
             ContainerElement(type: CampaignsListManagerType.self, factory: {
                 CampaignsListManager(campaignRepository: manager.resolve(type: CampaignRepositoryType.self)!,
                                      campaignTriggerAgent: manager.resolve(type: CampaignTriggerAgentType.self)!,
-                                     messageMixerService: manager.resolve(type: MessageMixerServiceType.self)!)
+                                     messageMixerService: manager.resolve(type: MessageMixerServiceType.self)!,
+                                     configurationRepository: manager.resolve(type: ConfigurationRepositoryType.self)!)
             }),
             ContainerElement(type: TooltipDispatcherType.self, factory: {
                 TooltipDispatcher(router: manager.resolve(type: RouterType.self)!,
@@ -116,13 +101,15 @@ internal enum MainContainerFactory {
                                   impressionService: manager.resolve(type: ImpressionServiceType.self)!,
                                   eventMatcher: manager.resolve(type: EventMatcherType.self)!,
                                   campaignTriggerAgent: manager.resolve(type: CampaignTriggerAgentType.self)!,
-                                  pushPrimerOptions: RInAppMessaging.pushPrimerAuthorizationOptions)
+                                  pushPrimerOptions: RInAppMessaging.pushPrimerAuthorizationOptions,
+                                  configurationRepository: manager.resolve(type: ConfigurationRepositoryType.self)!)
             }, transient: true),
             ContainerElement(type: SlideUpViewPresenterType.self, factory: {
                 SlideUpViewPresenter(campaignRepository: manager.resolve(type: CampaignRepositoryType.self)!,
                                      impressionService: manager.resolve(type: ImpressionServiceType.self)!,
                                      eventMatcher: manager.resolve(type: EventMatcherType.self)!,
-                                     campaignTriggerAgent: manager.resolve(type: CampaignTriggerAgentType.self)!)
+                                     campaignTriggerAgent: manager.resolve(type: CampaignTriggerAgentType.self)!,
+                                     configurationRepository: manager.resolve(type: ConfigurationRepositoryType.self)!)
             }, transient: true),
             ContainerElement(type: CampaignTriggerAgentType.self, factory: {
                 CampaignTriggerAgent(eventMatcher: manager.resolve(type: EventMatcherType.self)!,

--- a/Sources/RInAppMessaging/InAppMessagingModule.swift
+++ b/Sources/RInAppMessaging/InAppMessagingModule.swift
@@ -172,7 +172,7 @@ extension InAppMessagingModule {
 
 // MARK: - Enabled method
 extension InAppMessagingModule {
-    private func isEnabled(config: ConfigData) -> Bool {
+    private func isEnabled(config: ConfigEndpointData) -> Bool {
         guard config.rolloutPercentage > 0 else {
             return false
         }

--- a/Sources/RInAppMessaging/InAppMessagingModuleConfiguration.swift
+++ b/Sources/RInAppMessaging/InAppMessagingModuleConfiguration.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+internal struct InAppMessagingModuleConfiguration {
+    let configurationURL: String?
+    let subscriptionID: String?
+    let isTooltipFeatureEnabled: Bool
+}

--- a/Sources/RInAppMessaging/InAppMessagingModuleConfiguration.swift
+++ b/Sources/RInAppMessaging/InAppMessagingModuleConfiguration.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 internal struct InAppMessagingModuleConfiguration {
-    let configurationURL: String?
+    let configURLString: String?
     let subscriptionID: String?
     let isTooltipFeatureEnabled: Bool
 }

--- a/Sources/RInAppMessaging/Models/Responses/ConfigEndpointData.swift
+++ b/Sources/RInAppMessaging/Models/Responses/ConfigEndpointData.swift
@@ -1,10 +1,10 @@
 import struct Foundation.URL
 
-internal struct GetConfigResponse: Decodable {
-    let data: ConfigData
+internal struct ConfigEndpointResponse: Decodable {
+    let data: ConfigEndpointData
 }
 
-internal struct ConfigData: Decodable {
+internal struct ConfigEndpointData: Decodable {
     let rolloutPercentage: Int
     let endpoints: EndpointURL?
 }

--- a/Sources/RInAppMessaging/Protocols/ErrorReportable.swift
+++ b/Sources/RInAppMessaging/Protocols/ErrorReportable.swift
@@ -12,15 +12,7 @@ internal protocol ErrorReportable: AnyObject {
 extension ErrorReportable {
 
     func reportError(description: String, data: Any?) {
-        let prefix = "InAppMessaging: "
-        var userInfo: [String: Any] = [NSLocalizedDescriptionKey: prefix + description]
-        if let data = data {
-            userInfo["data"] = data
-        }
-
-        let error = NSError(domain: "InAppMessaging.\(type(of: self))",
-                            code: 0,
-                            userInfo: userInfo)
+        let error = NSError.iamError(description: description, data: data, callerClass: type(of: self))
 
         errorDelegate?.didReceive(error: error)
 
@@ -29,5 +21,20 @@ extension ErrorReportable {
         } else {
             Logger.debug(description)
         }
+    }
+}
+
+extension NSError {
+
+    static func iamError(description: String, data: Any? = nil, callerClass: AnyClass = NSError.self) -> NSError {
+        let prefix = "InAppMessaging: "
+        var userInfo: [String: Any] = [NSLocalizedDescriptionKey: prefix + description]
+        if let data = data {
+            userInfo["data"] = data
+        }
+
+        return NSError(domain: "InAppMessaging.\(callerClass)",
+                       code: 0,
+                       userInfo: userInfo)
     }
 }

--- a/Sources/RInAppMessaging/Repositories/ConfigurationRepository.swift
+++ b/Sources/RInAppMessaging/Repositories/ConfigurationRepository.swift
@@ -46,6 +46,6 @@ internal class ConfigurationRepository: ConfigurationRepositoryType {
     }
 
     func getConfigEndpointURL() -> String? {
-        iamModuleConfiguration?.configurationURL
+        iamModuleConfiguration?.configURLString
     }
 }

--- a/Sources/RInAppMessaging/Repositories/ConfigurationRepository.swift
+++ b/Sources/RInAppMessaging/Repositories/ConfigurationRepository.swift
@@ -9,7 +9,7 @@ internal protocol ConfigurationRepositoryType: AnyObject {
     func getEndpoints() -> EndpointURL?
     func getRolloutPercentage() -> Int?
     func getSubscriptionID() -> String?
-    func getConfigEndpointURL() -> String?
+    func getConfigEndpointURLString() -> String?
 }
 
 internal class ConfigurationRepository: ConfigurationRepositoryType {
@@ -45,7 +45,7 @@ internal class ConfigurationRepository: ConfigurationRepositoryType {
         iamModuleConfiguration?.subscriptionID
     }
 
-    func getConfigEndpointURL() -> String? {
+    func getConfigEndpointURLString() -> String? {
         iamModuleConfiguration?.configURLString
     }
 }

--- a/Sources/RInAppMessaging/Repositories/ConfigurationRepository.swift
+++ b/Sources/RInAppMessaging/Repositories/ConfigurationRepository.swift
@@ -2,29 +2,50 @@ import Foundation
 
 internal protocol ConfigurationRepositoryType: AnyObject {
     var defaultHttpSessionConfiguration: URLSessionConfiguration { get }
+    var isTooltipFeatureEnabled: Bool { get }
 
-    func saveConfiguration(_ data: ConfigData)
+    func saveRemoteConfiguration(_ data: ConfigEndpointData)
+    func saveIAMModuleConfiguration(_ config: InAppMessagingModuleConfiguration)
     func getEndpoints() -> EndpointURL?
     func getRolloutPercentage() -> Int?
+    func getSubscriptionID() -> String?
+    func getConfigEndpointURL() -> String?
 }
 
 internal class ConfigurationRepository: ConfigurationRepositoryType {
-    private var configuration: ConfigData?
+    private var remoteConfiguration: ConfigEndpointData?
+    private var iamModuleConfiguration: InAppMessagingModuleConfiguration?
     private(set) var defaultHttpSessionConfiguration: URLSessionConfiguration = {
         let configuration = URLSessionConfiguration.ephemeral
         configuration.timeoutIntervalForRequest = 20
         return configuration
     }()
+    var isTooltipFeatureEnabled: Bool {
+        assert(iamModuleConfiguration != nil, "`iamModuleConfiguration` is not yet set. Possible race condition.")
+        return iamModuleConfiguration?.isTooltipFeatureEnabled ?? false
+    }
 
-    func saveConfiguration(_ data: ConfigData) {
-        configuration = data
+    func saveRemoteConfiguration(_ data: ConfigEndpointData) {
+        remoteConfiguration = data
+    }
+
+    func saveIAMModuleConfiguration(_ config: InAppMessagingModuleConfiguration) {
+        iamModuleConfiguration = config
     }
 
     func getEndpoints() -> EndpointURL? {
-        configuration?.endpoints
+        remoteConfiguration?.endpoints
     }
 
     func getRolloutPercentage() -> Int? {
-        configuration?.rolloutPercentage
+        remoteConfiguration?.rolloutPercentage
+    }
+
+    func getSubscriptionID() -> String? {
+        iamModuleConfiguration?.subscriptionID
+    }
+
+    func getConfigEndpointURL() -> String? {
+        iamModuleConfiguration?.configurationURL
     }
 }

--- a/Sources/RInAppMessaging/Services/ConfigurationService.swift
+++ b/Sources/RInAppMessaging/Services/ConfigurationService.swift
@@ -27,9 +27,8 @@ internal struct ConfigurationService: ConfigurationServiceType, HttpRequestable 
     }
 
     func getConfigData() -> Result<ConfigEndpointData, ConfigurationServiceError> {
-        guard let configURLString = configurationRepository.getConfigEndpointURL(),
+        guard let configURLString = configurationRepository.getConfigEndpointURLString(),
               let configURL = URL(string: configURLString) else {
-            assertionFailure("Invalid Configuration URL: \(configurationRepository.getConfigEndpointURL() ?? "<empty>")")
             return .failure(.missingOrInvalidConfigURL)
         }
 

--- a/Sources/RInAppMessaging/Services/DisplayPermissionService.swift
+++ b/Sources/RInAppMessaging/Services/DisplayPermissionService.swift
@@ -82,7 +82,7 @@ extension DisplayPermissionService {
 
     func buildHttpBody(with parameters: [String: Any]?) -> Result<Data, Error> {
 
-        guard let subscriptionId = bundleInfo.inAppSubscriptionId,
+        guard let subscriptionId = configurationRepository.getSubscriptionID(),
               let appVersion = bundleInfo.appVersion,
               let sdkVersion = bundleInfo.inAppSdkVersion
         else {
@@ -113,7 +113,7 @@ extension DisplayPermissionService {
 
     private func buildRequestHeader() -> [HeaderAttribute] {
         var builder = HeaderAttributesBuilder()
-        builder.addSubscriptionID(bundleInfo: bundleInfo)
+        builder.addSubscriptionID(configurationRepository: configurationRepository)
         builder.addAccessToken(accountRepository: accountRepository)
 
         return builder.build()

--- a/Sources/RInAppMessaging/Services/ImpressionService.swift
+++ b/Sources/RInAppMessaging/Services/ImpressionService.swift
@@ -55,7 +55,7 @@ internal class ImpressionService: ImpressionServiceType, HttpRequestable, TaskSc
         AnalyticsBroadcaster.sendEventName(Constants.RAnalytics.impressionsEventName,
                                            dataObject: [Constants.RAnalytics.Keys.impressions: impressionData,
                                                         Constants.RAnalytics.Keys.campaignID: campaignData.campaignId,
-                                                        Constants.RAnalytics.Keys.subscriptionID: bundleInfo.inAppSubscriptionId ?? "n/a"])
+                                                        Constants.RAnalytics.Keys.subscriptionID: configurationRepository.getSubscriptionID() ?? "n/a"])
         
         sendImpressionRequest(endpoint: impressionEndpoint, parameters: parameters)
     }
@@ -140,7 +140,7 @@ extension ImpressionService {
 
     private func buildRequestHeader() -> [HeaderAttribute] {
         var builder = HeaderAttributesBuilder()
-        builder.addSubscriptionID(bundleInfo: bundleInfo)
+        builder.addSubscriptionID(configurationRepository: configurationRepository)
         builder.addDeviceID()
         builder.addAccessToken(accountRepository: accountRepository)
 

--- a/Sources/RInAppMessaging/Services/MessageMixerService.swift
+++ b/Sources/RInAppMessaging/Services/MessageMixerService.swift
@@ -100,7 +100,7 @@ extension MessageMixerService {
 
     private func buildRequestHeader() -> [HeaderAttribute] {
         var builder = HeaderAttributesBuilder()
-        builder.addSubscriptionID(bundleInfo: bundleInfo)
+        builder.addSubscriptionID(configurationRepository: configurationRepository)
         builder.addDeviceID()
         builder.addAccessToken(accountRepository: accountRepository)
 

--- a/Sources/RInAppMessaging/Utilities/BundleInfo.swift
+++ b/Sources/RInAppMessaging/Utilities/BundleInfo.swift
@@ -7,9 +7,6 @@ import RSDKUtils
 
 internal class BundleInfo {
 
-    static var subscriptionIDOverride: String?
-    static var configurationURLOverride: String?
-
     class var bundle: Bundle {
         .main
     }
@@ -33,12 +30,10 @@ internal class BundleInfo {
     }
 
     class var inAppSubscriptionId: String? {
-        subscriptionIDOverride ??
         bundle.infoDictionary?[Constants.Info.subscriptionIDKey] as? String
     }
 
     class var inAppConfigurationURL: String? {
-        configurationURLOverride ??
         bundle.infoDictionary?[Constants.Info.configurationURLKey] as? String
     }
 

--- a/Sources/RInAppMessaging/Utilities/HeaderAttributesBuilder.swift
+++ b/Sources/RInAppMessaging/Utilities/HeaderAttributesBuilder.swift
@@ -14,8 +14,8 @@ struct HeaderAttributesBuilder {
     }
 
     @discardableResult
-    mutating func addSubscriptionID(bundleInfo: BundleInfo.Type) -> Bool {
-        guard let subId = bundleInfo.inAppSubscriptionId, !subId.isEmpty else {
+    mutating func addSubscriptionID(configurationRepository: ConfigurationRepositoryType) -> Bool {
+        guard let subId = configurationRepository.getSubscriptionID(), !subId.isEmpty else {
             return false
         }
         addedHeaders.append(HeaderAttribute(key: Keys.subscriptionID, value: subId))

--- a/Sources/RInAppMessaging/Views/Presenters/BaseViewPresenter.swift
+++ b/Sources/RInAppMessaging/Views/Presenters/BaseViewPresenter.swift
@@ -20,21 +20,23 @@ internal class BaseViewPresenter: BaseViewPresenterType {
     private let campaignRepository: CampaignRepositoryType
     private let eventMatcher: EventMatcherType
     private let campaignTriggerAgent: CampaignTriggerAgentType
+    private let configurationRepository: ConfigurationRepositoryType
 
     var campaign: Campaign!
     var impressions: [Impression] = []
     var associatedImage: UIImage?
-    var bundleInfo = BundleInfo.self
 
     init(campaignRepository: CampaignRepositoryType,
          impressionService: ImpressionServiceType,
          eventMatcher: EventMatcherType,
-         campaignTriggerAgent: CampaignTriggerAgentType) {
+         campaignTriggerAgent: CampaignTriggerAgentType,
+         configurationRepository: ConfigurationRepositoryType) {
 
         self.impressionService = impressionService
         self.eventMatcher = eventMatcher
         self.campaignRepository = campaignRepository
         self.campaignTriggerAgent = campaignTriggerAgent
+        self.configurationRepository = configurationRepository
     }
 
     func viewDidInitialize() {
@@ -86,6 +88,6 @@ extension BaseViewPresenter {
         AnalyticsBroadcaster.sendEventName(Constants.RAnalytics.impressionsEventName,
                                            dataObject: [Constants.RAnalytics.Keys.impressions: impressionData,
                                                         Constants.RAnalytics.Keys.campaignID: campaign.id,
-                                                        Constants.RAnalytics.Keys.subscriptionID: bundleInfo.inAppSubscriptionId ?? "n/a"])
+                                                        Constants.RAnalytics.Keys.subscriptionID: configurationRepository.getSubscriptionID() ?? "n/a"])
     }
 }

--- a/Sources/RInAppMessaging/Views/Presenters/FullViewPresenter.swift
+++ b/Sources/RInAppMessaging/Views/Presenters/FullViewPresenter.swift
@@ -24,6 +24,7 @@ internal class FullViewPresenter: BaseViewPresenter, FullViewPresenterType, Erro
          eventMatcher: EventMatcherType,
          campaignTriggerAgent: CampaignTriggerAgentType,
          pushPrimerOptions: UNAuthorizationOptions,
+         configurationRepository: ConfigurationRepositoryType,
          notificationCenter: RemoteNotificationRequestable = UNUserNotificationCenter.current()) {
 
         self.pushPrimerOptions = pushPrimerOptions
@@ -31,7 +32,8 @@ internal class FullViewPresenter: BaseViewPresenter, FullViewPresenterType, Erro
         super.init(campaignRepository: campaignRepository,
                    impressionService: impressionService,
                    eventMatcher: eventMatcher,
-                   campaignTriggerAgent: campaignTriggerAgent)
+                   campaignTriggerAgent: campaignTriggerAgent,
+                   configurationRepository: configurationRepository)
     }
 
     override func viewDidInitialize() {

--- a/Tests/Tests/BundleSpec.swift
+++ b/Tests/Tests/BundleSpec.swift
@@ -14,7 +14,6 @@ class BundleSpec: QuickSpec {
             beforeEach {
                 bundleMock = BundleMock()
                 bundleInfo.bundleMock = bundleMock
-                bundleInfo.reset()
             }
 
             it("should return expected applicationId") {
@@ -33,42 +32,14 @@ class BundleSpec: QuickSpec {
                 expect(bundleInfo.inAppSdkVersion).to(match(semverRegex))
             }
 
-            context("when calling inAppSubscriptionId") {
-
-                context("and subscriptionIDOverride is nil") {
-                    it("should return the value from Info.plist") {
-                        bundleMock.infoDictionaryMock[Constants.Info.subscriptionIDKey] = "sub-id"
-                        expect(bundleInfo.inAppSubscriptionId).to(equal("sub-id"))
-                    }
-                }
-
-                context("and subscriptionIDOverride is not nil") {
-                    beforeEach {
-                        bundleInfo.subscriptionIDOverride = "another-sub-id"
-                    }
-                    it("should return subscriptionIDOverride value") {
-                        expect(bundleInfo.inAppSubscriptionId).to(equal("another-sub-id"))
-                    }
-                }
+            it("should return expected inAppSubscriptionId") {
+                bundleMock.infoDictionaryMock[Constants.Info.subscriptionIDKey] = "sub-id"
+                expect(bundleInfo.inAppSubscriptionId).to(equal("sub-id"))
             }
 
-            context("when calling inAppConfigurationURL") {
-
-                context("and subscriptionIDOverride is nil") {
-                    it("should return the value from Info.plist") {
-                        bundleMock.infoDictionaryMock[Constants.Info.configurationURLKey] = "http://config.url"
-                        expect(bundleInfo.inAppConfigurationURL).to(equal("http://config.url"))
-                    }
-                }
-
-                context("and subscriptionIDOverride is not nil") {
-                    beforeEach {
-                        bundleInfo.configurationURLOverride = "http://config.alt"
-                    }
-                    it("should return subscriptionIDOverride value") {
-                        expect(bundleInfo.inAppConfigurationURL).to(equal("http://config.alt"))
-                    }
-                }
+            it("should return expected inAppConfigurationURL") {
+                bundleMock.infoDictionaryMock[Constants.Info.configurationURLKey] = "http://config.url"
+                expect(bundleInfo.inAppConfigurationURL).to(equal("http://config.url"))
             }
 
             it("should return expected customFontNameTitle") {
@@ -99,11 +70,6 @@ class BundleInfoMocked: BundleInfo {
     static var bundleMock: BundleMock!
     override class var bundle: Bundle {
         bundleMock
-    }
-
-    static func reset() {
-        subscriptionIDOverride = nil
-        configurationURLOverride = nil
     }
 }
 

--- a/Tests/Tests/CampaignsListManagerSpec.swift
+++ b/Tests/Tests/CampaignsListManagerSpec.swift
@@ -23,7 +23,7 @@ class CampaignsListManagerSpec: QuickSpec {
                 campaignTriggerAgent = CampaignTriggerAgentMock()
                 configurationRepository = ConfigurationRepository()
                 configurationRepository.saveIAMModuleConfiguration(
-                    InAppMessagingModuleConfiguration(configurationURL: nil, subscriptionID: nil, isTooltipFeatureEnabled: true))
+                    InAppMessagingModuleConfiguration(configURLString: nil, subscriptionID: nil, isTooltipFeatureEnabled: true))
                 manager = CampaignsListManager(campaignRepository: campaignRepository,
                                                campaignTriggerAgent: campaignTriggerAgent,
                                                messageMixerService: messageMixerService,
@@ -159,7 +159,7 @@ class CampaignsListManagerSpec: QuickSpec {
                     context("and tooltip feature is disabled") {
                         beforeEach {
                             configurationRepository.saveIAMModuleConfiguration(
-                                InAppMessagingModuleConfiguration(configurationURL: nil, subscriptionID: nil, isTooltipFeatureEnabled: false))
+                                InAppMessagingModuleConfiguration(configURLString: nil, subscriptionID: nil, isTooltipFeatureEnabled: false))
                         }
                         it("will request sync with ignoring tooltips") {
                             manager.refreshList()
@@ -170,7 +170,7 @@ class CampaignsListManagerSpec: QuickSpec {
                     context("and tooltip feature is enabled") {
                         beforeEach {
                             configurationRepository.saveIAMModuleConfiguration(
-                                InAppMessagingModuleConfiguration(configurationURL: nil, subscriptionID: nil, isTooltipFeatureEnabled: true))
+                                InAppMessagingModuleConfiguration(configURLString: nil, subscriptionID: nil, isTooltipFeatureEnabled: true))
                         }
                         it("will request sync without ignoring tooltips") {
                             manager.refreshList()

--- a/Tests/Tests/CampaignsValidatorSpec.swift
+++ b/Tests/Tests/CampaignsValidatorSpec.swift
@@ -11,6 +11,10 @@ class CampaignsValidatorSpec: QuickSpec {
         var eventMatcher: EventMatcher!
         var validatorHandler: ValidatorHandler!
 
+        func syncRepository(with campaigns: [Campaign]) {
+            campaignRepository.syncWith(list: campaigns, timestampMilliseconds: 0, ignoreTooltips: false)
+        }
+
         beforeEach {
             campaignRepository = CampaignRepository(userDataCache: UserDataCacheMock(),
                                                     accountRepository: AccountRepository(userDataCache: UserDataCacheMock()))
@@ -24,7 +28,7 @@ class CampaignsValidatorSpec: QuickSpec {
         describe("CampaignsValidator") {
 
             it("will accept outdated test campaign") {
-                campaignRepository.syncWith(list: [MockedCampaigns.outdatedTestCampaign], timestampMilliseconds: 0)
+                syncRepository(with: [MockedCampaigns.outdatedTestCampaign])
                 eventMatcher.matchAndStore(event: LoginSuccessfulEvent())
                 campaignsValidator.validate(validatedCampaignHandler: validatorHandler.closure)
                 expect(validatorHandler.validatedCampaigns).to(contain(MockedCampaigns.outdatedTestCampaign))
@@ -32,7 +36,7 @@ class CampaignsValidatorSpec: QuickSpec {
 
             it("will not accept test campaign with impressionLeft < 1") {
                 let testCampaign = TestHelpers.generateCampaign(id: "test", maxImpressions: 1, test: true)
-                campaignRepository.syncWith(list: [testCampaign], timestampMilliseconds: 0)
+                syncRepository(with: [testCampaign])
                 campaignRepository.decrementImpressionsLeftInCampaign(id: testCampaign.id)
                 eventMatcher.matchAndStore(event: LoginSuccessfulEvent())
                 campaignsValidator.validate(validatedCampaignHandler: validatorHandler.closure)
@@ -43,8 +47,7 @@ class CampaignsValidatorSpec: QuickSpec {
                 let campaign = TestHelpers.generateCampaign(
                     id: "test", maxImpressions: 2,
                     triggers: [Trigger.loginEventTrigger])
-                campaignRepository.syncWith(list: [campaign, MockedCampaigns.outdatedCampaign],
-                                            timestampMilliseconds: 0)
+                syncRepository(with: [campaign, MockedCampaigns.outdatedCampaign])
                 let event = LoginSuccessfulEvent()
                 eventMatcher.matchAndStore(event: event)
                 campaignsValidator.validate(validatedCampaignHandler: validatorHandler.closure)
@@ -53,8 +56,7 @@ class CampaignsValidatorSpec: QuickSpec {
             }
 
             it("will accept test campaigns with matching criteria") {
-                campaignRepository.syncWith(list: [MockedCampaigns.testCampaign, MockedCampaigns.outdatedCampaign],
-                                            timestampMilliseconds: 0)
+                syncRepository(with: [MockedCampaigns.testCampaign, MockedCampaigns.outdatedCampaign])
                 let event = LoginSuccessfulEvent()
                 eventMatcher.matchAndStore(event: event)
                 campaignsValidator.validate(validatedCampaignHandler: validatorHandler.closure)
@@ -66,14 +68,14 @@ class CampaignsValidatorSpec: QuickSpec {
                 let campaign = TestHelpers.generateCampaign(
                     id: "test", maxImpressions: 0,
                     triggers: [Trigger.loginEventTrigger])
-                campaignRepository.syncWith(list: [campaign], timestampMilliseconds: 0)
+                syncRepository(with: [campaign])
                 eventMatcher.matchAndStore(event: LoginSuccessfulEvent())
                 campaignsValidator.validate(validatedCampaignHandler: validatorHandler.closure)
                 expect(validatorHandler.validatedCampaigns).toEventuallyNot(contain(campaign))
             }
 
             it("won't accept outdated campaigns") {
-                campaignRepository.syncWith(list: [MockedCampaigns.outdatedCampaign], timestampMilliseconds: 0)
+                syncRepository(with: [MockedCampaigns.outdatedCampaign])
                 eventMatcher.matchAndStore(event: LoginSuccessfulEvent())
                 campaignsValidator.validate(validatedCampaignHandler: validatorHandler.closure)
                 expect(validatorHandler.validatedCampaigns).toNot(contain(MockedCampaigns.outdatedCampaign))
@@ -83,7 +85,7 @@ class CampaignsValidatorSpec: QuickSpec {
                 let campaign = TestHelpers.generateCampaign(
                     id: "test", maxImpressions: 2,
                     triggers: [Trigger.loginEventTrigger])
-                campaignRepository.syncWith(list: [campaign], timestampMilliseconds: 0)
+                syncRepository(with: [campaign])
                 eventMatcher.matchAndStore(event: LoginSuccessfulEvent())
                 _ = campaignRepository.optOutCampaign(campaign)
                 campaignsValidator.validate(validatedCampaignHandler: validatorHandler.closure)
@@ -107,7 +109,7 @@ class CampaignsValidatorSpec: QuickSpec {
                                 eventName: "testevent2",
                                 attributes: []
                             )])
-                    campaignRepository.syncWith(list: [campaign], timestampMilliseconds: 0)
+                    syncRepository(with: [campaign])
                     eventMatcher.matchAndStore(event: LoginSuccessfulEvent())
                     eventMatcher.matchAndStore(event: AppStartEvent())
                     campaignsValidator.validate(validatedCampaignHandler: validatorHandler.closure)
@@ -129,7 +131,7 @@ class CampaignsValidatorSpec: QuickSpec {
                                 eventName: "testevent2",
                                 attributes: []
                             )])
-                    campaignRepository.syncWith(list: [campaign], timestampMilliseconds: 0)
+                    syncRepository(with: [campaign])
                     eventMatcher.matchAndStore(event: LoginSuccessfulEvent())
                     eventMatcher.matchAndStore(event: AppStartEvent())
                     campaignsValidator.validate(validatedCampaignHandler: validatorHandler.closure)
@@ -140,7 +142,7 @@ class CampaignsValidatorSpec: QuickSpec {
                     let campaign = TestHelpers.generateCampaign(
                         id: "test", maxImpressions: 2,
                         triggers: [])
-                    campaignRepository.syncWith(list: [campaign], timestampMilliseconds: 0)
+                    syncRepository(with: [campaign])
                     eventMatcher.matchAndStore(event: LoginSuccessfulEvent())
                     campaignsValidator.validate(validatedCampaignHandler: validatorHandler.closure)
                     expect(validatorHandler.validatedCampaigns).to(beEmpty())
@@ -150,7 +152,7 @@ class CampaignsValidatorSpec: QuickSpec {
                     let campaign = TestHelpers.generateCampaign(
                         id: "test", maxImpressions: 2, test: true,
                         triggers: [])
-                    campaignRepository.syncWith(list: [campaign], timestampMilliseconds: 0)
+                    syncRepository(with: [campaign])
                     eventMatcher.matchAndStore(event: LoginSuccessfulEvent())
                     campaignsValidator.validate(validatedCampaignHandler: validatorHandler.closure)
                     expect(validatorHandler.validatedCampaigns).to(beEmpty())
@@ -171,7 +173,7 @@ class CampaignsValidatorSpec: QuickSpec {
                                 eventName: "testevent2",
                                 attributes: []
                             )])
-                    campaignRepository.syncWith(list: [campaign], timestampMilliseconds: 0)
+                    syncRepository(with: [campaign])
                     eventMatcher.matchAndStore(event: LoginSuccessfulEvent())
                     campaignsValidator.validate(validatedCampaignHandler: validatorHandler.closure)
                     expect(validatorHandler.validatedCampaigns).toEventuallyNot(contain(campaign))

--- a/Tests/Tests/ConfigEndpointResponseSpec.swift
+++ b/Tests/Tests/ConfigEndpointResponseSpec.swift
@@ -3,15 +3,15 @@ import Quick
 import Nimble
 @testable import RInAppMessaging
 
-class GetConfigResponseSpec: QuickSpec {
+class ConfigEndpointResponseSpec: QuickSpec {
 
     override func spec() {
 
-        describe("GetConfigResponse model") {
+        describe("ConfigEndpointResponse model") {
             context("when decoding JSON payload") {
 
                 it("will be correctly created if all fields are present") {
-                    let model = try? JSONDecoder().decode(GetConfigResponse.self, from: Payloads.allFields.utf8Data!)
+                    let model = try? JSONDecoder().decode(ConfigEndpointResponse.self, from: Payloads.allFields.utf8Data!)
 
                     expect(model).toNot(beNil())
                     expect(model?.data.rolloutPercentage).to(equal(0))
@@ -21,7 +21,7 @@ class GetConfigResponseSpec: QuickSpec {
                 }
 
                 it("will be correctly created if there are no endpoints") {
-                    let model = try? JSONDecoder().decode(GetConfigResponse.self, from: Payloads.noEndpoints.utf8Data!)
+                    let model = try? JSONDecoder().decode(ConfigEndpointResponse.self, from: Payloads.noEndpoints.utf8Data!)
 
                     expect(model).toNot(beNil())
                     expect(model?.data.rolloutPercentage).to(equal(0))
@@ -29,7 +29,7 @@ class GetConfigResponseSpec: QuickSpec {
                 }
 
                 it("will be correctly created if endpoints field is empty") {
-                    let model = try? JSONDecoder().decode(GetConfigResponse.self, from: Payloads.emptyEndpoints.utf8Data!)
+                    let model = try? JSONDecoder().decode(ConfigEndpointResponse.self, from: Payloads.emptyEndpoints.utf8Data!)
 
                     expect(model).toNot(beNil())
                     expect(model?.data.rolloutPercentage).to(equal(0))
@@ -39,7 +39,7 @@ class GetConfigResponseSpec: QuickSpec {
                 }
 
                 it("will be correctly created if there is no ping endpoint") {
-                    let model = try? JSONDecoder().decode(GetConfigResponse.self, from: Payloads.noPingEndpoint.utf8Data!)
+                    let model = try? JSONDecoder().decode(ConfigEndpointResponse.self, from: Payloads.noPingEndpoint.utf8Data!)
 
                     expect(model).toNot(beNil())
                     expect(model?.data.rolloutPercentage).to(equal(0))
@@ -49,7 +49,7 @@ class GetConfigResponseSpec: QuickSpec {
                 }
 
                 it("will be correctly created if there is no impression endpoint") {
-                    let model = try? JSONDecoder().decode(GetConfigResponse.self, from: Payloads.noImpressionEndpoint.utf8Data!)
+                    let model = try? JSONDecoder().decode(ConfigEndpointResponse.self, from: Payloads.noImpressionEndpoint.utf8Data!)
 
                     expect(model).toNot(beNil())
                     expect(model?.data.rolloutPercentage).to(equal(0))
@@ -59,7 +59,7 @@ class GetConfigResponseSpec: QuickSpec {
                 }
 
                 it("will be correctly created if there is no display permission endpoint") {
-                    let model = try? JSONDecoder().decode(GetConfigResponse.self, from: Payloads.noDisplayPermissionEndpoint.utf8Data!)
+                    let model = try? JSONDecoder().decode(ConfigEndpointResponse.self, from: Payloads.noDisplayPermissionEndpoint.utf8Data!)
 
                     expect(model).toNot(beNil())
                     expect(model?.data.rolloutPercentage).to(equal(0))
@@ -69,13 +69,13 @@ class GetConfigResponseSpec: QuickSpec {
                 }
 
                 it("will not be correctly created if there is no rolloutPercentage flag") {
-                    let model = try? JSONDecoder().decode(GetConfigResponse.self, from: Payloads.noRolloutPercentage.utf8Data!)
+                    let model = try? JSONDecoder().decode(ConfigEndpointResponse.self, from: Payloads.noRolloutPercentage.utf8Data!)
 
                     expect(model).to(beNil())
                 }
 
                 it("will not be correctly created if there is no data") {
-                    let model = try? JSONDecoder().decode(GetConfigResponse.self, from: Payloads.noData.utf8Data!)
+                    let model = try? JSONDecoder().decode(ConfigEndpointResponse.self, from: Payloads.noData.utf8Data!)
 
                     expect(model).to(beNil())
                 }

--- a/Tests/Tests/ConfigurationManagerSpec.swift
+++ b/Tests/Tests/ConfigurationManagerSpec.swift
@@ -215,7 +215,7 @@ class ConfigurationManagerSpec: QuickSpec {
 
                     it("should retry 3 times for .internalServerError error") {
                         configurationService.mockedError = .internalServerError(500)
-                        var returnedConfig: ConfigData?
+                        var returnedConfig: ConfigEndpointData?
                         configurationManager.fetchAndSaveConfigData(completion: { config in
                             returnedConfig = config
                         })
@@ -264,6 +264,19 @@ class ConfigurationManagerSpec: QuickSpec {
                         configurationManager.fetchAndSaveConfigData(completion: { _ in })
                         expect(errorDelegate.wasErrorReceived).to(beTrue())
                     }
+                }
+            }
+
+            context("when calling saveIAMModuleConfiguration") {
+
+                it("should store data in Configuration Repository") {
+                    let config = InAppMessagingModuleConfiguration(configurationURL: "config.url",
+                                                                   subscriptionID: "sub-id",
+                                                                   isTooltipFeatureEnabled: true)
+                    configurationManager.saveIAMModuleConfiguration(config)
+                    expect(configurationRepository.isTooltipFeatureEnabled).to(equal(config.isTooltipFeatureEnabled))
+                    expect(configurationRepository.getSubscriptionID()).to(equal(config.subscriptionID))
+                    expect(configurationRepository.getConfigEndpointURL()).to(equal(config.configurationURL))
                 }
             }
         }

--- a/Tests/Tests/ConfigurationManagerSpec.swift
+++ b/Tests/Tests/ConfigurationManagerSpec.swift
@@ -264,6 +264,22 @@ class ConfigurationManagerSpec: QuickSpec {
                         configurationManager.fetchAndSaveConfigData(completion: { _ in })
                         expect(errorDelegate.wasErrorReceived).to(beTrue())
                     }
+
+                    it("should not retry for .missingOrInvalidConfigURL error") {
+                        configurationService.mockedError = .missingOrInvalidConfigURL
+                        configurationManager.fetchAndSaveConfigData(completion: { _ in })
+                        expect(configurationManager.scheduledTask).toAfterTimeout(beNil())
+                    }
+
+                    it("should return disable response for .missingOrInvalidConfigURL error") {
+                        configurationService.mockedError = .missingOrInvalidConfigURL
+                        waitUntil { done in
+                            configurationManager.fetchAndSaveConfigData(completion: { config in
+                                expect(config.rolloutPercentage).to(equal(0))
+                                done()
+                            })
+                        }
+                    }
                 }
             }
 
@@ -276,7 +292,7 @@ class ConfigurationManagerSpec: QuickSpec {
                     configurationManager.saveIAMModuleConfiguration(config)
                     expect(configurationRepository.isTooltipFeatureEnabled).to(equal(config.isTooltipFeatureEnabled))
                     expect(configurationRepository.getSubscriptionID()).to(equal(config.subscriptionID))
-                    expect(configurationRepository.getConfigEndpointURL()).to(equal(config.configURLString))
+                    expect(configurationRepository.getConfigEndpointURLString()).to(equal(config.configURLString))
                 }
             }
         }

--- a/Tests/Tests/ConfigurationManagerSpec.swift
+++ b/Tests/Tests/ConfigurationManagerSpec.swift
@@ -270,13 +270,13 @@ class ConfigurationManagerSpec: QuickSpec {
             context("when calling saveIAMModuleConfiguration") {
 
                 it("should store data in Configuration Repository") {
-                    let config = InAppMessagingModuleConfiguration(configurationURL: "config.url",
+                    let config = InAppMessagingModuleConfiguration(configURLString: "config.url",
                                                                    subscriptionID: "sub-id",
                                                                    isTooltipFeatureEnabled: true)
                     configurationManager.saveIAMModuleConfiguration(config)
                     expect(configurationRepository.isTooltipFeatureEnabled).to(equal(config.isTooltipFeatureEnabled))
                     expect(configurationRepository.getSubscriptionID()).to(equal(config.subscriptionID))
-                    expect(configurationRepository.getConfigEndpointURL()).to(equal(config.configurationURL))
+                    expect(configurationRepository.getConfigEndpointURL()).to(equal(config.configURLString))
                 }
             }
         }

--- a/Tests/Tests/ConfigurationRepositorySpec.swift
+++ b/Tests/Tests/ConfigurationRepositorySpec.swift
@@ -52,7 +52,7 @@ class ConfigurationRepositorySpec: QuickSpec {
             }
 
             context("when calling saveIAMModuleConfiguration") {
-                let sampleConfig = InAppMessagingModuleConfiguration(configurationURL: "http://config.url",
+                let sampleConfig = InAppMessagingModuleConfiguration(configURLString: "http://config.url",
                                                                      subscriptionID: "sub-id",
                                                                      isTooltipFeatureEnabled: true)
 
@@ -69,7 +69,7 @@ class ConfigurationRepositorySpec: QuickSpec {
                 }
 
                 it("will properly save config URL") {
-                    expect(configurationRepository.getConfigEndpointURL()).to(equal(sampleConfig.configurationURL))
+                    expect(configurationRepository.getConfigEndpointURL()).to(equal(sampleConfig.configURLString))
                 }
             }
         }

--- a/Tests/Tests/ConfigurationRepositorySpec.swift
+++ b/Tests/Tests/ConfigurationRepositorySpec.swift
@@ -23,7 +23,7 @@ class ConfigurationRepositorySpec: QuickSpec {
                 expect(configurationRepository.getEndpoints()).to(beNil())
                 expect(configurationRepository.getRolloutPercentage()).to(beNil())
                 expect(configurationRepository.getSubscriptionID()).to(beNil())
-                expect(configurationRepository.getConfigEndpointURL()).to(beNil())
+                expect(configurationRepository.getConfigEndpointURLString()).to(beNil())
             }
 
             it("will throw an assertion when `isTooltipFeatureEnabled` is accessed before save") {
@@ -69,7 +69,7 @@ class ConfigurationRepositorySpec: QuickSpec {
                 }
 
                 it("will properly save config URL") {
-                    expect(configurationRepository.getConfigEndpointURL()).to(equal(sampleConfig.configURLString))
+                    expect(configurationRepository.getConfigEndpointURLString()).to(equal(sampleConfig.configURLString))
                 }
             }
         }

--- a/Tests/Tests/ConfigurationRepositorySpec.swift
+++ b/Tests/Tests/ConfigurationRepositorySpec.swift
@@ -22,24 +22,55 @@ class ConfigurationRepositorySpec: QuickSpec {
             it("will not hold any data until saved") {
                 expect(configurationRepository.getEndpoints()).to(beNil())
                 expect(configurationRepository.getRolloutPercentage()).to(beNil())
+                expect(configurationRepository.getSubscriptionID()).to(beNil())
+                expect(configurationRepository.getConfigEndpointURL()).to(beNil())
             }
 
-            it("will properly save endpoint data") {
-                let endpoints = EndpointURL(ping: URL(string: "ping")!,
-                                            displayPermission: URL(string: "displayPermission")!,
-                                            impression: URL(string: "impression")!)
-                let config = ConfigData(rolloutPercentage: 100, endpoints: endpoints)
-                configurationRepository.saveConfiguration(config)
-
-                expect(configurationRepository.getEndpoints()).to(equal(endpoints))
+            it("will throw an assertion when `isTooltipFeatureEnabled` is accessed before save") {
+                expect(configurationRepository.isTooltipFeatureEnabled).to(throwAssertion())
             }
 
-            it("will properly save enabled flag") {
-                let rolloutPercentage = 100
-                let config = ConfigData(rolloutPercentage: rolloutPercentage, endpoints: .empty)
-                configurationRepository.saveConfiguration(config)
+            context("when calling saveRemoteConfiguration()") {
 
-                expect(configurationRepository.getRolloutPercentage()).to(equal(rolloutPercentage))
+                it("will properly save endpoint data") {
+                    let endpoints = EndpointURL(ping: URL(string: "ping")!,
+                                                displayPermission: URL(string: "displayPermission")!,
+                                                impression: URL(string: "impression")!)
+                    let config = ConfigEndpointData(rolloutPercentage: 100, endpoints: endpoints)
+                    configurationRepository.saveRemoteConfiguration(config)
+
+                    expect(configurationRepository.getEndpoints()).to(equal(endpoints))
+                }
+
+                it("will properly save enabled flag") {
+                    let rolloutPercentage = 100
+                    let config = ConfigEndpointData(rolloutPercentage: rolloutPercentage, endpoints: .empty)
+                    configurationRepository.saveRemoteConfiguration(config)
+
+                    expect(configurationRepository.getRolloutPercentage()).to(equal(rolloutPercentage))
+                }
+            }
+
+            context("when calling saveIAMModuleConfiguration") {
+                let sampleConfig = InAppMessagingModuleConfiguration(configurationURL: "http://config.url",
+                                                                     subscriptionID: "sub-id",
+                                                                     isTooltipFeatureEnabled: true)
+
+                beforeEach {
+                    configurationRepository.saveIAMModuleConfiguration(sampleConfig)
+                }
+
+                it("will properly save isTooltipFeatureEnabled flag") {
+                    expect(configurationRepository.isTooltipFeatureEnabled).to(equal(sampleConfig.isTooltipFeatureEnabled))
+                }
+
+                it("will properly save subscription ID") {
+                    expect(configurationRepository.getSubscriptionID()).to(equal(sampleConfig.subscriptionID))
+                }
+
+                it("will properly save config URL") {
+                    expect(configurationRepository.getConfigEndpointURL()).to(equal(sampleConfig.configurationURL))
+                }
             }
         }
     }

--- a/Tests/Tests/ConfigurationServiceSpec.swift
+++ b/Tests/Tests/ConfigurationServiceSpec.swift
@@ -10,6 +10,7 @@ import class RSDKUtils.URLSessionMock
 
 private let configURL = URL(string: "http://config.url")!
 
+// swiftlint:disable:next type_body_length
 class ConfigurationServiceSpec: QuickSpec {
 
     override func spec() {

--- a/Tests/Tests/ConfigurationServiceSpec.swift
+++ b/Tests/Tests/ConfigurationServiceSpec.swift
@@ -15,7 +15,7 @@ class ConfigurationServiceSpec: QuickSpec {
     override func spec() {
 
         let requestQueue = DispatchQueue(label: "iam.test.request")
-        let moduleConfig = InAppMessagingModuleConfiguration(configurationURL: configURL.absoluteString,
+        let moduleConfig = InAppMessagingModuleConfiguration(configURLString: configURL.absoluteString,
                                                              subscriptionID: "sub-id",
                                                              isTooltipFeatureEnabled: true)
 
@@ -338,7 +338,7 @@ class ConfigurationServiceSpec: QuickSpec {
                     }
 
                     it("will throw an assertion if configURL is nil") {
-                        configRepository.saveIAMModuleConfiguration(InAppMessagingModuleConfiguration(configurationURL: nil,
+                        configRepository.saveIAMModuleConfiguration(InAppMessagingModuleConfiguration(configURLString: nil,
                                                                                                       subscriptionID: "sub-id",
                                                                                                       isTooltipFeatureEnabled: true))
                         waitUntil { done in
@@ -350,7 +350,7 @@ class ConfigurationServiceSpec: QuickSpec {
                     }
 
                     it("will throw an assertion if configURL is empty") {
-                        configRepository.saveIAMModuleConfiguration(InAppMessagingModuleConfiguration(configurationURL: "",
+                        configRepository.saveIAMModuleConfiguration(InAppMessagingModuleConfiguration(configURLString: "",
                                                                                                       subscriptionID: "sub-id",
                                                                                                       isTooltipFeatureEnabled: true))
                         waitUntil { done in

--- a/Tests/Tests/ConfigurationServiceSpec.swift
+++ b/Tests/Tests/ConfigurationServiceSpec.swift
@@ -336,29 +336,38 @@ class ConfigurationServiceSpec: QuickSpec {
                         BundleInfoMock.appVersionMock = nil
                         makeRequestAndEvaluateMetadataError()
                     }
+                }
+                context("and config url is invalid") {
 
-                    it("will throw an assertion if configURL is nil") {
-                        configRepository.saveIAMModuleConfiguration(InAppMessagingModuleConfiguration(configURLString: nil,
-                                                                                                      subscriptionID: "sub-id",
-                                                                                                      isTooltipFeatureEnabled: true))
+                    func makeRequestAndValidateError() {
                         waitUntil { done in
                             requestQueue.async {
-                                expect(service.getConfigData()).to(throwAssertion())
+                                let result = service.getConfigData()
+                                let error = result.getError()
+                                expect(error).toNot(beNil())
+
+                                guard case .missingOrInvalidConfigURL = error else {
+                                    fail("Unexpected error type \(String(describing: error)). Expected .missingOrInvalidConfigURL")
+                                    done()
+                                    return
+                                }
                                 done()
                             }
                         }
                     }
 
-                    it("will throw an assertion if configURL is empty") {
+                    it("will return error if configURL is nil") {
+                        configRepository.saveIAMModuleConfiguration(InAppMessagingModuleConfiguration(configURLString: nil,
+                                                                                                      subscriptionID: "sub-id",
+                                                                                                      isTooltipFeatureEnabled: true))
+                        makeRequestAndValidateError()
+                    }
+
+                    it("will return error if configURL is empty") {
                         configRepository.saveIAMModuleConfiguration(InAppMessagingModuleConfiguration(configURLString: "",
                                                                                                       subscriptionID: "sub-id",
                                                                                                       isTooltipFeatureEnabled: true))
-                        waitUntil { done in
-                            requestQueue.async {
-                                expect(service.getConfigData()).to(throwAssertion())
-                                done()
-                            }
-                        }
+                        makeRequestAndValidateError()
                     }
                 }
             }

--- a/Tests/Tests/ConfigurationSpec.swift
+++ b/Tests/Tests/ConfigurationSpec.swift
@@ -1,5 +1,6 @@
 import Quick
 import Nimble
+import Foundation
 #if canImport(RSDKUtilsMain)
 import class RSDKUtilsMain.TypedDependencyManager // SPM version
 #else

--- a/Tests/Tests/ConfigurationSpec.swift
+++ b/Tests/Tests/ConfigurationSpec.swift
@@ -33,7 +33,7 @@ class ConfigurationSpec: QuickSpec {
                 dependencyManager = TypedDependencyManager()
                 configurationManager = ConfigurationManagerMock()
                 RInAppMessaging.deinitializeModule()
-                dependencyManager.appendContainer(MainContainerFactory.create(dependencyManager: dependencyManager))
+                dependencyManager.appendContainer(MainContainerFactory.create(dependencyManager: dependencyManager, configURL: nil))
                 dependencyManager.appendContainer(mockContainer())
             }
 
@@ -49,7 +49,8 @@ class ConfigurationSpec: QuickSpec {
                             expect(RInAppMessaging.initializedModule).toNot(beNil())
                             done()
                         }
-                        RInAppMessaging.configure(dependencyManager: dependencyManager)
+                        RInAppMessaging.configure(dependencyManager: dependencyManager,
+                                                  moduleConfig: InAppMessagingModuleConfiguration.empty)
                     }
 
                     expect(RInAppMessaging.initializedModule).toEventually(beNil())
@@ -57,7 +58,8 @@ class ConfigurationSpec: QuickSpec {
                 }
 
                 it("will not call ping") {
-                    RInAppMessaging.configure(dependencyManager: dependencyManager)
+                    RInAppMessaging.configure(dependencyManager: dependencyManager,
+                                              moduleConfig: InAppMessagingModuleConfiguration.empty)
 
                     expect(mockMessageMixer.wasPingCalled).toAfterTimeout(beFalse())
                 }
@@ -67,7 +69,8 @@ class ConfigurationSpec: QuickSpec {
 
                 it("will call ping") {
                     configurationManager.rolloutPercentage = 100
-                    RInAppMessaging.configure(dependencyManager: dependencyManager)
+                    RInAppMessaging.configure(dependencyManager: dependencyManager,
+                                              moduleConfig: InAppMessagingModuleConfiguration.empty)
 
                     expect(mockMessageMixer.wasPingCalled).toEventually(beTrue())
                 }

--- a/Tests/Tests/ConfigurationSpec.swift
+++ b/Tests/Tests/ConfigurationSpec.swift
@@ -33,7 +33,8 @@ class ConfigurationSpec: QuickSpec {
                 dependencyManager = TypedDependencyManager()
                 configurationManager = ConfigurationManagerMock()
                 RInAppMessaging.deinitializeModule()
-                dependencyManager.appendContainer(MainContainerFactory.create(dependencyManager: dependencyManager, configURL: nil))
+                dependencyManager.appendContainer(MainContainerFactory.create(dependencyManager: dependencyManager,
+                                                                              configURL: URL(string: "config.url")!))
                 dependencyManager.appendContainer(mockContainer())
             }
 

--- a/Tests/Tests/CustomEventSpec.swift
+++ b/Tests/Tests/CustomEventSpec.swift
@@ -14,6 +14,10 @@ class CustomEventsSpec: QuickSpec {
         var eventMatcher: EventMatcher!
         var validatorHandler: ValidatorHandler!
 
+        func syncRepository(with campaigns: [Campaign]) {
+            campaignRepository.syncWith(list: campaigns, timestampMilliseconds: 0, ignoreTooltips: false)
+        }
+
         beforeEach {
             campaignRepository = CampaignRepository(userDataCache: UserDataCacheMock(),
                                                     accountRepository: AccountRepository(userDataCache: UserDataCacheMock()))
@@ -37,7 +41,7 @@ class CustomEventsSpec: QuickSpec {
         describe("CampaignsValidator") {
             it("should accept a campaign that is matched using an custom event with a STRING type and equals operator") {
                 let mockResponse = TestHelpers.MockResponse.stringTypeWithEqualsOperator
-                campaignRepository.syncWith(list: mockResponse.data, timestampMilliseconds: 0)
+                syncRepository(with: mockResponse.data)
 
                 let customEvent = CustomEvent(
                     withName: "testEvent",
@@ -63,7 +67,7 @@ class CustomEventsSpec: QuickSpec {
 
             it("should accept a campaign that is matched using an custom event with a STRING type and isNotEqual operator") {
                 let mockResponse = TestHelpers.MockResponse.stringTypeWithNotEqualsOperator
-                campaignRepository.syncWith(list: mockResponse.data, timestampMilliseconds: 0)
+                syncRepository(with: mockResponse.data)
 
                 let customEvent = CustomEvent(
                     withName: "testEvent",
@@ -89,7 +93,7 @@ class CustomEventsSpec: QuickSpec {
 
             it("should accept a campaign that is matched using an custom event with an INTEGER type and equals operator") {
                 let mockResponse = TestHelpers.MockResponse.intTypeWithEqualsOperator
-                campaignRepository.syncWith(list: mockResponse.data, timestampMilliseconds: 0)
+                syncRepository(with: mockResponse.data)
 
                 let customEvent = CustomEvent(
                     withName: "testEvent",
@@ -115,7 +119,7 @@ class CustomEventsSpec: QuickSpec {
 
             it("should accept a campaign that is matched using an custom event with an INTEGER type and isNotEqual operator") {
                 let mockResponse = TestHelpers.MockResponse.intTypeWithNotEqualsOperator
-                campaignRepository.syncWith(list: mockResponse.data, timestampMilliseconds: 0)
+                syncRepository(with: mockResponse.data)
 
                 let customEvent = CustomEvent(
                     withName: "testEvent",
@@ -141,7 +145,7 @@ class CustomEventsSpec: QuickSpec {
 
             it("should accept a campaign that is matched using an custom event with an INTEGER type and greaterThan operator") {
                 let mockResponse = TestHelpers.MockResponse.intTypeWithGreaterThanOperator
-                campaignRepository.syncWith(list: mockResponse.data, timestampMilliseconds: 0)
+                syncRepository(with: mockResponse.data)
 
                 let customEvent = CustomEvent(
                     withName: "testEvent",
@@ -167,7 +171,7 @@ class CustomEventsSpec: QuickSpec {
 
             it("should accept a campaign that is matched using an custom event with an INTEGER type and lessThan operator") {
                 let mockResponse = TestHelpers.MockResponse.intTypeWithLessThanOperator
-                campaignRepository.syncWith(list: mockResponse.data, timestampMilliseconds: 0)
+                syncRepository(with: mockResponse.data)
 
                 let customEvent = CustomEvent(
                     withName: "testEvent",
@@ -193,7 +197,7 @@ class CustomEventsSpec: QuickSpec {
 
             it("should accept a campaign that is matched using an custom event with a DOUBLE type and equals operator") {
                 let mockResponse = TestHelpers.MockResponse.doubleTypeWithEqualsOperator
-                campaignRepository.syncWith(list: mockResponse.data, timestampMilliseconds: 0)
+                syncRepository(with: mockResponse.data)
 
                 let customEvent = CustomEvent(
                     withName: "testEvent",
@@ -219,7 +223,7 @@ class CustomEventsSpec: QuickSpec {
 
             it("should accept a campaign that is matched using an custom event with a DOUBLE type and isNotEqual operator") {
                 let mockResponse = TestHelpers.MockResponse.doubleTypeWithNotEqualsOperator
-                campaignRepository.syncWith(list: mockResponse.data, timestampMilliseconds: 0)
+                syncRepository(with: mockResponse.data)
 
                 let customEvent = CustomEvent(
                     withName: "testEvent",
@@ -245,7 +249,7 @@ class CustomEventsSpec: QuickSpec {
 
             it("should accept a campaign that is matched using an custom event with a DOUBLE type and greaterThan operator") {
                 let mockResponse = TestHelpers.MockResponse.doubleTypeWithGreaterThanOperator
-                campaignRepository.syncWith(list: mockResponse.data, timestampMilliseconds: 0)
+                syncRepository(with: mockResponse.data)
 
                 let customEvent = CustomEvent(
                     withName: "testEvent",
@@ -271,7 +275,7 @@ class CustomEventsSpec: QuickSpec {
 
             it("should accept a campaign that is matched using an custom event with a DOUBLE type and lessThan operator") {
                 let mockResponse = TestHelpers.MockResponse.doubleTypeWithLessThanOperator
-                campaignRepository.syncWith(list: mockResponse.data, timestampMilliseconds: 0)
+                syncRepository(with: mockResponse.data)
 
                 let customEvent = CustomEvent(
                     withName: "testEvent",
@@ -297,7 +301,7 @@ class CustomEventsSpec: QuickSpec {
 
             it("should accept a campaign that is matched using an custom event with a BOOL type and equals operator") {
                 let mockResponse = TestHelpers.MockResponse.boolTypeWithEqualsOperator
-                campaignRepository.syncWith(list: mockResponse.data, timestampMilliseconds: 0)
+                syncRepository(with: mockResponse.data)
 
                 let customEvent = CustomEvent(
                     withName: "testEvent",
@@ -323,7 +327,7 @@ class CustomEventsSpec: QuickSpec {
 
             it("should accept a campaign that is matched using an custom event with a BOOL type and isNotEqual operator") {
                 let mockResponse = TestHelpers.MockResponse.boolTypeWithNotEqualOperator
-                campaignRepository.syncWith(list: mockResponse.data, timestampMilliseconds: 0)
+                syncRepository(with: mockResponse.data)
 
                 let customEvent = CustomEvent(
                     withName: "testEvent",
@@ -349,7 +353,7 @@ class CustomEventsSpec: QuickSpec {
 
             it("should accept a campaign that is matched using an custom event with a time(int) type and equals operator") {
                 let mockResponse = TestHelpers.MockResponse.timeTypeWithEqualsOperator
-                campaignRepository.syncWith(list: mockResponse.data, timestampMilliseconds: 0)
+                syncRepository(with: mockResponse.data)
 
                 let customEvent = CustomEvent(
                     withName: "testEvent",
@@ -375,7 +379,7 @@ class CustomEventsSpec: QuickSpec {
 
             it("should accept a campaign that is matched using an custom event with a time(int) type and isNotEqual operator") {
                 let mockResponse = TestHelpers.MockResponse.timeTypeWithNotEqualsOperator
-                campaignRepository.syncWith(list: mockResponse.data, timestampMilliseconds: 0)
+                syncRepository(with: mockResponse.data)
 
                 let customEvent = CustomEvent(
                     withName: "testEvent",
@@ -401,7 +405,7 @@ class CustomEventsSpec: QuickSpec {
 
             it("should accept a campaign that is matched using an custom event with a time(int) type and greaterThan operator") {
                 let mockResponse = TestHelpers.MockResponse.timeTypeWithGreaterThanOperator
-                campaignRepository.syncWith(list: mockResponse.data, timestampMilliseconds: 0)
+                syncRepository(with: mockResponse.data)
 
                 let customEvent = CustomEvent(
                     withName: "testEvent",
@@ -427,7 +431,7 @@ class CustomEventsSpec: QuickSpec {
 
             it("should accept a campaign that is matched using an custom event with a time(int) type and lessThan operator") {
                 let mockResponse = TestHelpers.MockResponse.timeTypeWithLessThanOperator
-                campaignRepository.syncWith(list: mockResponse.data, timestampMilliseconds: 0)
+                syncRepository(with: mockResponse.data)
 
                 let customEvent = CustomEvent(
                     withName: "testEvent",
@@ -453,7 +457,7 @@ class CustomEventsSpec: QuickSpec {
 
             it("should accept a campaign that is matched even with a case-insensitive event name") {
                 let mockResponse = TestHelpers.MockResponse.caseInsensitiveEventName
-                campaignRepository.syncWith(list: mockResponse.data, timestampMilliseconds: 0)
+                syncRepository(with: mockResponse.data)
 
                 let customEvent = CustomEvent(
                     withName: "TESTEVENT",
@@ -468,7 +472,7 @@ class CustomEventsSpec: QuickSpec {
 
             it("should accept a campaign that is matched even with a case-insensitive attribute name") {
                 let mockResponse = TestHelpers.MockResponse.caseInsensitiveAttributeName
-                campaignRepository.syncWith(list: mockResponse.data, timestampMilliseconds: 0)
+                syncRepository(with: mockResponse.data)
 
                 let customEvent = CustomEvent(
                     withName: "TESTEVENT",
@@ -484,7 +488,7 @@ class CustomEventsSpec: QuickSpec {
 
             it("should accept a campaign that is matched even with a case-insensitive attribute value") {
                 let mockResponse = TestHelpers.MockResponse.caseInsensitiveAttributeValue
-                campaignRepository.syncWith(list: mockResponse.data, timestampMilliseconds: 0)
+                syncRepository(with: mockResponse.data)
 
                 let customEvent = CustomEvent(
                     withName: "TESTEVENT",

--- a/Tests/Tests/DisplayPermissionServiceSpec.swift
+++ b/Tests/Tests/DisplayPermissionServiceSpec.swift
@@ -19,7 +19,7 @@ class DisplayPermissionServiceSpec: QuickSpec {
                                                 ping: URL(string: "https://ping.url")!,
                                                 displayPermission: URL(string: "https://permission.url")!,
                                                 impression: nil))
-        let moduleConfig = InAppMessagingModuleConfiguration(configurationURL: "https://config.url",
+        let moduleConfig = InAppMessagingModuleConfiguration(configURLString: "https://config.url",
                                                              subscriptionID: "sub-id",
                                                              isTooltipFeatureEnabled: true)
         let campaign = TestHelpers.generateCampaign(id: "test")

--- a/Tests/Tests/HeaderAttributesBuilderSpec.swift
+++ b/Tests/Tests/HeaderAttributesBuilderSpec.swift
@@ -11,34 +11,41 @@ class HeaderAttributesBuilderSpec: QuickSpec {
             var builder: HeaderAttributesBuilder!
             let accountRepository = AccountRepository(userDataCache: UserDataCacheMock())
             let userInfoProvider = UserInfoProviderMock()
+            var configurationRepository: ConfigurationRepository!
+
             accountRepository.setPreference(userInfoProvider)
 
             beforeEach {
                 builder = HeaderAttributesBuilder()
                 BundleInfoMock.reset()
                 userInfoProvider.clear()
+                configurationRepository = ConfigurationRepository()
             }
 
             context("when calling addSubscriptionID") {
 
                 it("should return false for empty subscription id") {
-                    BundleInfoMock.inAppSubscriptionIdMock = ""
-                    expect(builder.addSubscriptionID(bundleInfo: BundleInfoMock.self)).to(beFalse())
+                    configurationRepository.saveIAMModuleConfiguration(
+                        InAppMessagingModuleConfiguration(subscriptionID: ""))
+                    expect(builder.addSubscriptionID(configurationRepository: configurationRepository)).to(beFalse())
                 }
 
                 it("should return false for nil subscription id") {
-                    BundleInfoMock.inAppSubscriptionIdMock = nil
-                    expect(builder.addSubscriptionID(bundleInfo: BundleInfoMock.self)).to(beFalse())
+                    configurationRepository.saveIAMModuleConfiguration(
+                        InAppMessagingModuleConfiguration(subscriptionID: nil))
+                    expect(builder.addSubscriptionID(configurationRepository: configurationRepository)).to(beFalse())
                 }
 
                 it("should return true for any subscription id") {
-                    BundleInfoMock.inAppSubscriptionIdMock = "some-id"
-                    expect(builder.addSubscriptionID(bundleInfo: BundleInfoMock.self)).to(beTrue())
+                    configurationRepository.saveIAMModuleConfiguration(
+                        InAppMessagingModuleConfiguration(subscriptionID: "some-id"))
+                    expect(builder.addSubscriptionID(configurationRepository: configurationRepository)).to(beTrue())
                 }
 
                 it("should append new header attribute") {
-                    BundleInfoMock.inAppSubscriptionIdMock = "some-id"
-                    builder.addSubscriptionID(bundleInfo: BundleInfoMock.self)
+                    configurationRepository.saveIAMModuleConfiguration(
+                        InAppMessagingModuleConfiguration(subscriptionID: "some-id"))
+                    builder.addSubscriptionID(configurationRepository: configurationRepository)
                     expect(builder.build()).to(elementsEqual([HeaderAttribute(key: Constants.Request.Header.subscriptionID, value: "some-id")]))
                 }
             }
@@ -69,11 +76,12 @@ class HeaderAttributesBuilderSpec: QuickSpec {
                 }
 
                 it("should return array with all expected types") {
-                    BundleInfoMock.inAppSubscriptionIdMock = "some-id"
+                    configurationRepository.saveIAMModuleConfiguration(
+                        InAppMessagingModuleConfiguration(subscriptionID: "some-id"))
                     userInfoProvider.accessToken = "token"
 
                     builder.addDeviceID()
-                    builder.addSubscriptionID(bundleInfo: BundleInfoMock.self)
+                    builder.addSubscriptionID(configurationRepository: configurationRepository)
                     builder.addAccessToken(accountRepository: accountRepository)
 
                     expect(builder.build()).to(contain(HeaderAttribute(key: Constants.Request.Header.subscriptionID, value: "some-id")))

--- a/Tests/Tests/Helpers/TestHelpers.swift
+++ b/Tests/Tests/Helpers/TestHelpers.swift
@@ -22,7 +22,7 @@ class ValidatorHandler {
     }
 }
 
-// swiftlint:disable:next type_body_length
+// swiftlint:disable type_body_length
 struct TestHelpers {
 
     static func generateCampaign(id: String,

--- a/Tests/Tests/Helpers/TestHelpers.swift
+++ b/Tests/Tests/Helpers/TestHelpers.swift
@@ -528,9 +528,9 @@ extension Trigger {
 }
 
 extension InAppMessagingModuleConfiguration {
-    static let empty = Self.init(configurationURL: nil, subscriptionID: nil, isTooltipFeatureEnabled: true)
+    static let empty = Self.init(configURLString: nil, subscriptionID: nil, isTooltipFeatureEnabled: true)
 
     init(subscriptionID: String?) {
-        self.init(configurationURL: "url", subscriptionID: subscriptionID, isTooltipFeatureEnabled: true)
+        self.init(configURLString: "url", subscriptionID: subscriptionID, isTooltipFeatureEnabled: true)
     }
 }

--- a/Tests/Tests/Helpers/TestHelpers.swift
+++ b/Tests/Tests/Helpers/TestHelpers.swift
@@ -526,3 +526,11 @@ extension Trigger {
                                            eventName: "login",
                                            attributes: [])
 }
+
+extension InAppMessagingModuleConfiguration {
+    static let empty = Self.init(configurationURL: nil, subscriptionID: nil, isTooltipFeatureEnabled: true)
+
+    init(subscriptionID: String?) {
+        self.init(configurationURL: "url", subscriptionID: subscriptionID, isTooltipFeatureEnabled: true)
+    }
+}

--- a/Tests/Tests/ImpressionServiceSpec.swift
+++ b/Tests/Tests/ImpressionServiceSpec.swift
@@ -21,7 +21,7 @@ class ImpressionServiceSpec: QuickSpec {
                                                 ping: URL(string: "https://ping.url")!,
                                                 displayPermission: nil,
                                                 impression: impressionURL))
-        let moduleConfig = InAppMessagingModuleConfiguration(configurationURL: "https://config.url",
+        let moduleConfig = InAppMessagingModuleConfiguration(configURLString: "https://config.url",
                                                              subscriptionID: "sub-id",
                                                              isTooltipFeatureEnabled: true)
         let campaign = TestHelpers.generateCampaign(id: "test")

--- a/Tests/Tests/MainContainerSpec.swift
+++ b/Tests/Tests/MainContainerSpec.swift
@@ -50,7 +50,7 @@ class MainContainerSpec: QuickSpec {
             context("when a valid configURL is provided") {
                 beforeEach {
                     dependencyManager.appendContainer(MainContainerFactory.create(dependencyManager: dependencyManager,
-                                                                                  configURL: "http://config.url"))
+                                                                                  configURL: URL(string: "http://config.url")!))
                 }
 
                 it("will have all dependencies resolved") {
@@ -60,32 +60,10 @@ class MainContainerSpec: QuickSpec {
                 }
             }
 
-            context("when empty configURL is provided") {
-                beforeEach {
-                    dependencyManager.appendContainer(MainContainerFactory.create(dependencyManager: dependencyManager,
-                                                                                  configURL: ""))
-                }
-
-                it("will throw an assertion when resolving ReachabilityType dependency") {
-                    expect(dependencyManager.resolve(type: ReachabilityType.self)).to(throwAssertion())
-                }
-            }
-
-            context("when nil configURL is provided") {
-                beforeEach {
-                    dependencyManager.appendContainer(MainContainerFactory.create(dependencyManager: dependencyManager,
-                                                                                  configURL: nil))
-                }
-
-                it("will throw an assertion when resolving ReachabilityType dependency") {
-                    expect(dependencyManager.resolve(type: ReachabilityType.self)).to(throwAssertion())
-                }
-            }
-
             context("when ReachabilityType dependency is nil") {
                 beforeEach {
                     dependencyManager.appendContainer(MainContainerFactory.create(dependencyManager: dependencyManager,
-                                                                                  configURL: nil))
+                                                                                  configURL: URL(string: "config.url")!))
                     dependencyManager.appendContainer(TypedDependencyManager.Container([
                         // original ReachabilityType container throws an assertion which prevents further testing
                         TypedDependencyManager.ContainerElement(type: ReachabilityType.self, factory: { nil })

--- a/Tests/Tests/MainContainerSpec.swift
+++ b/Tests/Tests/MainContainerSpec.swift
@@ -1,5 +1,6 @@
 import Quick
 import Nimble
+import Foundation
 #if canImport(RSDKUtilsMain)
 import RSDKUtilsMain // SPM version
 #else

--- a/Tests/Tests/MessageMixerServiceSpec.swift
+++ b/Tests/Tests/MessageMixerServiceSpec.swift
@@ -15,7 +15,7 @@ class MessageMixerServiceSpec: QuickSpec {
 
         let requestQueue = DispatchQueue(label: "iam.test.request")
         let configData = ConfigEndpointData(rolloutPercentage: 100, endpoints: .empty)
-        let moduleConfig = InAppMessagingModuleConfiguration(configurationURL: "https://config.url",
+        let moduleConfig = InAppMessagingModuleConfiguration(configURLString: "https://config.url",
                                                              subscriptionID: "sub-id",
                                                              isTooltipFeatureEnabled: true)
         let accountRepository = AccountRepository(userDataCache: UserDataCacheMock())

--- a/Tests/Tests/ReadyCampaignDispatcherSpec.swift
+++ b/Tests/Tests/ReadyCampaignDispatcherSpec.swift
@@ -8,8 +8,10 @@ import class RSDKUtils.URLSessionMock
 #endif
 @testable import RInAppMessaging
 
+// swiftlint:disable:next type_body_length
 class ReadyCampaignDispatcherSpec: QuickSpec {
 
+    // swiftlint:disable:next function_body_length
     override func spec() {
         describe("CampaignDispatcher") {
             var dispatcher: CampaignDispatcher!

--- a/Tests/Tests/RouterSpec.swift
+++ b/Tests/Tests/RouterSpec.swift
@@ -37,7 +37,8 @@ class RouterSpec: QuickSpec {
             beforeEach {
                 errorDelegate = ErrorDelegateMock()
                 let dependencyManager = TypedDependencyManager()
-                dependencyManager.appendContainer(MainContainerFactory.create(dependencyManager: dependencyManager, configURL: nil))
+                dependencyManager.appendContainer(MainContainerFactory.create(dependencyManager: dependencyManager,
+                                                                              configURL: URL(string: "config.url")!))
                 dependencyManager.appendContainer(mockContainer())
                 router = Router(dependencyManager: dependencyManager, viewListener: ViewListenerMock())
                 router.errorDelegate = errorDelegate

--- a/Tests/Tests/RouterSpec.swift
+++ b/Tests/Tests/RouterSpec.swift
@@ -37,7 +37,7 @@ class RouterSpec: QuickSpec {
             beforeEach {
                 errorDelegate = ErrorDelegateMock()
                 let dependencyManager = TypedDependencyManager()
-                dependencyManager.appendContainer(MainContainerFactory.create(dependencyManager: dependencyManager))
+                dependencyManager.appendContainer(MainContainerFactory.create(dependencyManager: dependencyManager, configURL: nil))
                 dependencyManager.appendContainer(mockContainer())
                 router = Router(dependencyManager: dependencyManager, viewListener: ViewListenerMock())
                 router.errorDelegate = errorDelegate


### PR DESCRIPTION
# Description
* Added a new flag in `configure()` API method to enable/disable the tooltip feature
* Refactored the way SDK configuration data is accessed in runtime

## Links
SDKCF-6075

# Checklist
- [X] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [X] I wrote/updated tests for new/changed code
- [X] I removed all sensitive data **before every commit**, including API endpoints and keys
- [X] I ran `fastlane ci` without errors
