### PR TITLE
chore: bump SDK version to 7.4.0-snapshot (SDKCF-6066)

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -8,7 +8,7 @@ PODS:
   - GRMustache.swift (4.0.1)
   - Nimble (10.0.0)
   - Quick (5.0.1)
-  - RInAppMessaging (7.3.0):
+  - RInAppMessaging (7.4.0-snapshot):
     - RSDKUtils (~> 4.0)
   - RSDKUtils (4.0.0):
     - RSDKUtils/Main (= 4.0.0)
@@ -112,7 +112,7 @@ SPEC CHECKSUMS:
   GRMustache.swift: a6436504284b22b4b05daf5f46f77bd3fe00a9a2
   Nimble: 5316ef81a170ce87baf72dd961f22f89a602ff84
   Quick: 749aa754fd1e7d984f2000fe051e18a3a9809179
-  RInAppMessaging: 52ee1fa093b9b7a201344db0c0c2b7cdb83d02f8
+  RInAppMessaging: 8004adf0f7f304025313ea443c43e7312e505c54
   RSDKUtils: e2a63eb729298706abe02e735436a2586c65e164
   Shock: 34def30d5e729f6c1eea2a5b5c2d024b875af86c
   SwiftLint: 284cea64b6187c5d6bd83e9a548a64104d546447

--- a/RInAppMessaging.podspec
+++ b/RInAppMessaging.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'RInAppMessaging'
-  s.version          = '7.3.0'
+  s.version          = '7.4.0-snapshot'
   s.summary          = 'Rakuten module to manage and display in-app messages'
   s.homepage         = 'https://github.com/rakutentech/ios-inappmessaging'
   s.license          = { :type => 'MIT', :file => 'LICENSE' }

--- a/Sources/RInAppMessaging/Resources/Versions.plist
+++ b/Sources/RInAppMessaging/Resources/Versions.plist
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>IAMCurrentModuleVersion</key>
-	<string>7.3.0</string>
+	<string>7.4.0-snapshot</string>
 </dict>
 </plist>


### PR DESCRIPTION
# Description
Set 7.4.0-snapshot version for development

## Links
SDKCF-6066

# Checklist
- [X] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [ ] I wrote/updated tests for new/changed code
- [X] I removed all sensitive data **before every commit**, including API endpoints and keys
- [ ] I ran `fastlane ci` without errors
