### PR TITLE
refactor: prefer SWIFT_PACKAGE macro for import conditions

### DIFF
--- a/Sources/RInAppMessaging/ConfigurationManager.swift
+++ b/Sources/RInAppMessaging/ConfigurationManager.swift
@@ -1,6 +1,7 @@
 import Foundation
-#if canImport(RSDKUtilsMain)
-import RSDKUtilsMain // SPM version
+
+#if SWIFT_PACKAGE
+import RSDKUtilsMain
 #else
 import RSDKUtils
 #endif

--- a/Sources/RInAppMessaging/DependencyManager/MainContainer.swift
+++ b/Sources/RInAppMessaging/DependencyManager/MainContainer.swift
@@ -1,6 +1,7 @@
 import Foundation
-#if canImport(RSDKUtilsMain)
-import RSDKUtilsMain // SPM version
+
+#if SWIFT_PACKAGE
+import RSDKUtilsMain
 #else
 import RSDKUtils
 #endif

--- a/Sources/RInAppMessaging/EventMatcher.swift
+++ b/Sources/RInAppMessaging/EventMatcher.swift
@@ -1,6 +1,7 @@
 import Foundation
-#if canImport(RSDKUtilsMain)
-import RSDKUtilsMain // SPM version
+
+#if SWIFT_PACKAGE
+import RSDKUtilsMain
 #else
 import RSDKUtils
 #endif

--- a/Sources/RInAppMessaging/Extensions/UIColor+IAM.swift
+++ b/Sources/RInAppMessaging/Extensions/UIColor+IAM.swift
@@ -1,6 +1,7 @@
 import UIKit
-#if canImport(RSDKUtilsMain)
-import RSDKUtilsMain // SPM version
+
+#if SWIFT_PACKAGE
+import RSDKUtilsMain
 #else
 import RSDKUtils
 #endif

--- a/Sources/RInAppMessaging/RInAppMessaging.swift
+++ b/Sources/RInAppMessaging/RInAppMessaging.swift
@@ -1,7 +1,8 @@
 import Foundation
 import struct UserNotifications.UNAuthorizationOptions
-#if canImport(RSDKUtilsMain)
-import RSDKUtilsMain // SPM version
+
+#if SWIFT_PACKAGE
+import RSDKUtilsMain
 #else
 import RSDKUtils
 #endif

--- a/Sources/RInAppMessaging/Repositories/AccountRepository.swift
+++ b/Sources/RInAppMessaging/Repositories/AccountRepository.swift
@@ -1,6 +1,7 @@
 import class Foundation.Bundle
-#if canImport(RSDKUtilsMain)
-import class RSDKUtilsMain.WeakWrapper // SPM version
+
+#if SWIFT_PACKAGE
+import class RSDKUtilsMain.WeakWrapper
 #else
 import class RSDKUtils.WeakWrapper
 #endif

--- a/Sources/RInAppMessaging/Repositories/CampaignRepository.swift
+++ b/Sources/RInAppMessaging/Repositories/CampaignRepository.swift
@@ -1,6 +1,7 @@
 import Foundation
-#if canImport(RSDKUtilsMain)
-import RSDKUtilsMain // SPM version
+
+#if SWIFT_PACKAGE
+import RSDKUtilsMain
 #else
 import RSDKUtils
 #endif

--- a/Sources/RInAppMessaging/Router.swift
+++ b/Sources/RInAppMessaging/Router.swift
@@ -1,6 +1,7 @@
 import UIKit
-#if canImport(RSDKUtilsMain)
-import RSDKUtilsMain // SPM version
+
+#if SWIFT_PACKAGE
+import RSDKUtilsMain
 #else
 import RSDKUtils
 #endif

--- a/Sources/RInAppMessaging/Services/ImpressionService.swift
+++ b/Sources/RInAppMessaging/Services/ImpressionService.swift
@@ -1,8 +1,9 @@
 import Foundation
-#if canImport(RSDKUtils)
-import class RSDKUtils.AnalyticsBroadcaster
-#else // SPM Version
+
+#if SWIFT_PACKAGE
 import class RSDKUtilsMain.AnalyticsBroadcaster
+#else
+import class RSDKUtils.AnalyticsBroadcaster
 #endif
 
 internal protocol ImpressionServiceType: ErrorReportable {

--- a/Sources/RInAppMessaging/UserDataCache.swift
+++ b/Sources/RInAppMessaging/UserDataCache.swift
@@ -1,6 +1,7 @@
 import Foundation
-#if canImport(RSDKUtilsMain)
-import class RSDKUtilsMain.AtomicGetSet // SPM version
+
+#if SWIFT_PACKAGE
+import class RSDKUtilsMain.AtomicGetSet
 #else
 import class RSDKUtils.AtomicGetSet
 #endif

--- a/Sources/RInAppMessaging/Utilities/BundleInfo.swift
+++ b/Sources/RInAppMessaging/Utilities/BundleInfo.swift
@@ -1,6 +1,7 @@
 import Foundation
-#if canImport(RSDKUtilsMain)
-import RSDKUtilsMain // SPM version
+
+#if SWIFT_PACKAGE
+import RSDKUtilsMain
 #else
 import RSDKUtils
 #endif

--- a/Sources/RInAppMessaging/Utilities/CommonUtility.swift
+++ b/Sources/RInAppMessaging/Utilities/CommonUtility.swift
@@ -1,6 +1,7 @@
 import Foundation
-#if canImport(RSDKUtilsMain)
-import protocol RSDKUtilsMain.Lockable // SPM version
+
+#if SWIFT_PACKAGE
+import protocol RSDKUtilsMain.Lockable
 #else
 import protocol RSDKUtils.Lockable
 #endif

--- a/Sources/RInAppMessaging/ViewListener.swift
+++ b/Sources/RInAppMessaging/ViewListener.swift
@@ -1,7 +1,8 @@
 import Foundation
 import UIKit
-#if canImport(RSDKUtilsMain)
-import RSDKUtilsMain // SPM version
+
+#if SWIFT_PACKAGE
+import RSDKUtilsMain
 #else
 import RSDKUtils
 #endif

--- a/Sources/RInAppMessaging/Views/Presenters/BaseViewPresenter.swift
+++ b/Sources/RInAppMessaging/Views/Presenters/BaseViewPresenter.swift
@@ -1,8 +1,9 @@
 import UIKit
-#if canImport(RSDKUtils)
-import class RSDKUtils.AnalyticsBroadcaster
-#else // SPM Version
+
+#if SWIFT_PACKAGE
 import class RSDKUtilsMain.AnalyticsBroadcaster
+#else
+import class RSDKUtils.AnalyticsBroadcaster
 #endif
 
 internal protocol BaseViewPresenterType: ImpressionTrackable {

--- a/Sources/RInAppMessaging/Views/Presenters/FullViewPresenter.swift
+++ b/Sources/RInAppMessaging/Views/Presenters/FullViewPresenter.swift
@@ -3,7 +3,7 @@ import UserNotifications
 
 #if canImport(RSDKUtils)
 import class RSDKUtils.AnalyticsBroadcaster
-#else // SPM Version
+#else // SPM version
 import class RSDKUtilsMain.AnalyticsBroadcaster
 #endif
 

--- a/Tests/IntegrationTests/IntegrationTests.swift
+++ b/Tests/IntegrationTests/IntegrationTests.swift
@@ -1,6 +1,7 @@
 import XCTest
-#if canImport(RSDKUtilsMain)
-import class RSDKUtilsMain.TypedDependencyManager // SPM version
+
+#if SWIFT_PACKAGE
+import class RSDKUtilsMain.TypedDependencyManager
 #else
 import class RSDKUtils.TypedDependencyManager
 #endif

--- a/Tests/Tests/ConfigurationServiceSpec.swift
+++ b/Tests/Tests/ConfigurationServiceSpec.swift
@@ -1,11 +1,13 @@
 import Foundation
 import Quick
 import Nimble
-#if canImport(RSDKUtilsTestHelpers)
-import class RSDKUtilsTestHelpers.URLSessionMock // SPM version
-#else
+
+#if canImport(RSDKUtils)
 import class RSDKUtils.URLSessionMock
+#else // SPM version
+import class RSDKUtilsTestHelpers.URLSessionMock
 #endif
+
 @testable import RInAppMessaging
 
 private let configURL = URL(string: "http://config.url")!

--- a/Tests/Tests/ConfigurationServiceSpec.swift
+++ b/Tests/Tests/ConfigurationServiceSpec.swift
@@ -2,8 +2,8 @@ import Foundation
 import Quick
 import Nimble
 
-#if SWIFT_PACKAGE
-import class RSDKUtilsTestHelpers.URLSessionMock
+#if canImport(RSDKUtilsTestHelpers)
+import class RSDKUtilsTestHelpers.URLSessionMock // SPM version
 #else
 import class RSDKUtils.URLSessionMock
 #endif

--- a/Tests/Tests/ConfigurationServiceSpec.swift
+++ b/Tests/Tests/ConfigurationServiceSpec.swift
@@ -2,10 +2,10 @@ import Foundation
 import Quick
 import Nimble
 
-#if canImport(RSDKUtils)
-import class RSDKUtils.URLSessionMock
-#else // SPM version
+#if SWIFT_PACKAGE
 import class RSDKUtilsTestHelpers.URLSessionMock
+#else
+import class RSDKUtils.URLSessionMock
 #endif
 
 @testable import RInAppMessaging

--- a/Tests/Tests/ConfigurationSpec.swift
+++ b/Tests/Tests/ConfigurationSpec.swift
@@ -1,11 +1,13 @@
 import Quick
 import Nimble
 import Foundation
-#if canImport(RSDKUtilsMain)
-import class RSDKUtilsMain.TypedDependencyManager // SPM version
-#else
+
+#if canImport(RSDKUtils)
 import class RSDKUtils.TypedDependencyManager
+#else // SPM version
+import class RSDKUtilsMain.TypedDependencyManager
 #endif
+
 @testable import RInAppMessaging
 
 /// Tests for behavior of the SDK when supplied with different configuration responses.

--- a/Tests/Tests/ConfigurationSpec.swift
+++ b/Tests/Tests/ConfigurationSpec.swift
@@ -2,10 +2,10 @@ import Quick
 import Nimble
 import Foundation
 
-#if canImport(RSDKUtils)
-import class RSDKUtils.TypedDependencyManager
-#else // SPM version
+#if SWIFT_PACKAGE
 import class RSDKUtilsMain.TypedDependencyManager
+#else
+import class RSDKUtils.TypedDependencyManager
 #endif
 
 @testable import RInAppMessaging
@@ -58,7 +58,7 @@ class ConfigurationSpec: QuickSpec {
                     }
 
                     expect(RInAppMessaging.initializedModule).toEventually(beNil())
-                    expect(RInAppMessaging.dependencyManager).to(beNil())
+                    expect(RInAppMessaging.dependencyManager).toEventually(beNil())
                 }
 
                 it("will not call ping") {

--- a/Tests/Tests/ConfigurationSpec.swift
+++ b/Tests/Tests/ConfigurationSpec.swift
@@ -2,8 +2,8 @@ import Quick
 import Nimble
 import Foundation
 
-#if SWIFT_PACKAGE
-import class RSDKUtilsMain.TypedDependencyManager
+#if canImport(RSDKUtilsMain)
+import class RSDKUtilsMain.TypedDependencyManager // SPM version
 #else
 import class RSDKUtils.TypedDependencyManager
 #endif

--- a/Tests/Tests/DisplayPermissionServiceSpec.swift
+++ b/Tests/Tests/DisplayPermissionServiceSpec.swift
@@ -2,11 +2,11 @@ import Foundation
 import Quick
 import Nimble
 
-#if SWIFT_PACKAGE
+#if canImport(RSDKUtils)
+import RSDKUtils
+#else // SPM version
 import RSDKUtilsNimble
 import class RSDKUtilsTestHelpers.URLSessionMock
-#else
-import RSDKUtils
 #endif
 
 @testable import RInAppMessaging

--- a/Tests/Tests/DisplayPermissionServiceSpec.swift
+++ b/Tests/Tests/DisplayPermissionServiceSpec.swift
@@ -1,12 +1,14 @@
 import Foundation
 import Quick
 import Nimble
+
 #if canImport(RSDKUtils)
 import RSDKUtils
 #else // SPM version
 import RSDKUtilsNimble
 import class RSDKUtilsTestHelpers.URLSessionMock
 #endif
+
 @testable import RInAppMessaging
 
 class DisplayPermissionServiceSpec: QuickSpec {

--- a/Tests/Tests/DisplayPermissionServiceSpec.swift
+++ b/Tests/Tests/DisplayPermissionServiceSpec.swift
@@ -2,11 +2,11 @@ import Foundation
 import Quick
 import Nimble
 
-#if canImport(RSDKUtils)
-import RSDKUtils
-#else // SPM version
+#if SWIFT_PACKAGE
 import RSDKUtilsNimble
 import class RSDKUtilsTestHelpers.URLSessionMock
+#else
+import RSDKUtils
 #endif
 
 @testable import RInAppMessaging

--- a/Tests/Tests/Helpers/SharedMocks.swift
+++ b/Tests/Tests/Helpers/SharedMocks.swift
@@ -1,10 +1,10 @@
 import Foundation
 import UIKit
 
-#if canImport(RSDKUtils)
-import RSDKUtils
-#else // SPM version
+#if SWIFT_PACKAGE
 import RSDKUtilsMain
+#else
+import RSDKUtils
 #endif
 
 @testable import RInAppMessaging

--- a/Tests/Tests/Helpers/SharedMocks.swift
+++ b/Tests/Tests/Helpers/SharedMocks.swift
@@ -1,8 +1,8 @@
 import Foundation
 import UIKit
 
-#if SWIFT_PACKAGE
-import RSDKUtilsMain
+#if canImport(RSDKUtilsMain)
+import RSDKUtilsMain // SPM version
 #else
 import RSDKUtils
 #endif

--- a/Tests/Tests/Helpers/SharedMocks.swift
+++ b/Tests/Tests/Helpers/SharedMocks.swift
@@ -1,10 +1,12 @@
 import Foundation
 import UIKit
-#if canImport(RSDKUtilsMain)
-import RSDKUtilsMain // SPM version
-#else
+
+#if canImport(RSDKUtils)
 import RSDKUtils
+#else // SPM version
+import RSDKUtilsMain
 #endif
+
 @testable import RInAppMessaging
 
 let TooltipViewIdentifierMock = "view.id"

--- a/Tests/Tests/HttpRequestableSpec.swift
+++ b/Tests/Tests/HttpRequestableSpec.swift
@@ -2,8 +2,8 @@ import Foundation
 import Quick
 import Nimble
 
-#if SWIFT_PACKAGE
-import class RSDKUtilsTestHelpers.URLSessionMock
+#if canImport(RSDKUtilsTestHelpers)
+import class RSDKUtilsTestHelpers.URLSessionMock // SPM version
 #else
 import class RSDKUtils.URLSessionMock
 #endif

--- a/Tests/Tests/HttpRequestableSpec.swift
+++ b/Tests/Tests/HttpRequestableSpec.swift
@@ -1,11 +1,14 @@
 import Foundation
 import Quick
 import Nimble
-#if canImport(RSDKUtilsTestHelpers)
-import class RSDKUtilsTestHelpers.URLSessionMock // SPM version
-#else
-import class RSDKUtils.URLSessionMock
+
+#if canImport(RSDKUtils)
+import RSDKUtils
+#else // SPM version
+import RSDKUtilsNimble
+import class RSDKUtilsTestHelpers.URLSessionMock
 #endif
+
 @testable import RInAppMessaging
 
 // swiftlint:disable:next type_body_length

--- a/Tests/Tests/HttpRequestableSpec.swift
+++ b/Tests/Tests/HttpRequestableSpec.swift
@@ -2,11 +2,10 @@ import Foundation
 import Quick
 import Nimble
 
-#if canImport(RSDKUtils)
-import RSDKUtils
-#else // SPM version
-import RSDKUtilsNimble
+#if SWIFT_PACKAGE
 import class RSDKUtilsTestHelpers.URLSessionMock
+#else
+import class RSDKUtils.URLSessionMock
 #endif
 
 @testable import RInAppMessaging

--- a/Tests/Tests/ImpressionServiceSpec.swift
+++ b/Tests/Tests/ImpressionServiceSpec.swift
@@ -2,11 +2,11 @@ import Foundation
 import Quick
 import Nimble
 
-#if SWIFT_PACKAGE
+#if canImport(RSDKUtils)
+import RSDKUtils
+#else // SPM version
 import RSDKUtilsNimble
 import class RSDKUtilsTestHelpers.URLSessionMock
-#else
-import RSDKUtils
 #endif
 
 @testable import RInAppMessaging

--- a/Tests/Tests/ImpressionServiceSpec.swift
+++ b/Tests/Tests/ImpressionServiceSpec.swift
@@ -1,12 +1,14 @@
 import Foundation
 import Quick
 import Nimble
+
 #if canImport(RSDKUtils)
 import RSDKUtils
 #else // SPM version
 import RSDKUtilsNimble
 import class RSDKUtilsTestHelpers.URLSessionMock
 #endif
+
 @testable import RInAppMessaging
 
 private let impressionURL = URL(string: "https://impression.url")!

--- a/Tests/Tests/ImpressionServiceSpec.swift
+++ b/Tests/Tests/ImpressionServiceSpec.swift
@@ -2,11 +2,11 @@ import Foundation
 import Quick
 import Nimble
 
-#if canImport(RSDKUtils)
-import RSDKUtils
-#else // SPM version
+#if SWIFT_PACKAGE
 import RSDKUtilsNimble
 import class RSDKUtilsTestHelpers.URLSessionMock
+#else
+import RSDKUtils
 #endif
 
 @testable import RInAppMessaging

--- a/Tests/Tests/InAppMessagingModuleSpec.swift
+++ b/Tests/Tests/InAppMessagingModuleSpec.swift
@@ -2,8 +2,8 @@ import Foundation
 import Quick
 import Nimble
 
-#if SWIFT_PACKAGE
-import RSDKUtilsNimble
+#if canImport(RSDKUtilsNimble)
+import RSDKUtilsNimble // SPM version
 #else
 import RSDKUtils
 #endif

--- a/Tests/Tests/InAppMessagingModuleSpec.swift
+++ b/Tests/Tests/InAppMessagingModuleSpec.swift
@@ -1,11 +1,13 @@
 import Foundation
 import Quick
 import Nimble
-#if canImport(RSDKUtilsNimble)
-import RSDKUtilsNimble // SPM version
-#else
+
+#if canImport(RSDKUtils)
 import RSDKUtils
+#else // SPM version
+import RSDKUtilsNimble
 #endif
+
 @testable import RInAppMessaging
 
 // swiftlint:disable:next type_body_length

--- a/Tests/Tests/InAppMessagingModuleSpec.swift
+++ b/Tests/Tests/InAppMessagingModuleSpec.swift
@@ -2,10 +2,10 @@ import Foundation
 import Quick
 import Nimble
 
-#if canImport(RSDKUtils)
-import RSDKUtils
-#else // SPM version
+#if SWIFT_PACKAGE
 import RSDKUtilsNimble
+#else
+import RSDKUtils
 #endif
 
 @testable import RInAppMessaging

--- a/Tests/Tests/MainContainerSpec.swift
+++ b/Tests/Tests/MainContainerSpec.swift
@@ -2,10 +2,10 @@ import Quick
 import Nimble
 import Foundation
 
-#if canImport(RSDKUtils)
-import RSDKUtils
-#else // SPM version
+#if SWIFT_PACKAGE
 import RSDKUtilsMain
+#else
+import RSDKUtils
 #endif
 
 @testable import RInAppMessaging

--- a/Tests/Tests/MainContainerSpec.swift
+++ b/Tests/Tests/MainContainerSpec.swift
@@ -1,11 +1,13 @@
 import Quick
 import Nimble
 import Foundation
-#if canImport(RSDKUtilsMain)
-import RSDKUtilsMain // SPM version
-#else
+
+#if canImport(RSDKUtils)
 import RSDKUtils
+#else // SPM version
+import RSDKUtilsMain
 #endif
+
 @testable import RInAppMessaging
 
 class MainContainerSpec: QuickSpec {

--- a/Tests/Tests/MainContainerSpec.swift
+++ b/Tests/Tests/MainContainerSpec.swift
@@ -2,8 +2,8 @@ import Quick
 import Nimble
 import Foundation
 
-#if SWIFT_PACKAGE
-import RSDKUtilsMain
+#if canImport(RSDKUtilsMain)
+import RSDKUtilsMain // SPM version
 #else
 import RSDKUtils
 #endif

--- a/Tests/Tests/MessageMixerServiceSpec.swift
+++ b/Tests/Tests/MessageMixerServiceSpec.swift
@@ -2,11 +2,11 @@ import Foundation
 import Quick
 import Nimble
 
-#if SWIFT_PACKAGE
+#if canImport(RSDKUtils)
+import RSDKUtils
+#else // SPM version
 import RSDKUtilsNimble
 import class RSDKUtilsTestHelpers.URLSessionMock
-#else
-import RSDKUtils
 #endif
 
 @testable import RInAppMessaging

--- a/Tests/Tests/MessageMixerServiceSpec.swift
+++ b/Tests/Tests/MessageMixerServiceSpec.swift
@@ -1,12 +1,14 @@
 import Foundation
 import Quick
 import Nimble
+
 #if canImport(RSDKUtils)
 import RSDKUtils
 #else // SPM version
 import RSDKUtilsNimble
 import class RSDKUtilsTestHelpers.URLSessionMock
 #endif
+
 @testable import RInAppMessaging
 
 class MessageMixerServiceSpec: QuickSpec {

--- a/Tests/Tests/MessageMixerServiceSpec.swift
+++ b/Tests/Tests/MessageMixerServiceSpec.swift
@@ -2,11 +2,11 @@ import Foundation
 import Quick
 import Nimble
 
-#if canImport(RSDKUtils)
-import RSDKUtils
-#else // SPM version
+#if SWIFT_PACKAGE
 import RSDKUtilsNimble
 import class RSDKUtilsTestHelpers.URLSessionMock
+#else
+import RSDKUtils
 #endif
 
 @testable import RInAppMessaging

--- a/Tests/Tests/PublicAPISpec.swift
+++ b/Tests/Tests/PublicAPISpec.swift
@@ -2,8 +2,8 @@ import UIKit
 import Quick
 import Nimble
 
-#if SWIFT_PACKAGE
-import class RSDKUtilsMain.TypedDependencyManager
+#if canImport(RSDKUtilsMain)
+import class RSDKUtilsMain.TypedDependencyManager // SPM version
 #else
 import class RSDKUtils.TypedDependencyManager
 #endif

--- a/Tests/Tests/PublicAPISpec.swift
+++ b/Tests/Tests/PublicAPISpec.swift
@@ -2,10 +2,10 @@ import UIKit
 import Quick
 import Nimble
 
-#if canImport(RSDKUtils)
-import class RSDKUtils.TypedDependencyManager
-#else // SPM version
+#if SWIFT_PACKAGE
 import class RSDKUtilsMain.TypedDependencyManager
+#else
+import class RSDKUtils.TypedDependencyManager
 #endif
 
 @testable import RInAppMessaging

--- a/Tests/Tests/PublicAPISpec.swift
+++ b/Tests/Tests/PublicAPISpec.swift
@@ -1,11 +1,13 @@
 import UIKit
 import Quick
 import Nimble
-#if canImport(RSDKUtilsMain)
-import class RSDKUtilsMain.TypedDependencyManager // SPM version
-#else
+
+#if canImport(RSDKUtils)
 import class RSDKUtils.TypedDependencyManager
+#else // SPM version
+import class RSDKUtilsMain.TypedDependencyManager
 #endif
+
 @testable import RInAppMessaging
 
 // swiftlint:disable type_body_length

--- a/Tests/Tests/ReadyCampaignDispatcherSpec.swift
+++ b/Tests/Tests/ReadyCampaignDispatcherSpec.swift
@@ -2,8 +2,8 @@ import Foundation
 import Quick
 import Nimble
 
-#if SWIFT_PACKAGE
-import class RSDKUtilsTestHelpers.URLSessionMock
+#if canImport(RSDKUtilsTestHelpers)
+import class RSDKUtilsTestHelpers.URLSessionMock // SPM version
 #else
 import class RSDKUtils.URLSessionMock
 #endif

--- a/Tests/Tests/ReadyCampaignDispatcherSpec.swift
+++ b/Tests/Tests/ReadyCampaignDispatcherSpec.swift
@@ -2,10 +2,10 @@ import Foundation
 import Quick
 import Nimble
 
-#if canImport(RSDKUtils)
-import class RSDKUtils.URLSessionMock
-#else // SPM version
+#if SWIFT_PACKAGE
 import class RSDKUtilsTestHelpers.URLSessionMock
+#else
+import class RSDKUtils.URLSessionMock
 #endif
 
 @testable import RInAppMessaging

--- a/Tests/Tests/ReadyCampaignDispatcherSpec.swift
+++ b/Tests/Tests/ReadyCampaignDispatcherSpec.swift
@@ -1,11 +1,13 @@
 import Foundation
 import Quick
 import Nimble
-#if canImport(RSDKUtilsTestHelpers)
-import class RSDKUtilsTestHelpers.URLSessionMock // SPM version
-#else
+
+#if canImport(RSDKUtils)
 import class RSDKUtils.URLSessionMock
+#else // SPM version
+import class RSDKUtilsTestHelpers.URLSessionMock
 #endif
+
 @testable import RInAppMessaging
 
 // swiftlint:disable:next type_body_length

--- a/Tests/Tests/RouterSpec.swift
+++ b/Tests/Tests/RouterSpec.swift
@@ -2,11 +2,11 @@ import Quick
 import Nimble
 import UIKit
 
-#if canImport(RSDKUtils)
-import RSDKUtils
-#else // SPM version
+#if SWIFT_PACKAGE
 import RSDKUtilsNimble
 import class RSDKUtilsMain.TypedDependencyManager
+#else
+import class RSDKUtils.TypedDependencyManager
 #endif
 
 @testable import RInAppMessaging

--- a/Tests/Tests/RouterSpec.swift
+++ b/Tests/Tests/RouterSpec.swift
@@ -2,11 +2,11 @@ import Quick
 import Nimble
 import UIKit
 
-#if SWIFT_PACKAGE
+#if canImport(RSDKUtils)
+import RSDKUtils
+#else // SPM version
 import RSDKUtilsNimble
 import class RSDKUtilsMain.TypedDependencyManager
-#else
-import class RSDKUtils.TypedDependencyManager
 #endif
 
 @testable import RInAppMessaging

--- a/Tests/Tests/RouterSpec.swift
+++ b/Tests/Tests/RouterSpec.swift
@@ -1,12 +1,14 @@
 import Quick
 import Nimble
 import UIKit
+
 #if canImport(RSDKUtils)
-import class RSDKUtils.TypedDependencyManager
+import RSDKUtils
 #else // SPM version
 import RSDKUtilsNimble
 import class RSDKUtilsMain.TypedDependencyManager
 #endif
+
 @testable import RInAppMessaging
 
 @available(iOS 13.0, *) // Because of UIImage(named:in:with:)

--- a/Tests/Tests/TooltipDispatcherSpec.swift
+++ b/Tests/Tests/TooltipDispatcherSpec.swift
@@ -2,11 +2,13 @@ import Foundation
 import Quick
 import Nimble
 import UIKit
-#if canImport(RSDKUtilsTestHelpers)
-import class RSDKUtilsTestHelpers.URLSessionMock // SPM version
-#else
+
+#if canImport(RSDKUtils)
 import class RSDKUtils.URLSessionMock
+#else // SPM version
+import class RSDKUtilsTestHelpers.URLSessionMock
 #endif
+
 @testable import RInAppMessaging
 
 class TooltipDispatcherSpec: QuickSpec {

--- a/Tests/Tests/TooltipDispatcherSpec.swift
+++ b/Tests/Tests/TooltipDispatcherSpec.swift
@@ -3,8 +3,8 @@ import Quick
 import Nimble
 import UIKit
 
-#if SWIFT_PACKAGE
-import class RSDKUtilsTestHelpers.URLSessionMock
+#if canImport(RSDKUtilsTestHelpers)
+import class RSDKUtilsTestHelpers.URLSessionMock // SPM version
 #else
 import class RSDKUtils.URLSessionMock
 #endif

--- a/Tests/Tests/TooltipDispatcherSpec.swift
+++ b/Tests/Tests/TooltipDispatcherSpec.swift
@@ -3,10 +3,10 @@ import Quick
 import Nimble
 import UIKit
 
-#if canImport(RSDKUtils)
-import class RSDKUtils.URLSessionMock
-#else // SPM version
+#if SWIFT_PACKAGE
 import class RSDKUtilsTestHelpers.URLSessionMock
+#else
+import class RSDKUtils.URLSessionMock
 #endif
 
 @testable import RInAppMessaging

--- a/Tests/Tests/UserInfoProviderSpec.swift
+++ b/Tests/Tests/UserInfoProviderSpec.swift
@@ -1,10 +1,12 @@
 import Quick
 import Nimble
-#if canImport(RSDKUtilsNimble)
-import RSDKUtilsNimble // SPM version
-#else
+
+#if canImport(RSDKUtils)
 import RSDKUtils
+#else // SPM version
+import RSDKUtilsNimble
 #endif
+
 @testable import RInAppMessaging
 
 class UserInfoProviderSpec: QuickSpec {

--- a/Tests/Tests/UserInfoProviderSpec.swift
+++ b/Tests/Tests/UserInfoProviderSpec.swift
@@ -1,8 +1,8 @@
 import Quick
 import Nimble
 
-#if SWIFT_PACKAGE
-import RSDKUtilsNimble
+#if canImport(RSDKUtilsNimble)
+import RSDKUtilsNimble // SPM version
 #else
 import RSDKUtils
 #endif

--- a/Tests/Tests/UserInfoProviderSpec.swift
+++ b/Tests/Tests/UserInfoProviderSpec.swift
@@ -1,10 +1,10 @@
 import Quick
 import Nimble
 
-#if canImport(RSDKUtils)
-import RSDKUtils
-#else // SPM version
+#if SWIFT_PACKAGE
 import RSDKUtilsNimble
+#else
+import RSDKUtils
 #endif
 
 @testable import RInAppMessaging

--- a/Tests/Tests/ViewListenerSpec.swift
+++ b/Tests/Tests/ViewListenerSpec.swift
@@ -2,11 +2,13 @@ import Foundation
 import Quick
 import Nimble
 import UIKit
-#if canImport(RSDKUtilsNimble)
-import RSDKUtilsNimble // SPM version
-#else
+
+#if canImport(RSDKUtils)
 import RSDKUtils
+#else // SPM version
+import RSDKUtilsNimble
 #endif
+
 @testable import RInAppMessaging
 
 class ViewListenerSpec: QuickSpec {

--- a/Tests/Tests/ViewListenerSpec.swift
+++ b/Tests/Tests/ViewListenerSpec.swift
@@ -4,7 +4,7 @@ import Nimble
 import UIKit
 
 #if canImport(RSDKUtilsNimble)
-import RSDKUtilsNimble // SPM Version
+import RSDKUtilsNimble // SPM version
 #else
 import RSDKUtils
 #endif

--- a/Tests/Tests/ViewListenerSpec.swift
+++ b/Tests/Tests/ViewListenerSpec.swift
@@ -3,10 +3,10 @@ import Quick
 import Nimble
 import UIKit
 
-#if canImport(RSDKUtils)
+#if canImport(RSDKUtilsNimble)
+import RSDKUtilsNimble // SPM Version
+#else
 import RSDKUtils
-#else // SPM version
-import RSDKUtilsNimble
 #endif
 
 @testable import RInAppMessaging

--- a/Tests/UITests/FullScreenViewSpec.swift
+++ b/Tests/UITests/FullScreenViewSpec.swift
@@ -3,8 +3,8 @@ import Quick
 import Nimble
 import class Shock.MockServer
 
-#if SWIFT_PACKAGE
-import RSDKUtilsNimble
+#if canImport(RSDKUtilsNimble)
+import RSDKUtilsNimble // SPM version
 #else
 import RSDKUtils
 #endif

--- a/Tests/UITests/FullScreenViewSpec.swift
+++ b/Tests/UITests/FullScreenViewSpec.swift
@@ -1,12 +1,13 @@
 import XCTest
 import Quick
 import Nimble
-#if canImport(RSDKUtilsNimble)
-import RSDKUtilsNimble // SPM version
+import class Shock.MockServer
+
+#if SWIFT_PACKAGE
+import RSDKUtilsNimble
 #else
 import RSDKUtils
 #endif
-import class Shock.MockServer
 
 class FullScreenViewSpec: QuickSpec {
 

--- a/Tests/UITests/ModalViewSpec.swift
+++ b/Tests/UITests/ModalViewSpec.swift
@@ -1,12 +1,13 @@
 import XCTest
 import Quick
 import Nimble
-#if canImport(RSDKUtilsMain)
-import RSDKUtilsMain // SPM version
+import class Shock.MockServer
+
+#if SWIFT_PACKAGE
+import RSDKUtilsMain
 #else
 import RSDKUtils
 #endif
-import class Shock.MockServer
 
 class ModalViewSpec: QuickSpec {
 

--- a/Tests/UITests/ModalViewSpec.swift
+++ b/Tests/UITests/ModalViewSpec.swift
@@ -3,8 +3,8 @@ import Quick
 import Nimble
 import class Shock.MockServer
 
-#if SWIFT_PACKAGE
-import RSDKUtilsMain
+#if canImport(RSDKUtilsMain)
+import RSDKUtilsMain // SPM version
 #else
 import RSDKUtils
 #endif


### PR DESCRIPTION
# Description
changed `#if canImport(...)` to `#if SWIFT_PACKAGE` wherever possible.
This change couldn't be done for tests files as they always run in a application contexts (`SWIFT_PACKAGE` is false)

## Links
n/a

# Checklist
- [X] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [ ] I wrote/updated tests for new/changed code
- [X] I removed all sensitive data **before every commit**, including API endpoints and keys
- [X] I ran `fastlane ci` without errors
