### PR TITLE
fix: ignore 'Tooltip' in contexts list (SDKCF-6028)

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,8 @@ From the SDK side, host app developers will be able to log custom events as show
 ### **Campaign context verification**
 
 An optional variable `onVerifyContext` is called before a message is displayed for campaigns that have one or more contexts defined. A context can be added as the text inside "[]" within an IAM portal "Campaign Name" e.g. the campaign name is "[ctx1] title" so the context is "ctx1". Return `false` in `onVerifyContext` closure to prevent campaign from displaying (it won't count as an impression).<br/>
-__Note__: `onVerifyContext` is not called for campaigns without defined contexts
+__Note__: `onVerifyContext` is not called for campaigns without defined contexts.<br/>
+__Note__: This feature also works with Tooltips. ('[Tooltip]' in the title is not considered as a context)
 
 ```swift
 RInAppMessaging.onVerifyContext = { (contexts: [String], campaignTitle: String) in

--- a/Sources/RInAppMessaging/TooltipDispatcher.swift
+++ b/Sources/RInAppMessaging/TooltipDispatcher.swift
@@ -103,9 +103,9 @@ internal class TooltipDispatcher: TooltipDispatcherType, ViewListenerObserver {
                     tooltipView.startAutoDisappearIfNeeded(seconds: autoCloseSeconds)
                 },
                 confirmation: {
-                    let contexts = tooltip.contexts // first context will always be "Tooltip"
+                    let contexts = Array(tooltip.contexts.dropFirst()) // first context will always be "Tooltip"
                     let tooltipTitle = tooltip.data.messagePayload.title
-                    guard let delegate = self.delegate, contexts.count > 1, !tooltip.data.isTest else {
+                    guard let delegate = self.delegate, !contexts.isEmpty, !tooltip.data.isTest else {
                         return true
                     }
                     let shouldShow = delegate.shouldShowTooltip(title: tooltipTitle,

--- a/Tests/Tests/PublicAPISpec.swift
+++ b/Tests/Tests/PublicAPISpec.swift
@@ -442,6 +442,14 @@ class PublicAPISpec: QuickSpec {
                     // multiple onVerifyContext calls are possible due to target view tracking logic updates
                 }
 
+                it("will not pass 'Tooltip' in the context array") {
+                    generateAndDisplayLoginTooltip(uiElementIdentifier: "view-id", addContexts: true)
+
+                    expect(contextVerifier.onVerifyContextCallCount).toEventually(beGreaterThan(0))
+                    expect(contextVerifier.onVerifyContextCallParameters?.contexts).toNot(contain("Tooltip"))
+                    // multiple onVerifyContext calls are possible due to target view tracking logic updates
+                }
+
                 it("will call the method before showing a tooltip with expected parameters") {
                     contextVerifier.shouldShowCampaign = true
                     tooltipTargetView.accessibilityIdentifier = TooltipViewIdentifierMock
@@ -460,23 +468,6 @@ class PublicAPISpec: QuickSpec {
 
                     expect(contextVerifier.onVerifyContextCallParameters?.title)
                         .toEventually(equal("[Tooltip][ctx1][ctx2] title"), timeout: .seconds(2))
-                    expect(contextVerifier.onVerifyContextCallParameters?.contexts).to(contain(["Tooltip", "ctx1", "ctx2"]))
-                }
-
-                it("will call the method before showing a message with expected parameters") {
-                    contextVerifier.shouldShowCampaign = true
-                    messageMixerService.mockedResponse = PingResponse(
-                        nextPingMilliseconds: Int.max,
-                        currentPingMilliseconds: 0,
-                        data: [
-                            TestHelpers.generateCampaign(id: "1",
-                                                         title: "[ctx1][ctx2] title",
-                                                         triggers: [Trigger.loginEventTrigger])
-                        ])
-                    campaignsListManager.refreshList()
-                    RInAppMessaging.logEvent(LoginSuccessfulEvent())
-
-                    expect(contextVerifier.onVerifyContextCallParameters?.title).toEventually(equal("[ctx1][ctx2] title"), timeout: .seconds(2))
                     expect(contextVerifier.onVerifyContextCallParameters?.contexts).to(contain(["ctx1", "ctx2"]))
                 }
             }


### PR DESCRIPTION
# Description
'Tooltip' context should be ignored otherwise `onVerifyContext` will be called for every tooltip and that doesn't make sense

## Links
SDKCF-6028

# Checklist
- [X] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [X] I wrote/updated tests for new/changed code
- [X] I removed all sensitive data **before every commit**, including API endpoints and keys
- [ ] I ran `fastlane ci` without errors
