### PR TITLE
improve: [Tooltip] fix UITabBar item support by adding new extension method (SDKCF-6134)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 	- Added contexts validation for tooltip campaigns [SDKCF-6028]
 	- Added a feature flag to enable/disable the Tooltip feature [SDKCF-6075]
 	- Added tracking of opt-in/opt-outs in Push Primer feature [SDKCF-6026]
+- Improvements:
+	- Restored tab bar items support. Added UITabBar extension method for convenience [SDKCF-6134]
 - Bug fixes:
 	- Fixed an edge case of not readable status bar when campaign message is displayed [SDKCF-5134]
 

--- a/README.md
+++ b/README.md
@@ -283,6 +283,16 @@ To enable tooltips you must set `enableTooltipFeature` flag to true when calling
 RInAppMessaging.configure(enableTooltipFeature: true)
 ```
 
+#### **Displaying Tooltips on tab bar buttons**
+To be able to display tooltips on UITabBar items/buttons you need to set `accessibilityIdentifier` of UITabBarItem object associated with your tab view controller. Then you need to call `updateItemIdentifiers()` method on `UITabBar` object.
+
+A code example from UIViewController's `viewDidLoad()` method
+```swift
+tabBarItem.accessibilityIdentifier = "UIElement.4"
+tabBarController?.tabBar.updateItemIdentifiers()
+```
+This setup can be also done in other lifecycle methods and classes.
+
 ## **Build/Run Example Application and Unit Tests**
 
 * Clone or fork the repo

--- a/RInAppMessaging.xcodeproj/project.pbxproj
+++ b/RInAppMessaging.xcodeproj/project.pbxproj
@@ -90,6 +90,7 @@
 		607FACDD1AFB9204008FA782 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 607FACDC1AFB9204008FA782 /* Images.xcassets */; };
 		607FACE01AFB9204008FA782 /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = 607FACDE1AFB9204008FA782 /* LaunchScreen.xib */; };
 		C9827558262C423C00476505 /* BackoffSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9827557262C423C00476505 /* BackoffSpec.swift */; };
+		D24CF280294BE3FA007C6C85 /* UITabBarExtensionSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D24CF27F294BE3F9007C6C85 /* UITabBarExtensionSpec.swift */; };
 		D911DC4F211115730082B950 /* ConfigurationSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9F418282110FD9F00E2158F /* ConfigurationSpec.swift */; };
 		D920D8C92277B80F008FB38D /* SecondPageViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = D920D8C82277B80F008FB38D /* SecondPageViewController.xib */; };
 		D920D8CB2277B965008FB38D /* SecondPageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D920D8CA2277B965008FB38D /* SecondPageViewController.swift */; };
@@ -215,6 +216,7 @@
 		6DA608F3248603BA00A8260D /* Example-Debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Example-Debug.xcconfig"; sourceTree = "<group>"; };
 		6DA608F424860B7F00A8260D /* Example-Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Example-Release.xcconfig"; sourceTree = "<group>"; };
 		C9827557262C423C00476505 /* BackoffSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackoffSpec.swift; sourceTree = "<group>"; };
+		D24CF27F294BE3F9007C6C85 /* UITabBarExtensionSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UITabBarExtensionSpec.swift; sourceTree = "<group>"; };
 		D920D8C82277B80F008FB38D /* SecondPageViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = SecondPageViewController.xib; sourceTree = "<group>"; };
 		D920D8CA2277B965008FB38D /* SecondPageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecondPageViewController.swift; sourceTree = "<group>"; };
 		D924268022D91046002F50D3 /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ja; path = ja.lproj/Main.strings; sourceTree = "<group>"; };
@@ -438,6 +440,7 @@
 				45EA720425B71FA2001B2049 /* UIApplicationExtensionSpec.swift */,
 				455FEBE127F214640064470D /* UIColorExtensionSpec.swift */,
 				4BBE7EAE274F1A6A0039D2BF /* UIFontExtensionSpec.swift */,
+				D24CF27F294BE3F9007C6C85 /* UITabBarExtensionSpec.swift */,
 				45EA720C25B72002001B2049 /* UIViewExtensionSpec.swift */,
 				4538BCF5262AE8FA009952BE /* UserDataCacheSpec.swift */,
 				45DC6D0427A426C000B28C13 /* ViewListenerSpec.swift */,
@@ -727,6 +730,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D24CF280294BE3FA007C6C85 /* UITabBarExtensionSpec.swift in Sources */,
 				45ADA542247D206B00A9E2A3 /* RouterSpec.swift in Sources */,
 				456FE1E72428513200304872 /* ErrorReportableSpec.swift in Sources */,
 				4538BCF6262AE8FA009952BE /* UserDataCacheSpec.swift in Sources */,

--- a/SampleSPM/SampleSPM.xcodeproj/project.pbxproj
+++ b/SampleSPM/SampleSPM.xcodeproj/project.pbxproj
@@ -104,6 +104,7 @@
 		D234A745291C62CF0086AC80 /* SerializationSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D234A717291C62CE0086AC80 /* SerializationSpec.swift */; };
 		D234A747291C63000086AC80 /* MockServerHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = D234A746291C63000086AC80 /* MockServerHelper.swift */; };
 		D234A759291C653F0086AC80 /* Shock in Frameworks */ = {isa = PBXBuildFile; productRef = D234A758291C653F0086AC80 /* Shock */; };
+		D24CF282294BE427007C6C85 /* UITabBarExtensionSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D24CF281294BE427007C6C85 /* UITabBarExtensionSpec.swift */; };
 		D920D8C92277B80F008FB38D /* SecondPageViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = D920D8C82277B80F008FB38D /* SecondPageViewController.xib */; };
 		D920D8CB2277B965008FB38D /* SecondPageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D920D8CA2277B965008FB38D /* SecondPageViewController.swift */; };
 		D924268722D91C15002F50D3 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = D924268522D91C15002F50D3 /* Localizable.strings */; };
@@ -227,6 +228,7 @@
 		D234A716291C62CE0086AC80 /* UIFontExtensionSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIFontExtensionSpec.swift; sourceTree = "<group>"; };
 		D234A717291C62CE0086AC80 /* SerializationSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SerializationSpec.swift; sourceTree = "<group>"; };
 		D234A746291C63000086AC80 /* MockServerHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = MockServerHelper.swift; path = ../Tests/UITests/Helpers/MockServerHelper.swift; sourceTree = "<group>"; };
+		D24CF281294BE427007C6C85 /* UITabBarExtensionSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UITabBarExtensionSpec.swift; sourceTree = "<group>"; };
 		D920D8C82277B80F008FB38D /* SecondPageViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = SecondPageViewController.xib; sourceTree = "<group>"; };
 		D920D8CA2277B965008FB38D /* SecondPageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecondPageViewController.swift; sourceTree = "<group>"; };
 		D924268022D91046002F50D3 /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ja; path = ja.lproj/Main.strings; sourceTree = "<group>"; };
@@ -475,6 +477,7 @@
 				D234A709291C62CD0086AC80 /* UIApplicationExtensionSpec.swift */,
 				D234A6F8291C62CA0086AC80 /* UIColorExtensionSpec.swift */,
 				D234A716291C62CE0086AC80 /* UIFontExtensionSpec.swift */,
+				D24CF281294BE427007C6C85 /* UITabBarExtensionSpec.swift */,
 				D234A712291C62CE0086AC80 /* UIViewExtensionSpec.swift */,
 				D234A70A291C62CD0086AC80 /* UserDataCacheSpec.swift */,
 				D234A6FD291C62CB0086AC80 /* UserInfoProviderSpec.swift */,
@@ -759,6 +762,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D24CF282294BE427007C6C85 /* UITabBarExtensionSpec.swift in Sources */,
 				D234A736291C62CF0086AC80 /* TooltipViewSpec.swift in Sources */,
 				D234A72F291C62CF0086AC80 /* MatchingUtilitySpec.swift in Sources */,
 				D234A72E291C62CF0086AC80 /* BackoffSpec.swift in Sources */,

--- a/Sources/RInAppMessaging/Extensions/UITabBar+IAM.swift
+++ b/Sources/RInAppMessaging/Extensions/UITabBar+IAM.swift
@@ -1,0 +1,24 @@
+import UIKit
+
+public extension UITabBar {
+
+    /// Updates accessibilityIdentifer value of UITabBar buttons.
+    /// The values are taken from corresponding UITabBarItem objects present in `items` array.
+    @objc func updateItemIdentifiers() {
+        guard let tabBarItems = items, !tabBarItems.isEmpty else {
+            return
+        }
+        let tabBarButtons = subviews
+            .filter { $0.isKind(of: NSClassFromString("UIControl")!) } // We are looking for instances of UITabBarButton private class
+            .sorted { $0.frame.minX < $1.frame.minX } // Ensuring the right order
+
+        guard tabBarButtons.count == items?.count else {
+            Logger.debug("Unexpected tab bar items setup: \(tabBarButtons) \(items ?? [])")
+            return
+        }
+
+        zip(tabBarItems, tabBarButtons).forEach { (item, button) in
+            button.accessibilityIdentifier = item.accessibilityIdentifier
+        }
+    }
+}

--- a/Sources/RInAppMessaging/TooltipManager.swift
+++ b/Sources/RInAppMessaging/TooltipManager.swift
@@ -64,6 +64,9 @@ extension TooltipManager {
     }
 
     func viewDidUpdateIdentifier(from: String?, to: String?, view: UIView) {
-        // unused
+        guard let identifier = to else {
+            return
+        }
+        verify(view: view, identifier: identifier)
     }
 }

--- a/Tests/Tests/TooltipManagerSpec.swift
+++ b/Tests/Tests/TooltipManagerSpec.swift
@@ -92,6 +92,26 @@ class TooltipManagerSpec: QuickSpec {
                     expect((iamModule.loggedEvent as? ViewAppearedEvent)?.viewIdentifier).to(equal(TooltipViewIdentifierMock))
                 }
             }
+
+            context("when calling viewDidUpdateIdentifier") {
+                it("will not iterate over displayed views") {
+                    manager.viewDidUpdateIdentifier(from: nil, to: "id", view: UIView())
+                    expect(viewListener.wasIterateOverDisplayedViewsCalled).to(beFalse())
+                }
+
+                it("will log event for matching view") {
+                    let superview = UIView()
+                    let view = UIView()
+                    view.accessibilityIdentifier = TooltipViewIdentifierMock
+                    superview.addSubview(view)
+                    campaignRepository.list = [TestHelpers.generateTooltip(id: "test")]
+
+                    manager.viewDidUpdateIdentifier(from: "old-id", to: TooltipViewIdentifierMock, view: view)
+                    expect(iamModule.loggedEvent).toEventuallyNot(beNil())
+                    expect(iamModule.loggedEvent?.type).to(equal(.viewAppeared))
+                    expect((iamModule.loggedEvent as? ViewAppearedEvent)?.viewIdentifier).to(equal(TooltipViewIdentifierMock))
+                }
+            }
         }
     }
 }

--- a/Tests/Tests/UITabBarExtensionSpec.swift
+++ b/Tests/Tests/UITabBarExtensionSpec.swift
@@ -1,0 +1,58 @@
+import Quick
+import Nimble
+import UIKit
+@testable import RInAppMessaging
+
+class UITabBarExtensionsSpec: QuickSpec {
+
+    override func spec() {
+
+        describe("UITabBar+IAM") {
+
+            context("when calling updateItemIdentifiers method") {
+
+                var tabBar: UITabBar!
+                var tabBarButtons: [UIView] {
+                    tabBar.subviews.filter { $0.isKind(of: NSClassFromString("UIControl")!) }
+                }
+
+                beforeEach {
+                    tabBar = UITabBar()
+                }
+
+                it("should set expected identifiers on UITabBarButton subviews") {
+                    let item1 = UITabBarItem(title: "1", image: nil, selectedImage: nil)
+                    let item2 = UITabBarItem(title: "2", image: nil, selectedImage: nil)
+                    tabBar.setItems([item1, item2], animated: false)
+
+                    expect(tabBarButtons).toNot(beEmpty())
+                    expect(tabBarButtons.map({ $0.accessibilityIdentifier })).to(equal([nil, nil]))
+                    item1.accessibilityIdentifier = "id1"
+                    item2.accessibilityIdentifier = "id2"
+                    tabBar.updateItemIdentifiers()
+
+                    expect(tabBarButtons).to(containElementSatisfying({ $0.accessibilityIdentifier == "id2" }))
+                    expect(tabBarButtons).to(containElementSatisfying({ $0.accessibilityIdentifier == "id1" }))
+                }
+
+                it("should not update identifiers if items and buttons don't match") {
+                    let item1 = UITabBarItem(title: "1", image: nil, selectedImage: nil)
+                    let item2 = UITabBarItem(title: "2", image: nil, selectedImage: nil)
+                    tabBar.setItems([item1, item2], animated: false)
+
+                    expect(tabBarButtons).toNot(beEmpty())
+                    expect(tabBarButtons.map({ $0.accessibilityIdentifier })).to(equal([nil, nil]))
+                    item1.accessibilityIdentifier = "id1"
+                    item2.accessibilityIdentifier = "id2"
+                    tabBarButtons.first?.removeFromSuperview()
+
+                    expect(tabBarButtons).toNot(haveCount(2))
+                    tabBar.updateItemIdentifiers()
+
+                    expect(tabBarButtons).toNot(containElementSatisfying({ $0.accessibilityIdentifier == "id2" }))
+                    expect(tabBarButtons).toNot(containElementSatisfying({ $0.accessibilityIdentifier == "id1" }))
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
# Description
Added new UITabBar extension method to provide a convenient way for setting accessibilityIdentifier in UITabBar buttons properly.

Note: Nimble version was synchronized with SPM version to avoid compilation errors (when using `allPass()` function)

## Links
SDKCF-6134

# Checklist
- [X] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [X] I wrote/updated tests for new/changed code
- [X] I removed all sensitive data **before every commit**, including API endpoints and keys
- [X] I ran `fastlane ci` without errors
