### PR TITLE
feat: track opt-in/opt-outs events in Push Primer feature (SDKCF-6026)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 	- Added new API method to close displayed tooltips [SDKCF-6027]
 	- Added contexts validation for tooltip campaigns [SDKCF-6028]
 	- Added a feature flag to enable/disable the Tooltip feature [SDKCF-6075]
+	- Added tracking of opt-in/opt-outs in Push Primer feature [SDKCF-6026]
 - Bug fixes:
 	- Fixed an edge case of not readable status bar when campaign message is displayed [SDKCF-5134]
 

--- a/Sources/RInAppMessaging/Constants.swift
+++ b/Sources/RInAppMessaging/Constants.swift
@@ -50,13 +50,15 @@ internal enum Constants {
 
     enum RAnalytics {
         static let impressionsEventName = "_rem_iam_impressions"
-        
+        static let pushPrimerEventName = "_rem_iam_pushprimer"
+
         enum Keys {
             static let action = "action"
             static let timestamp = "timestamp"
             static let impressions = "impressions"
             static let campaignID = "campaign_id"
             static let subscriptionID = "subscription_id"
+            static let pushPermission = "push_permission"
         }
     }
 

--- a/Sources/RInAppMessaging/Protocols/RemoteNotificationRequestable.swift
+++ b/Sources/RInAppMessaging/Protocols/RemoteNotificationRequestable.swift
@@ -5,6 +5,7 @@ protocol RemoteNotificationRequestable {
     func requestAuthorization(options: UNAuthorizationOptions,
                               completionHandler: @escaping (Bool, Error?) -> Void)
     func registerForRemoteNotifications()
+    func getAuthorizationStatus(completionHandler: @escaping (UNAuthorizationStatus) -> Void)
 }
 
 extension RemoteNotificationRequestable {
@@ -13,4 +14,10 @@ extension RemoteNotificationRequestable {
     }
 }
 
-extension UNUserNotificationCenter: RemoteNotificationRequestable { }
+extension UNUserNotificationCenter: RemoteNotificationRequestable {
+    func getAuthorizationStatus(completionHandler: @escaping (UNAuthorizationStatus) -> Void) {
+        getNotificationSettings { settings in
+            completionHandler(settings.authorizationStatus)
+        }
+    }
+}

--- a/Sources/RInAppMessaging/Views/Presenters/BaseViewPresenter.swift
+++ b/Sources/RInAppMessaging/Views/Presenters/BaseViewPresenter.swift
@@ -20,7 +20,7 @@ internal class BaseViewPresenter: BaseViewPresenterType {
     private let campaignRepository: CampaignRepositoryType
     private let eventMatcher: EventMatcherType
     private let campaignTriggerAgent: CampaignTriggerAgentType
-    private let configurationRepository: ConfigurationRepositoryType
+    let configurationRepository: ConfigurationRepositoryType
 
     var campaign: Campaign!
     var impressions: [Impression] = []

--- a/Sources/RInAppMessaging/Views/Presenters/FullViewPresenter.swift
+++ b/Sources/RInAppMessaging/Views/Presenters/FullViewPresenter.swift
@@ -158,6 +158,6 @@ internal class FullViewPresenter: BaseViewPresenter, FullViewPresenterType, Erro
         AnalyticsBroadcaster.sendEventName(Constants.RAnalytics.pushPrimerEventName,
                                            dataObject: [Constants.RAnalytics.Keys.pushPermission: NSNumber(value: didOptIn),
                                                         Constants.RAnalytics.Keys.campaignID: campaign.id,
-                                                        Constants.RAnalytics.Keys.subscriptionID: bundleInfo.inAppSubscriptionId ?? "n/a"])
+                                                        Constants.RAnalytics.Keys.subscriptionID: configurationRepository.getSubscriptionID() ?? "n/a"])
     }
 }

--- a/Sources/RInAppMessaging/Views/Presenters/FullViewPresenter.swift
+++ b/Sources/RInAppMessaging/Views/Presenters/FullViewPresenter.swift
@@ -156,7 +156,7 @@ internal class FullViewPresenter: BaseViewPresenter, FullViewPresenterType, Erro
 
     private func trackPushPrimerAction(didOptIn: Bool) {
         AnalyticsBroadcaster.sendEventName(Constants.RAnalytics.pushPrimerEventName,
-                                           dataObject: [Constants.RAnalytics.Keys.pushPermission: Int(booleanLiteral: didOptIn),
+                                           dataObject: [Constants.RAnalytics.Keys.pushPermission: NSNumber(value: didOptIn),
                                                         Constants.RAnalytics.Keys.campaignID: campaign.id,
                                                         Constants.RAnalytics.Keys.subscriptionID: bundleInfo.inAppSubscriptionId ?? "n/a"])
     }

--- a/Tests/Tests/Helpers/SharedMocks.swift
+++ b/Tests/Tests/Helpers/SharedMocks.swift
@@ -533,6 +533,7 @@ final class UNUserNotificationCenterMock: RemoteNotificationRequestable {
     private(set) var didCallRegisterForRemoteNotifications = false
     var authorizationRequestError: Error?
     var authorizationGranted = true
+    var authorizationStatus = UNAuthorizationStatus.notDetermined
 
     func requestAuthorization(options: UNAuthorizationOptions = [],
                               completionHandler: @escaping (Bool, Error?) -> Void) {
@@ -542,6 +543,10 @@ final class UNUserNotificationCenterMock: RemoteNotificationRequestable {
 
     func registerForRemoteNotifications() {
         didCallRegisterForRemoteNotifications = true
+    }
+
+    func getAuthorizationStatus(completionHandler: @escaping (UNAuthorizationStatus) -> Void) {
+        completionHandler(authorizationStatus)
     }
 }
 

--- a/Tests/Tests/ViewPresenterSpec.swift
+++ b/Tests/Tests/ViewPresenterSpec.swift
@@ -53,7 +53,7 @@ class ViewPresenterSpec: QuickSpec {
 
                 it("will send `impression` type to RAnalytics with all required properties") {
                     let subscriptionID = "sub-id"
-                    configurationRepository.saveIAMModuleConfiguration(InAppMessagingModuleConfiguration.init(subscriptionID: subscriptionID))
+                    configurationRepository.saveIAMModuleConfiguration(InAppMessagingModuleConfiguration(subscriptionID: subscriptionID))
 
                     expect {
                         presenter.logImpression(type: .impression)
@@ -337,7 +337,6 @@ class ViewPresenterSpec: QuickSpec {
                 presenter.view = view
                 presenter.campaign = campaign
                 presenter.errorDelegate = errorDelegate
-                presenter.bundleInfo = bundleInfo
             }
 
             context("when viewDidInitialize is called") {
@@ -505,7 +504,7 @@ class ViewPresenterSpec: QuickSpec {
 
                         return params["eventName"] as? String == Constants.RAnalytics.pushPrimerEventName &&
                         data[Constants.RAnalytics.Keys.pushPermission] as? Int == Int(booleanLiteral: expectedFlag) &&
-                        data[Constants.RAnalytics.Keys.subscriptionID] as? String == bundleInfo.inAppSubscriptionIdMock &&
+                        data[Constants.RAnalytics.Keys.subscriptionID] as? String == configurationRepository.getSubscriptionID() &&
                         data[Constants.RAnalytics.Keys.campaignID] as? String == campaign.id
                     }
 
@@ -537,7 +536,7 @@ class ViewPresenterSpec: QuickSpec {
 
                         it("will track analytics event when user gives permission") {
                             notificationCenterMock.authorizationStatus = .notDetermined
-                            bundleInfo.inAppSubscriptionIdMock = "sub-id"
+                            configurationRepository.saveIAMModuleConfiguration(InAppMessagingModuleConfiguration(subscriptionID: "sub-id"))
 
                             expect {
                                 presenter.didClickAction(sender: sender)
@@ -548,12 +547,12 @@ class ViewPresenterSpec: QuickSpec {
 
                         it("will not track analytics event when authorization popup did not appear") {
                             notificationCenterMock.authorizationStatus = .authorized
-                            bundleInfo.inAppSubscriptionIdMock = "sub-id"
+                            configurationRepository.saveIAMModuleConfiguration(InAppMessagingModuleConfiguration(subscriptionID: "sub-id"))
 
                             var receivedNotification: Notification?
-                            let observer = NotificationCenter.default.addObserver(forName: .rAnalyticsCustomEvent,
-                                                                                  object: nil,
-                                                                                  queue: OperationQueue()) { notification in
+                            NotificationCenter.default.addObserver(forName: .rAnalyticsCustomEvent,
+                                                                   object: nil,
+                                                                   queue: OperationQueue()) { notification in
                                 receivedNotification = notification
                             }
                             presenter.didClickAction(sender: sender)
@@ -569,7 +568,7 @@ class ViewPresenterSpec: QuickSpec {
 
                         it("will track analytics event when user denies permission") {
                             notificationCenterMock.authorizationStatus = .notDetermined
-                            bundleInfo.inAppSubscriptionIdMock = "sub-id"
+                            configurationRepository.saveIAMModuleConfiguration(InAppMessagingModuleConfiguration(subscriptionID: "sub-id"))
 
                             expect {
                                 presenter.didClickAction(sender: sender)
@@ -580,12 +579,12 @@ class ViewPresenterSpec: QuickSpec {
 
                         it("will not track analytics event when authorization popup did not appear") {
                             notificationCenterMock.authorizationStatus = .denied
-                            bundleInfo.inAppSubscriptionIdMock = "sub-id"
+                            configurationRepository.saveIAMModuleConfiguration(InAppMessagingModuleConfiguration(subscriptionID: "sub-id"))
 
                             var receivedNotification: Notification?
-                            let observer = NotificationCenter.default.addObserver(forName: .rAnalyticsCustomEvent,
-                                                                                  object: nil,
-                                                                                  queue: OperationQueue()) { notification in
+                            NotificationCenter.default.addObserver(forName: .rAnalyticsCustomEvent,
+                                                                   object: nil,
+                                                                   queue: OperationQueue()) { notification in
                                 receivedNotification = notification
                             }
                             presenter.didClickAction(sender: sender)

--- a/Tests/Tests/ViewPresenterSpec.swift
+++ b/Tests/Tests/ViewPresenterSpec.swift
@@ -337,6 +337,7 @@ class ViewPresenterSpec: QuickSpec {
                 presenter.view = view
                 presenter.campaign = campaign
                 presenter.errorDelegate = errorDelegate
+                presenter.bundleInfo = bundleInfo
             }
 
             context("when viewDidInitialize is called") {
@@ -496,6 +497,18 @@ class ViewPresenterSpec: QuickSpec {
                                               impression: .actionOne,
                                               uri: nil, trigger: nil)
 
+                    func validatePushPermissionNotification(_ notification: Notification, expectedFlag: Bool) -> Bool {
+                        guard let params = notification.object as? [String: Any],
+                              let data = params["eventData"] as? [String: Any] else {
+                            return false
+                        }
+
+                        return params["eventName"] as? String == Constants.RAnalytics.pushPrimerEventName &&
+                        data[Constants.RAnalytics.Keys.pushPermission] as? Int == Int(booleanLiteral: expectedFlag) &&
+                        data[Constants.RAnalytics.Keys.subscriptionID] as? String == bundleInfo.inAppSubscriptionIdMock &&
+                        data[Constants.RAnalytics.Keys.campaignID] as? String == campaign.id
+                    }
+
                     it("will call dismiss on the view object") {
                         presenter.didClickAction(sender: sender)
                         expect(view.wasDismissCalled).to(beTrue())
@@ -521,11 +534,63 @@ class ViewPresenterSpec: QuickSpec {
                             presenter.didClickAction(sender: sender)
                             expect(notificationCenterMock.didCallRegisterForRemoteNotifications).toEventually(beTrue())
                         }
+
+                        it("will track analytics event when user gives permission") {
+                            notificationCenterMock.authorizationStatus = .notDetermined
+                            bundleInfo.inAppSubscriptionIdMock = "sub-id"
+
+                            expect {
+                                presenter.didClickAction(sender: sender)
+                            }.toEventually(postNotifications(containElementSatisfying({
+                                validatePushPermissionNotification($0, expectedFlag: true)
+                            })))
+                        }
+
+                        it("will not track analytics event when authorization popup did not appear") {
+                            notificationCenterMock.authorizationStatus = .authorized
+                            bundleInfo.inAppSubscriptionIdMock = "sub-id"
+
+                            var receivedNotification: Notification?
+                            let observer = NotificationCenter.default.addObserver(forName: .rAnalyticsCustomEvent,
+                                                                                  object: nil,
+                                                                                  queue: OperationQueue()) { notification in
+                                receivedNotification = notification
+                            }
+                            presenter.didClickAction(sender: sender)
+
+                            expect(receivedNotification).toAfterTimeout(beNil())
+                        }
                     }
 
                     context("when authorization is not granted") {
                         beforeEach {
                             notificationCenterMock.authorizationGranted = false
+                        }
+
+                        it("will track analytics event when user denies permission") {
+                            notificationCenterMock.authorizationStatus = .notDetermined
+                            bundleInfo.inAppSubscriptionIdMock = "sub-id"
+
+                            expect {
+                                presenter.didClickAction(sender: sender)
+                            }.toEventually(postNotifications(containElementSatisfying({
+                                validatePushPermissionNotification($0, expectedFlag: false)
+                            })))
+                        }
+
+                        it("will not track analytics event when authorization popup did not appear") {
+                            notificationCenterMock.authorizationStatus = .denied
+                            bundleInfo.inAppSubscriptionIdMock = "sub-id"
+
+                            var receivedNotification: Notification?
+                            let observer = NotificationCenter.default.addObserver(forName: .rAnalyticsCustomEvent,
+                                                                                  object: nil,
+                                                                                  queue: OperationQueue()) { notification in
+                                receivedNotification = notification
+                            }
+                            presenter.didClickAction(sender: sender)
+
+                            expect(receivedNotification).toAfterTimeout(beNil())
                         }
 
                         it("will not try to register for remote notifications") {


### PR DESCRIPTION
# Description
Added tracking of opt-in/opt-out events in Push Primer feature.
The event are sent to RAnalytics whenever user allows or denies push notification authorization as a part of Push Primer feature.

## Links
SDKCF-6026

# Checklist
- [X] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [X] I wrote/updated tests for new/changed code
- [X] I removed all sensitive data **before every commit**, including API endpoints and keys
- [X] I ran `fastlane ci` without errors
