### PR TITLE
fix: use integer values instead of boolean in `push_permission` parameter (SDKCF-6133)

### DIFF
--- a/Sources/RInAppMessaging/Views/Presenters/FullViewPresenter.swift
+++ b/Sources/RInAppMessaging/Views/Presenters/FullViewPresenter.swift
@@ -156,7 +156,7 @@ internal class FullViewPresenter: BaseViewPresenter, FullViewPresenterType, Erro
 
     private func trackPushPrimerAction(didOptIn: Bool) {
         AnalyticsBroadcaster.sendEventName(Constants.RAnalytics.pushPrimerEventName,
-                                           dataObject: [Constants.RAnalytics.Keys.pushPermission: NSNumber(value: didOptIn),
+                                           dataObject: [Constants.RAnalytics.Keys.pushPermission: didOptIn ? 1 : 0,
                                                         Constants.RAnalytics.Keys.campaignID: campaign.id,
                                                         Constants.RAnalytics.Keys.subscriptionID: configurationRepository.getSubscriptionID() ?? "n/a"])
     }

--- a/Tests/Tests/ViewPresenterSpec.swift
+++ b/Tests/Tests/ViewPresenterSpec.swift
@@ -501,6 +501,10 @@ class ViewPresenterSpec: QuickSpec {
                               let data = params["eventData"] as? [String: Any] else {
                             return false
                         }
+                        guard !(data[Constants.RAnalytics.Keys.pushPermission] is Bool) else {
+                            // the value should be an integer 1/0
+                            return false
+                        }
 
                         return params["eventName"] as? String == Constants.RAnalytics.pushPrimerEventName &&
                         data[Constants.RAnalytics.Keys.pushPermission] as? Int == Int(booleanLiteral: expectedFlag) &&


### PR DESCRIPTION
# Description
According to the specs, the `push_permission` parameter in the push primer analytics event should be 1/0, not true/false.

## Links
SDKCF-6026
SDKCF-6133

# Checklist
- [X] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [X] I wrote/updated tests for new/changed code
- [X] I removed all sensitive data **before every commit**, including API endpoints and keys
- [X] I ran `fastlane ci` without errors
