### PR TITLE
chore: update README with info about `closeTooltip()` API

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,6 +293,16 @@ tabBarController?.tabBar.updateItemIdentifiers()
 ```
 This setup can be also done in other lifecycle methods and classes.
 
+#### **Manually closing displayed tooltip**
+Tooltips can be closed manually in similar way campaign messages are closed with `closeMessage()` API method.<br/>
+The `closeTooltip(with uiElementIdentifier: String)` API method closes currently displayed tooltip attached to provided UI Element without user interaction. The `uiElementIdentifier` parameter identifier tells SDK which tooltip should be closed. Its value should match the value put under `UIElement` parameter in tooltip JSON payload.
+
+```swift
+RInAppMessaging.closeTooltip(with: "uielement.button.action1")
+```
+**Note:** Calling this method will not count as an impression (i.e. the message won't be counted as displayed). 
+
+
 ## **Build/Run Example Application and Unit Tests**
 
 * Clone or fork the repo


### PR DESCRIPTION
# Description
Added missing info about `closeTooltip()` API method to README

## Links
n/a

# Checklist
- [X] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [ ] I wrote/updated tests for new/changed code
- [X] I removed all sensitive data **before every commit**, including API endpoints and keys
- [ ] I ran `fastlane ci` without errors
