### PR TITLE
fix: remove "last user" cache to keep anonymous user cache independent (SDKCF-6409)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Changelog
 
+### Unreleased
+- Bug fixes:
+	- Removed "last user" cache to avoid overwriting anonymous user cache during init [SDKCF-6409]
+- Improvements:
+	- Created new test scheme to combine unit test and UI test results [SDKCF-6356]
+
 ### 7.3.0 (2023-01-11)
 - Features:
 	- Added new API method to close displayed tooltips [SDKCF-6027]

--- a/README.md
+++ b/README.md
@@ -147,10 +147,10 @@ A preference is what will allow IAM to identify users for targeting and segmenta
 1.  IDTrackingIdentifier - The value provided by the internal ID SDK as the "tracking identifier" value.
 1.  AccessToken - This is the token provided by the internal RAuthentication SDK as the "accessToken" value
 
-The preference object can be set once per app session. IAM SDK will read object's properties on demand.
+⚠️ The method is designed to be called ONCE once per app session - i.e. only one instance of `UserInfoProvider` can be created. IAM SDK will read object's properties on demand. There's no need to call this method again after login/logout for example.
 
-To help IAM identify users, please keep user information in the preference object up to date.
-After logout is complete please ensure that all `UserInfoProvider` methods in the preference object return `nil`.  
+To ensure correct user targeting, please keep user information in the preference object up to date.
+After logout process is complete the preference object should return `nil` or `""` in all `UserInfoProvider` methods.  
 Preferences are not persisted so this function needs to be called on every launch.
 
 #### Generic example using UserID
@@ -374,5 +374,10 @@ In your `Info.plist` configuration, set the PostScript names under `InAppMessagi
   * IAM SDK is not able to verify if provided accessToken is invalid or not matching userId.
 * Status bar characters and icons are not visible when Full-Screen campaign is presented
   * If your app is running on iOS version below 13.0 you need to either change background color of the campaign or set proper `preferredStatusbarStyle` in the top-most view controller. (for iOS versions above 13.0 this issue is handled internally by the SDK)
+* A launch event campaign is presented more times than expected.
+  * Ensure that `registerPreference()` is called after `configure()` and before any `logEvent()` method
+  * The preference object must contain up-to-date information before `registerPreference()` is called
+  * Each *userId*/*idTrackingIdentifier* combination (including empty one) has its own counter for campaign impressions.
+  * Killing the app or calling `closeMessage()` API while campaign is being displayed doesn't count as impression.
 
 #### For other issues and more detailed information, Rakuten developers should refer to the Troubleshooting Guide on the internal developer documentation portal.

--- a/Sources/RInAppMessaging/InAppMessagingModule.swift
+++ b/Sources/RInAppMessaging/InAppMessagingModule.swift
@@ -125,7 +125,7 @@ internal class InAppMessagingModule: ErrorDelegate, CampaignDispatcherDelegate, 
     // visible for testing
     func checkUserChanges() {
         if accountRepository.updateUserInfo() {
-            campaignRepository.loadCachedData(syncWithLastUserData: false)
+            campaignRepository.loadCachedData()
             campaignsListManager.refreshList()
         }
     }
@@ -184,7 +184,6 @@ extension InAppMessagingModule {
 extension InAppMessagingModule {
 
     func userDidChangeOrLogout() {
-        campaignRepository.clearLastUserData()
         eventMatcher.clearNonPersistentEvents()
     }
 }

--- a/Tests/Tests/CampaignRepositorySpec.swift
+++ b/Tests/Tests/CampaignRepositorySpec.swift
@@ -1,5 +1,12 @@
 import Quick
 import Nimble
+
+#if canImport(RSDKUtils)
+import RSDKUtils
+#else // SPM version
+import RSDKUtilsNimble
+#endif
+
 @testable import RInAppMessaging
 
 // swiftlint:disable:next type_body_length
@@ -17,9 +24,6 @@ class CampaignRepositorySpec: QuickSpec {
             }
             var userCache: UserDataCacheContainer? {
                 userDataCache.cachedData[accountRepository.getUserIdentifiers()]
-            }
-            var lastUserCache: UserDataCacheContainer? {
-                userDataCache.cachedData[CampaignRepository.lastUser]
             }
             let userInfoProvider = UserInfoProviderMock()
             let campaign = TestHelpers.generateCampaign(id: "campaign-id",
@@ -51,8 +55,8 @@ class CampaignRepositorySpec: QuickSpec {
                                                         accountRepository: accountRepository)
             }
 
-            it("will load last user cache data during initialization") {
-                userDataCache.lastUserDataMock = UserDataCacheContainer(campaignData: [campaign])
+            it("will load current user's cached data during initialization") {
+                userDataCache.userDataMock = UserDataCacheContainer(campaignData: [campaign])
                 let campaignRepository = CampaignRepository(userDataCache: userDataCache,
                                                             accountRepository: accountRepository)
                 expect(campaignRepository.list).to(equal([campaign]))
@@ -130,21 +134,18 @@ class CampaignRepositorySpec: QuickSpec {
                     it("will save updated list to the cache (anonymous user)") {
                         syncRepository(with: [campaign])
                         expect(userDataCache.cachedCampaignData).to(equal([campaign]))
-                        expect(lastUserCache?.campaignData).to(equal(userCache?.campaignData))
                     }
 
                     it("will save updated list to the cache (logged-in user)") {
                         userInfoProvider.userID = "user"
                         syncRepository(with: [campaign])
                         expect(userCache?.campaignData).to(equal([campaign]))
-                        expect(lastUserCache?.campaignData).to(equal(userCache?.campaignData))
                     }
 
                     it("will save test campaigns to the cache") {
                         userInfoProvider.userID = "user"
                         syncRepository(with: [testCampaign])
                         expect(userCache?.campaignData).to(equal([testCampaign]))
-                        expect(lastUserCache?.campaignData).to(equal(userCache?.campaignData))
                     }
                 }
 
@@ -219,21 +220,18 @@ class CampaignRepositorySpec: QuickSpec {
                     it("will save updated list to the cache (anonymous user)") {
                         syncRepository(with: [tooltip])
                         expect(userDataCache.cachedCampaignData).to(equal([tooltip]))
-                        expect(lastUserCache?.campaignData).to(equal(userCache?.campaignData))
                     }
 
                     it("will save updated list to the cache (logged-in user)") {
                         userInfoProvider.userID = "user"
                         syncRepository(with: [tooltip])
                         expect(userCache?.campaignData).to(equal([tooltip]))
-                        expect(lastUserCache?.campaignData).to(equal(userCache?.campaignData))
                     }
 
-                    it("will save test campaigns to the cache") {
+                    it("will save test tooltip campaigns to the cache") {
                         userInfoProvider.userID = "user"
                         syncRepository(with: [testTooltip])
                         expect(userCache?.campaignData).to(equal([testTooltip]))
-                        expect(lastUserCache?.campaignData).to(equal(userCache?.campaignData))
                     }
                 }
             }
@@ -262,7 +260,6 @@ class CampaignRepositorySpec: QuickSpec {
                     syncRepository(with: [campaign])
                     campaignRepository.optOutCampaign(campaign)
                     expect(userDataCache.cachedCampaignData?.first?.isOptedOut).to(beTrue())
-                    expect(lastUserCache?.campaignData).to(equal(userCache?.campaignData))
                 }
 
                 it("will save updated list to the cache (logged-in user)") {
@@ -270,7 +267,6 @@ class CampaignRepositorySpec: QuickSpec {
                     syncRepository(with: [campaign])
                     campaignRepository.optOutCampaign(campaign)
                     expect(userCache?.campaignData?.first?.isOptedOut).to(beTrue())
-                    expect(lastUserCache?.campaignData).to(equal(userCache?.campaignData))
                 }
 
                 it("will NOT cache updated campaign if it's marked as `isTest`") {
@@ -278,7 +274,6 @@ class CampaignRepositorySpec: QuickSpec {
                     syncRepository(with: [testCampaign])
                     campaignRepository.optOutCampaign(testCampaign)
                     expect(userCache?.campaignData?.first?.isOptedOut).to(beFalse())
-                    expect(lastUserCache?.campaignData?.first?.isOptedOut).to(beFalse())
                 }
             }
 
@@ -317,7 +312,6 @@ class CampaignRepositorySpec: QuickSpec {
                         syncRepository(with: [campaign])
                         campaignRepository.decrementImpressionsLeftInCampaign(id: campaign.id)
                         expect(userDataCache.cachedCampaignData?.first?.impressionsLeft).to(equal(campaign.impressionsLeft - 1))
-                        expect(lastUserCache?.campaignData).to(equal(userCache?.campaignData))
                     }
 
                     it("will save updated list to the cache (logged-in user)") {
@@ -325,7 +319,6 @@ class CampaignRepositorySpec: QuickSpec {
                         syncRepository(with: [campaign])
                         campaignRepository.decrementImpressionsLeftInCampaign(id: campaign.id)
                         expect(userCache?.campaignData?.first?.impressionsLeft).to(equal(campaign.impressionsLeft - 1))
-                        expect(lastUserCache?.campaignData).to(equal(userCache?.campaignData))
                     }
 
                     it("will save updated campaign even if it's marked as `isTest`") {
@@ -333,7 +326,6 @@ class CampaignRepositorySpec: QuickSpec {
                         syncRepository(with: [testCampaign])
                         campaignRepository.decrementImpressionsLeftInCampaign(id: testCampaign.id)
                         expect(userCache?.campaignData?.first?.impressionsLeft).to(equal(2))
-                        expect(lastUserCache?.campaignData?.first?.impressionsLeft).to(equal(2))
                     }
                 }
 
@@ -371,7 +363,6 @@ class CampaignRepositorySpec: QuickSpec {
                         syncRepository(with: [tooltip])
                         campaignRepository.decrementImpressionsLeftInCampaign(id: tooltip.id)
                         expect(userDataCache.cachedCampaignData?.first?.impressionsLeft).to(equal(tooltip.impressionsLeft - 1))
-                        expect(lastUserCache?.campaignData).to(equal(userCache?.campaignData))
                     }
 
                     it("will save updated list to the cache (logged-in user)") {
@@ -379,7 +370,6 @@ class CampaignRepositorySpec: QuickSpec {
                         syncRepository(with: [tooltip])
                         campaignRepository.decrementImpressionsLeftInCampaign(id: tooltip.id)
                         expect(userCache?.campaignData?.first?.impressionsLeft).to(equal(tooltip.impressionsLeft - 1))
-                        expect(lastUserCache?.campaignData).to(equal(userCache?.campaignData))
                     }
 
                     it("will save updated campaign even if it's marked as `isTest`") {
@@ -387,7 +377,6 @@ class CampaignRepositorySpec: QuickSpec {
                         syncRepository(with: [testTooltip])
                         campaignRepository.decrementImpressionsLeftInCampaign(id: testTooltip.id)
                         expect(userCache?.campaignData?.first?.impressionsLeft).to(equal(2))
-                        expect(lastUserCache?.campaignData?.first?.impressionsLeft).to(equal(2))
                     }
                 }
             }
@@ -416,7 +405,6 @@ class CampaignRepositorySpec: QuickSpec {
                     syncRepository(with: [campaign])
                     campaignRepository.incrementImpressionsLeftInCampaign(id: campaign.id)
                     expect(userDataCache.cachedCampaignData?.first?.impressionsLeft).to(equal(campaign.impressionsLeft + 1))
-                    expect(lastUserCache?.campaignData).to(equal(userCache?.campaignData))
                 }
 
                 it("will save updated list to the cache (logged-in user)") {
@@ -424,7 +412,6 @@ class CampaignRepositorySpec: QuickSpec {
                     syncRepository(with: [campaign])
                     campaignRepository.incrementImpressionsLeftInCampaign(id: campaign.id)
                     expect(userCache?.campaignData?.first?.impressionsLeft).to(equal(campaign.impressionsLeft + 1))
-                    expect(lastUserCache?.campaignData).to(equal(userCache?.campaignData))
                 }
 
                 it("will save updated campaign even if it's marked as `isTest`") {
@@ -432,102 +419,29 @@ class CampaignRepositorySpec: QuickSpec {
                     syncRepository(with: [testCampaign])
                     campaignRepository.incrementImpressionsLeftInCampaign(id: testCampaign.id)
                     expect(userCache?.campaignData?.first?.impressionsLeft).to(equal(4))
-                    expect(lastUserCache?.campaignData?.first?.impressionsLeft).to(equal(4))
                 }
             }
 
             context("when loadCache is called") {
 
-                let modifiedCampaign = TestHelpers.generateCampaign(id: campaign.id, maxImpressions: 0)
                 let otherCampaign = TestHelpers.generateCampaign(id: "test2", maxImpressions: 3)
 
-                let modifiedTooltip = TestHelpers.generateTooltip(id: tooltip.id,
-                                                                  isTest: false,
-                                                                  maxImpressions: 0)
-                let otherTooltip = TestHelpers.generateTooltip(id: "test2",
-                                                               isTest: false,
-                                                               maxImpressions: 3)
-
-                context("and lastUserDataMock is not empty") {
-
-                    beforeEach {
-                        userDataCache.lastUserDataMock = UserDataCacheContainer(campaignData: [campaign, tooltip])
-                        userDataCache.userDataMock = nil
-                    }
-
-                    context("and syncWithLastUserData set to false") {
-
-                        it("will not populate campaign list from cache data") {
-                            expect(campaignRepository.list).to(beEmpty())
-                            campaignRepository.loadCachedData(syncWithLastUserData: false)
-                            expect(campaignRepository.list).to(beEmpty())
-                        }
-                    }
-
-                    context("and syncWithDefaultUserData set to true") {
-
-                        it("will populate campaign list from last user cache data") {
-                            userDataCache.userDataMock = UserDataCacheContainer(campaignData: [campaign, tooltip])
-                            expect(campaignRepository.list).to(beEmpty())
-                            campaignRepository.loadCachedData(syncWithLastUserData: true)
-                            expect(campaignRepository.list).to(haveCount(2))
-                        }
-
-                        it("will populate campaign list from cache data and add new campaings from last user cache") {
-                            userDataCache.lastUserDataMock = UserDataCacheContainer(campaignData: [otherCampaign])
-                            userDataCache.userDataMock = UserDataCacheContainer(campaignData: [campaign])
-                            campaignRepository.loadCachedData(syncWithLastUserData: true)
-                            expect(campaignRepository.list).to(equal([campaign, otherCampaign]))
-                        }
-
-                        it("will populate campaign list from cache data and update campaings from last user cache") {
-                            userDataCache.lastUserDataMock = UserDataCacheContainer(campaignData: [modifiedCampaign])
-                            userDataCache.userDataMock = UserDataCacheContainer(campaignData: [campaign])
-                            campaignRepository.loadCachedData(syncWithLastUserData: true)
-                            expect(campaignRepository.list).to(elementsEqual([modifiedCampaign]))
-                        }
-
-                        it("will populate campaign list from cache data and add new tooltips from last user cache") {
-                            userDataCache.lastUserDataMock = UserDataCacheContainer(campaignData: [otherTooltip])
-                            userDataCache.userDataMock = UserDataCacheContainer(campaignData: [tooltip])
-                            campaignRepository.loadCachedData(syncWithLastUserData: true)
-                            expect(campaignRepository.list).to(equal([tooltip, otherTooltip]))
-                        }
-
-                        it("will populate campaign list from cache data and update tooltips from last user cache") {
-                            userDataCache.lastUserDataMock = UserDataCacheContainer(campaignData: [modifiedTooltip])
-                            userDataCache.userDataMock = UserDataCacheContainer(campaignData: [tooltip])
-                            campaignRepository.loadCachedData(syncWithLastUserData: true)
-                            expect(campaignRepository.list).to(elementsEqual([modifiedTooltip]))
-                        }
-                    }
+                beforeEach {
+                    userDataCache.userDataMock = UserDataCacheContainer(campaignData: [campaign, tooltip])
                 }
 
-                context("and lastUserDataMock is empty") {
+                it("will populate campaign list from cache data") {
+                    expect(campaignRepository.list).to(beEmpty())
+                    campaignRepository.loadCachedData()
+                    expect(campaignRepository.list).to(elementsEqualOrderAgnostic([campaign, tooltip]))
+                }
 
-                    beforeEach {
-                        userDataCache.lastUserDataMock = nil
-                        userDataCache.userDataMock = UserDataCacheContainer(campaignData: [campaign, tooltip])
-                    }
-
-                    context("and syncWithLastUserData set to false") {
-
-                        it("will populate campaign list from cache data") {
-                            expect(campaignRepository.list).to(beEmpty())
-                            campaignRepository.loadCachedData(syncWithLastUserData: false)
-                            expect(campaignRepository.list).to(haveCount(2))
-                        }
-
-                    }
-
-                    context("and syncWithDefaultUserData set to true") {
-
-                        it("will not clear existing campaign list if there is no cache data") {
-                            expect(campaignRepository.list).to(beEmpty())
-                            campaignRepository.loadCachedData(syncWithLastUserData: true)
-                            expect(campaignRepository.list).to(haveCount(2))
-                        }
-                    }
+                it("will replace existing data in the repository") {
+                    syncRepository(with: [otherCampaign])
+                    expect(campaignRepository.list).to(elementsEqual([otherCampaign]))
+                    campaignRepository.loadCachedData()
+                    expect(campaignRepository.list).to(haveCount(2))
+                    expect(campaignRepository.list).toNot(contain(otherCampaign))
                 }
             }
         }

--- a/Tests/Tests/Helpers/SharedMocks.swift
+++ b/Tests/Tests/Helpers/SharedMocks.swift
@@ -37,8 +37,6 @@ class CampaignRepositoryMock: CampaignRepositoryType {
     private(set) var wasOptOutCalled = false
     private(set) var lastSyncCampaigns = [Campaign]()
     private(set) var wasLoadCachedDataCalled = false
-    private(set) var loadCachedDataParameters: (Bool)?
-    private(set) var wasClearLastUserDataCalled = false
     private(set) var didSyncIgnoringTooltips = false
 
     func decrementImpressionsLeftInCampaign(id: String) -> Campaign? {
@@ -69,9 +67,8 @@ class CampaignRepositoryMock: CampaignRepositoryType {
         didSyncIgnoringTooltips = ignoreTooltips
     }
 
-    func loadCachedData(syncWithLastUserData: Bool) {
+    func loadCachedData() {
         wasLoadCachedDataCalled = true
-        loadCachedDataParameters = (syncWithLastUserData)
     }
 
     func resetFlags() {
@@ -80,12 +77,6 @@ class CampaignRepositoryMock: CampaignRepositoryType {
         wasOptOutCalled = false
         lastSyncCampaigns = [Campaign]()
         wasLoadCachedDataCalled = false
-        loadCachedDataParameters = nil
-        wasClearLastUserDataCalled = false
-    }
-
-    func clearLastUserData() {
-        wasClearLastUserDataCalled = true
     }
 
     private func indexAndCampaign(forID id: String) -> (Int, Campaign)? {
@@ -421,13 +412,12 @@ class RouterMock: RouterType {
 
 class UserDataCacheMock: UserDataCacheable {
     var userDataMock: UserDataCacheContainer?
-    var lastUserDataMock: UserDataCacheContainer?
     var cachedCampaignData: [Campaign]?
     var cachedDisplayPermissionData: (DisplayPermissionResponse, String)?
     var cachedData = [[UserIdentifier]: UserDataCacheContainer]()
 
     func getUserData(identifiers: [UserIdentifier]) -> UserDataCacheContainer? {
-        identifiers == CampaignRepository.lastUser ? lastUserDataMock : userDataMock
+        userDataMock ?? cachedData[identifiers]
     }
 
     func cacheCampaignData(_ data: [Campaign], userIdentifiers: [UserIdentifier]) {

--- a/Tests/Tests/InAppMessagingModuleSpec.swift
+++ b/Tests/Tests/InAppMessagingModuleSpec.swift
@@ -435,17 +435,10 @@ class InAppMessagingModuleSpec: QuickSpec {
                             expect(campaignsListManager.wasRefreshListCalled).to(beTrue())
                         }
 
-                        it("will reload campaigns repository cache with syncWithLastUserData set to false") {
+                        it("will reload campaigns repository cache") {
                             campaignRepository.resetFlags()
                             iamModule.checkUserChanges()
                             expect(campaignRepository.wasLoadCachedDataCalled).to(beTrue())
-                            expect(campaignRepository.loadCachedDataParameters).to(equal((false)))
-                        }
-
-                        it("will clear last user data") {
-                            campaignRepository.resetFlags()
-                            iamModule.checkUserChanges()
-                            expect(campaignRepository.wasClearLastUserDataCalled).to(beTrue())
                         }
 
                         it("will clear event list") {
@@ -469,17 +462,10 @@ class InAppMessagingModuleSpec: QuickSpec {
                             expect(campaignsListManager.wasRefreshListCalled).to(beTrue())
                         }
 
-                        it("will reload campaigns repository cache with syncWithLastUserData set to false") {
+                        it("will reload campaigns repository cache") {
                             campaignRepository.resetFlags()
                             iamModule.checkUserChanges()
                             expect(campaignRepository.wasLoadCachedDataCalled).to(beTrue())
-                            expect(campaignRepository.loadCachedDataParameters).to(equal((false)))
-                        }
-
-                        it("will clear last user data") {
-                            campaignRepository.resetFlags()
-                            iamModule.checkUserChanges()
-                            expect(campaignRepository.wasClearLastUserDataCalled).to(beTrue())
                         }
 
                         it("will clear event list") {
@@ -501,17 +487,10 @@ class InAppMessagingModuleSpec: QuickSpec {
                             expect(campaignsListManager.wasRefreshListCalled).to(beTrue())
                         }
 
-                        it("will reload campaigns repository cache with syncWithLastUserData set to false") {
+                        it("will reload campaigns repository cache") {
                             campaignRepository.resetFlags()
                             iamModule.checkUserChanges()
                             expect(campaignRepository.wasLoadCachedDataCalled).to(beTrue())
-                            expect(campaignRepository.loadCachedDataParameters).to(equal((false)))
-                        }
-
-                        it("will not clear last user data") {
-                            campaignRepository.resetFlags()
-                            iamModule.checkUserChanges()
-                            expect(campaignRepository.wasClearLastUserDataCalled).to(beFalse())
                         }
 
                         it("will not clear event list") {
@@ -540,12 +519,6 @@ class InAppMessagingModuleSpec: QuickSpec {
                             expect(campaignRepository.wasLoadCachedDataCalled).to(beFalse())
                         }
 
-                        it("will not clear last user data") {
-                            campaignRepository.resetFlags()
-                            iamModule.checkUserChanges()
-                            expect(campaignRepository.wasClearLastUserDataCalled).to(beFalse())
-                        }
-
                         it("will not clear event list") {
                             eventMatcher.wasClearNonPersistentEventsCalled = false // reset
                             iamModule.checkUserChanges()
@@ -571,12 +544,6 @@ class InAppMessagingModuleSpec: QuickSpec {
                             campaignRepository.resetFlags()
                             iamModule.checkUserChanges()
                             expect(campaignRepository.wasLoadCachedDataCalled).to(beFalse())
-                        }
-
-                        it("will not clear last user data") {
-                            campaignRepository.resetFlags()
-                            iamModule.checkUserChanges()
-                            expect(campaignRepository.wasClearLastUserDataCalled).to(beFalse())
                         }
 
                         it("will not clear event list") {


### PR DESCRIPTION
# Description
Removed the concept of "last user" cache to keep anonymous user cache independent and simplify the SDK's logic.
The anonymous user cache was overwritten with last user data on each init to provide continuity of data flow for the short time between moment when app is inited with empty user info and the moment when user preference object contains last logged in user info.
The SDK shouldn't try to predict login/logout/refresh behaviour in the host app.

## Links
SDKCF-6409

# Checklist
- [X] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [X] I wrote/updated tests for new/changed code
- [X] I removed all sensitive data **before every commit**, including API endpoints and keys
- [X] I ran `fastlane ci` without errors
