### PR TITLE
chore: bump RSDKUtils to 4.0, remove duplicated code (SDKCF-6120, SDKCF-5284)

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/rakutentech/ios-sdkutils.git",
         "state": {
           "branch": null,
-          "revision": "82592c03840b1ced37d1902bd0daef916a754999",
-          "version": "3.0.0"
+          "revision": "e1cbd6702c33ef64f3531eea3b47476e22caa4b0",
+          "version": "4.0.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
             targets: ["RInAppMessaging"])
     ],
     dependencies: [
-        .package(name: "RSDKUtils", url: "https://github.com/rakutentech/ios-sdkutils.git", .upToNextMinor(from: "3.0.0"))
+        .package(name: "RSDKUtils", url: "https://github.com/rakutentech/ios-sdkutils.git", .upToNextMajor(from: "4.0.0"))
     ],
     targets: [
         .target(

--- a/Podfile
+++ b/Podfile
@@ -6,7 +6,7 @@ secrets = ["RIAM_CONFIG_URL", "RIAM_APP_SUBSCRIPTION_KEY"]
 target 'RInAppMessaging_Example' do
   pod 'RInAppMessaging', :path => '.'
   pod 'SwiftLint', '~> 0.48.0' # Version 0.49+ requires macOS 12 and Swift 5.6
-  pod 'RSDKUtils', '~> 3.0.0', :testspecs => ['Nimble', 'TestHelpers']
+  pod 'RSDKUtils', '~> 4.0', :testspecs => ['Nimble', 'TestHelpers']
   pod 'Shock', '~> 6.1.2'
 
   abstract_target 'Tests-Common' do

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -9,16 +9,16 @@ PODS:
   - Nimble (10.0.0)
   - Quick (5.0.1)
   - RInAppMessaging (7.3.0-snapshot):
-    - RSDKUtils (~> 3.0.0)
-  - RSDKUtils (3.0.0):
-    - RSDKUtils/Main (= 3.0.0)
-  - RSDKUtils/Main (3.0.0):
+    - RSDKUtils (~> 4.0)
+  - RSDKUtils (4.0.0):
+    - RSDKUtils/Main (= 4.0.0)
+  - RSDKUtils/Main (4.0.0):
     - RSDKUtils/RLogger
-  - RSDKUtils/Nimble (3.0.0):
+  - RSDKUtils/Nimble (4.0.0):
     - Nimble
     - RSDKUtils/Main
-  - RSDKUtils/RLogger (3.0.0)
-  - RSDKUtils/TestHelpers (3.0.0):
+  - RSDKUtils/RLogger (4.0.0)
+  - RSDKUtils/TestHelpers (4.0.0):
     - RSDKUtils/Main
   - Shock (6.1.3):
     - GRMustache.swift (~> 4.0.1)
@@ -71,9 +71,9 @@ DEPENDENCIES:
   - Nimble
   - Quick (~> 5.0)
   - RInAppMessaging (from `.`)
-  - RSDKUtils (~> 3.0.0)
-  - RSDKUtils/Nimble (~> 3.0.0)
-  - RSDKUtils/TestHelpers (~> 3.0.0)
+  - RSDKUtils (~> 4.0)
+  - RSDKUtils/Nimble (~> 4.0)
+  - RSDKUtils/TestHelpers (~> 4.0)
   - Shock (~> 6.1.2)
   - SwiftLint (~> 0.48.0)
 
@@ -112,8 +112,8 @@ SPEC CHECKSUMS:
   GRMustache.swift: a6436504284b22b4b05daf5f46f77bd3fe00a9a2
   Nimble: 5316ef81a170ce87baf72dd961f22f89a602ff84
   Quick: 749aa754fd1e7d984f2000fe051e18a3a9809179
-  RInAppMessaging: a2222cac79bdb4d59a02e73bc3d4c6a2858f49bb
-  RSDKUtils: 36d97c9a41b5663ba56e73c626d27034a6c317e5
+  RInAppMessaging: 44ea81710f0d8615b995d8e3c6fb5fdc959fd6bb
+  RSDKUtils: e2a63eb729298706abe02e735436a2586c65e164
   Shock: 34def30d5e729f6c1eea2a5b5c2d024b875af86c
   SwiftLint: 284cea64b6187c5d6bd83e9a548a64104d546447
   SwiftNIO: 829958aab300642625091f82fc2f49cb7cf4ef24
@@ -123,6 +123,6 @@ SPEC CHECKSUMS:
   SwiftNIOHTTP1: ef56706550a1dc135ea69d65215b9941e643c23b
   SwiftNIOPosix: b49af4bdbecaadfadd5c93dfe28594d6722b75e4
 
-PODFILE CHECKSUM: 9fc14b4dcf4560e4b9dbc0db9300ea9545f21682
+PODFILE CHECKSUM: 51f33a476bd35d6694047e3d1bc6cae6adc4ef49
 
 COCOAPODS: 1.11.3

--- a/RInAppMessaging.podspec
+++ b/RInAppMessaging.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = '12.0'
   s.swift_versions = ['5.4', '5.5']
 
-  s.dependency 'RSDKUtils', '~> 3.0.0'
+  s.dependency 'RSDKUtils', '~> 4.0'
   s.source_files = 'Sources/RInAppMessaging/**/*.swift'
   s.resource_bundles = { 'RInAppMessagingResources' => ['Sources/RInAppMessaging/Resources/*'] }
 end

--- a/SampleSPM/SampleSPM.xcodeproj/project.pbxproj
+++ b/SampleSPM/SampleSPM.xcodeproj/project.pbxproj
@@ -1393,7 +1393,7 @@
 			repositoryURL = "https://github.com/rakutentech/ios-sdkutils.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 3.0.0;
+				minimumVersion = 4.0.0;
 			};
 		};
 		45FA9002272C2C5C005166FD /* XCRemoteSwiftPackageReference "Shock" */ = {

--- a/Sources/RInAppMessaging/Extensions/UIColor+IAM.swift
+++ b/Sources/RInAppMessaging/Extensions/UIColor+IAM.swift
@@ -52,14 +52,4 @@ internal extension UIColor {
         let threshold = 15
         return distance(from: anotherColor) <= threshold
     }
-
-    func isRGBAEqual(to anotherColor: UIColor) -> Bool {
-        var rgba1: (r: CGFloat, g: CGFloat, b: CGFloat, a: CGFloat) = (0, 0, 0, 0)
-        var rgba2: (r: CGFloat, g: CGFloat, b: CGFloat, a: CGFloat) = (0, 0, 0, 0)
-
-        getRed(&rgba1.r, green: &rgba1.g, blue: &rgba1.b, alpha: &rgba1.a)
-        anotherColor.getRed(&rgba2.r, green: &rgba2.g, blue: &rgba2.b, alpha: &rgba2.a)
-
-        return rgba1 == rgba2
-    }
 }

--- a/Sources/RInAppMessaging/Helpers/IAMAnalyticsBroadcaster.swift
+++ b/Sources/RInAppMessaging/Helpers/IAMAnalyticsBroadcaster.swift
@@ -1,6 +1,0 @@
-// This file should be removed after RSDKUtils 3.1.0 release
-import Foundation
-
-extension NSNotification.Name {
-    static let rAnalyticsCustomEvent = Notification.Name(rawValue: "com.rakuten.esd.sdk.events.custom")
-}

--- a/Sources/RInAppMessaging/Views/Components/ActionButton.swift
+++ b/Sources/RInAppMessaging/Views/Components/ActionButton.swift
@@ -1,4 +1,9 @@
 import UIKit
+#if SWIFT_PACKAGE
+import RSDKUtilsMain
+#else
+import RSDKUtils
+#endif
 
 // Button object used in campaigns's message view.
 internal class ActionButton: UIButton {

--- a/Tests/Tests/UIColorExtensionSpec.swift
+++ b/Tests/Tests/UIColorExtensionSpec.swift
@@ -45,29 +45,6 @@ class UIColorExtensionsSpec: QuickSpec {
                         to: UIColor(red: 1/255.0, green: 3/255.0, blue: 2/255.0, alpha: 1))).to(beTrue())
                 }
             }
-
-            context("when calling isRGBAEqual method") {
-                it("should return true for the same colors") {
-                    expect(UIColor.white.isRGBAEqual(to: .white)).to(beTrue())
-                }
-
-                it("should return true for the same colors but in different color spaces") {
-                    let grayscaleColor = UIColor(white: 0.2, alpha: 0.8)
-                    let rgbColor = UIColor(red: 0.2, green: 0.2, blue: 0.2, alpha: 0.8)
-                    let hsvColor = UIColor(hue: 0, saturation: 0, brightness: 0.2, alpha: 0.8)
-
-                    expect(grayscaleColor.isRGBAEqual(to: rgbColor)).to(beTrue())
-                    expect(rgbColor.isRGBAEqual(to: hsvColor)).to(beTrue())
-                }
-
-                it("should return false for different colors") {
-                    expect(UIColor.green.isRGBAEqual(to: .blue)).to(beFalse())
-                }
-
-                it("should return false for the same colors but with different alpha falue") {
-                    expect(UIColor.white.isRGBAEqual(to: .white.withAlphaComponent(0.3))).to(beFalse())
-                }
-            }
         }
     }
 }


### PR DESCRIPTION
# Description
Bumped RSDKUtils to 4.0 with "up to the next major" rule.
Removed `isRGBAEqual` method and `IAMAnalyticsBradcaster.swift` from IAM source code as that code is now available in RSDKUtils

## Links
SDKCF-6120
SDKCF-5284

# Checklist
- [X] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [X] I wrote/updated tests for new/changed code
- [X] I removed all sensitive data **before every commit**, including API endpoints and keys
- [X] I ran `fastlane ci` without errors
