### PR TITLE
fix: fix add displayPermission service to perform ping (SDKCF-4964)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Unreleased
 - Bug fixes:
 	- Removed "last user" cache to avoid overwriting anonymous user cache during init [SDKCF-6409]
+    - Added display permission service to perform ping on tooltip dispatcher [SDKCF-4964]
 - Improvements:
 	- Created new test scheme to combine unit test and UI test results [SDKCF-6356]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ### Unreleased
 - Bug fixes:
 	- Removed "last user" cache to avoid overwriting anonymous user cache during init [SDKCF-6409]
-    - Added display permission service to perform ping on tooltip dispatcher [SDKCF-4964]
+	- Added display permission service to perform ping on tooltip dispatcher [SDKCF-4964]
 - Improvements:
 	- Created new test scheme to combine unit test and UI test results [SDKCF-6356]
 

--- a/Sources/RInAppMessaging/DependencyManager/MainContainer.swift
+++ b/Sources/RInAppMessaging/DependencyManager/MainContainer.swift
@@ -76,7 +76,7 @@ internal enum MainContainerFactory {
             }),
             ContainerElement(type: TooltipDispatcherType.self, factory: {
                 TooltipDispatcher(router: manager.resolve(type: RouterType.self)!,
-                                  permissionService:manager.resolve(type: DisplayPermissionServiceType.self)!,
+                                  permissionService: manager.resolve(type: DisplayPermissionServiceType.self)!,
                                   campaignRepository: manager.resolve(type: CampaignRepositoryType.self)!,
                                   viewListener: manager.resolve(type: ViewListenerType.self)!)
             }),

--- a/Sources/RInAppMessaging/DependencyManager/MainContainer.swift
+++ b/Sources/RInAppMessaging/DependencyManager/MainContainer.swift
@@ -76,6 +76,7 @@ internal enum MainContainerFactory {
             }),
             ContainerElement(type: TooltipDispatcherType.self, factory: {
                 TooltipDispatcher(router: manager.resolve(type: RouterType.self)!,
+                                  permissionService:manager.resolve(type: DisplayPermissionServiceType.self)!,
                                   campaignRepository: manager.resolve(type: CampaignRepositoryType.self)!,
                                   viewListener: manager.resolve(type: ViewListenerType.self)!)
             }),

--- a/Sources/RInAppMessaging/TooltipDispatcher.swift
+++ b/Sources/RInAppMessaging/TooltipDispatcher.swift
@@ -92,6 +92,10 @@ internal class TooltipDispatcher: TooltipDispatcherType, ViewListenerObserver {
             delegate?.performPing()
         }
 
+        guard permissionResponse.display else {
+            return
+        }
+
         let waitForImageDispatchGroup = DispatchGroup()
         waitForImageDispatchGroup.enter()
 

--- a/Sources/RInAppMessaging/TooltipDispatcher.swift
+++ b/Sources/RInAppMessaging/TooltipDispatcher.swift
@@ -83,7 +83,6 @@ internal class TooltipDispatcher: TooltipDispatcherType, ViewListenerObserver {
         guard let resImgUrlString = tooltip.tooltipData?.imageUrl,
               let resImgUrl = URL(string: resImgUrlString)
         else {
-            // TOOLTIP: display permission?
             return
         }
 

--- a/Sources/RInAppMessaging/TooltipDispatcher.swift
+++ b/Sources/RInAppMessaging/TooltipDispatcher.swift
@@ -91,7 +91,7 @@ internal class TooltipDispatcher: TooltipDispatcherType, ViewListenerObserver {
             delegate?.performPing()
         }
 
-        guard permissionResponse.display else {
+        guard permissionResponse.display || tooltip.data.isTest else {
             return
         }
 

--- a/Sources/RInAppMessaging/TooltipDispatcher.swift
+++ b/Sources/RInAppMessaging/TooltipDispatcher.swift
@@ -2,6 +2,7 @@ import Foundation
 import UIKit
 
 internal protocol TooltipDispatcherDelegate: AnyObject {
+    func performPing()
     func shouldShowTooltip(title: String, contexts: [String]) -> Bool
 }
 
@@ -14,6 +15,7 @@ internal protocol TooltipDispatcherType: AnyObject {
 internal class TooltipDispatcher: TooltipDispatcherType, ViewListenerObserver {
 
     private let router: RouterType
+    private let permissionService: DisplayPermissionServiceType
     private let campaignRepository: CampaignRepositoryType
     private let viewListener: ViewListenerType
     private let dispatchQueue = DispatchQueue(label: "IAM.TooltipDisplay", qos: .userInteractive)
@@ -23,10 +25,12 @@ internal class TooltipDispatcher: TooltipDispatcherType, ViewListenerObserver {
     weak var delegate: TooltipDispatcherDelegate?
 
     init(router: RouterType,
+         permissionService: DisplayPermissionServiceType,
          campaignRepository: CampaignRepositoryType,
          viewListener: ViewListenerType) {
 
         self.router = router
+        self.permissionService = permissionService
         self.campaignRepository = campaignRepository
         self.viewListener = viewListener
 
@@ -81,6 +85,11 @@ internal class TooltipDispatcher: TooltipDispatcherType, ViewListenerObserver {
         else {
             // TOOLTIP: display permission?
             return
+        }
+
+        let permissionResponse = permissionService.checkPermission(forCampaign: tooltip.data)
+        if permissionResponse.performPing {
+            delegate?.performPing()
         }
 
         let waitForImageDispatchGroup = DispatchGroup()

--- a/Tests/Tests/TooltipDispatcherSpec.swift
+++ b/Tests/Tests/TooltipDispatcherSpec.swift
@@ -215,7 +215,7 @@ class TooltipDispatcherSpec: QuickSpec {
                             permissionService.shouldGrantPermission = true
                             let tooltip = TestHelpers.generateTooltip(id: "test", title: "[Tooltip][ctx] title", isTest: true)
                             dispatcher.setNeedsDisplay(tooltip: tooltip)
-                            expect(router.displayedTooltips).toEventuallyNot(beEmpty())
+                            expect(router.displayedTooltips).toAfterTimeoutNot(beEmpty())
                         }
                     }
 
@@ -225,7 +225,7 @@ class TooltipDispatcherSpec: QuickSpec {
                             permissionService.shouldGrantPermission = false
                             let tooltip = TestHelpers.generateTooltip(id: "test", title: "[Tooltip][ctx] title", isTest: true)
                             dispatcher.setNeedsDisplay(tooltip: tooltip)
-                            expect(router.displayedTooltips).toEventually(beEmpty())
+                            expect(router.displayedTooltips).toAfterTimeout(beEmpty())
                         }
                     }
                 }

--- a/Tests/Tests/TooltipDispatcherSpec.swift
+++ b/Tests/Tests/TooltipDispatcherSpec.swift
@@ -217,7 +217,7 @@ class TooltipDispatcherSpec: QuickSpec {
                                 permissionService.shouldGrantPermission = true
                                 let tooltip = TestHelpers.generateTooltip(id: "test", title: "[Tooltip][ctx] title", isTest: true)
                                 dispatcher.setNeedsDisplay(tooltip: tooltip)
-                                expect(router.displayedTooltips).toAfterTimeoutNot(beEmpty())
+                                expect(router.displayedTooltips).toEventuallyNot(beEmpty())
                             }
                         }
 
@@ -227,7 +227,7 @@ class TooltipDispatcherSpec: QuickSpec {
                                 permissionService.shouldGrantPermission = true
                                 let tooltip = TestHelpers.generateTooltip(id: "test", title: "[Tooltip][ctx] title", isTest: false)
                                 dispatcher.setNeedsDisplay(tooltip: tooltip)
-                                expect(router.displayedTooltips).toAfterTimeoutNot(beEmpty())
+                                expect(router.displayedTooltips).toEventuallyNot(beEmpty())
                             }
                         }
                     }
@@ -240,7 +240,7 @@ class TooltipDispatcherSpec: QuickSpec {
                                 permissionService.shouldGrantPermission = true
                                 let tooltip = TestHelpers.generateTooltip(id: "test", title: "[Tooltip][ctx] title", isTest: true)
                                 dispatcher.setNeedsDisplay(tooltip: tooltip)
-                                expect(router.displayedTooltips).toAfterTimeoutNot(beEmpty())
+                                expect(router.displayedTooltips).toEventuallyNot(beEmpty())
                             }
                         }
 

--- a/Tests/Tests/TooltipDispatcherSpec.swift
+++ b/Tests/Tests/TooltipDispatcherSpec.swift
@@ -187,6 +187,49 @@ class TooltipDispatcherSpec: QuickSpec {
                     expect(delegate.wasShouldShowCalled).toAfterTimeout(beFalse())
                 }
 
+                context("performing permission check") {
+
+                    context("and permission response perform ping are true") {
+
+                        it("will perform ping") {
+                            permissionService.shouldPerformPing = true
+                            let tooltip = TestHelpers.generateTooltip(id: "test", title: "[Tooltip][ctx] title", isTest: true)
+                            dispatcher.setNeedsDisplay(tooltip: tooltip)
+                            expect(delegate.wasPingCalled).toEventually(beTrue())
+                        }
+                    }
+
+                    context("and permission response perform ping are false") {
+
+                        it("will not perform ping") {
+                            permissionService.shouldPerformPing = false
+                            let tooltip = TestHelpers.generateTooltip(id: "test", title: "[Tooltip][ctx] title", isTest: true)
+                            dispatcher.setNeedsDisplay(tooltip: tooltip)
+                            expect(delegate.wasPingCalled).toEventually(beFalse())
+                        }
+                    }
+
+                    context("and permission response display are true") {
+
+                        it("will display the tooltip") {
+                            permissionService.shouldGrantPermission = true
+                            let tooltip = TestHelpers.generateTooltip(id: "test", title: "[Tooltip][ctx] title", isTest: true)
+                            dispatcher.setNeedsDisplay(tooltip: tooltip)
+                            expect(router.displayedTooltips).toEventuallyNot(beEmpty())
+                        }
+                    }
+
+                    context("and permission response display are false") {
+
+                        it("will not display the tooltip") {
+                            permissionService.shouldGrantPermission = false
+                            let tooltip = TestHelpers.generateTooltip(id: "test", title: "[Tooltip][ctx] title", isTest: true)
+                            dispatcher.setNeedsDisplay(tooltip: tooltip)
+                            expect(router.displayedTooltips).toEventually(beEmpty())
+                        }
+                    }
+                }
+
                 context("and contexts are approved") {
                     beforeEach {
                         delegate.shouldShowCampaign = true
@@ -206,13 +249,6 @@ class TooltipDispatcherSpec: QuickSpec {
                         dispatcher.setNeedsDisplay(tooltip: tooltip)
                         router.completeDisplayingTooltip(cancelled: false)
                         expect(campaignRepository.incrementImpressionsCalls).toAfterTimeout(equal(0))
-                    }
-
-                    it("will perform ping") {
-                        permissionService.shouldPerformPing = true
-                        let tooltip = TestHelpers.generateTooltip(id: "test", title: "[Tooltip][ctx] title", isTest: true)
-                        dispatcher.setNeedsDisplay(tooltip: tooltip)
-                        expect(delegate.wasPingCalled).toEventually(beTrue())
                     }
                 }
 

--- a/Tests/Tests/TooltipDispatcherSpec.swift
+++ b/Tests/Tests/TooltipDispatcherSpec.swift
@@ -211,21 +211,47 @@ class TooltipDispatcherSpec: QuickSpec {
 
                     context("and permission response display are true") {
 
-                        it("will display the tooltip") {
-                            permissionService.shouldGrantPermission = true
-                            let tooltip = TestHelpers.generateTooltip(id: "test", title: "[Tooltip][ctx] title", isTest: true)
-                            dispatcher.setNeedsDisplay(tooltip: tooltip)
-                            expect(router.displayedTooltips).toAfterTimeoutNot(beEmpty())
+                        context("and isTest are true") {
+
+                            it("will display the tooltip") {
+                                permissionService.shouldGrantPermission = true
+                                let tooltip = TestHelpers.generateTooltip(id: "test", title: "[Tooltip][ctx] title", isTest: true)
+                                dispatcher.setNeedsDisplay(tooltip: tooltip)
+                                expect(router.displayedTooltips).toAfterTimeoutNot(beEmpty())
+                            }
+                        }
+
+                        context("and isTest are false") {
+
+                            it("will display the tooltip") {
+                                permissionService.shouldGrantPermission = true
+                                let tooltip = TestHelpers.generateTooltip(id: "test", title: "[Tooltip][ctx] title", isTest: false)
+                                dispatcher.setNeedsDisplay(tooltip: tooltip)
+                                expect(router.displayedTooltips).toAfterTimeoutNot(beEmpty())
+                            }
                         }
                     }
 
                     context("and permission response display are false") {
 
-                        it("will not display the tooltip") {
-                            permissionService.shouldGrantPermission = false
-                            let tooltip = TestHelpers.generateTooltip(id: "test", title: "[Tooltip][ctx] title", isTest: true)
-                            dispatcher.setNeedsDisplay(tooltip: tooltip)
-                            expect(router.displayedTooltips).toAfterTimeout(beEmpty())
+                        context("and isTest are true") {
+
+                            it("will display the tooltip") {
+                                permissionService.shouldGrantPermission = true
+                                let tooltip = TestHelpers.generateTooltip(id: "test", title: "[Tooltip][ctx] title", isTest: true)
+                                dispatcher.setNeedsDisplay(tooltip: tooltip)
+                                expect(router.displayedTooltips).toAfterTimeoutNot(beEmpty())
+                            }
+                        }
+
+                        context("and isTest are false") {
+
+                            it("will not display the tooltip") {
+                                permissionService.shouldGrantPermission = false
+                                let tooltip = TestHelpers.generateTooltip(id: "test", title: "[Tooltip][ctx] title", isTest: false)
+                                dispatcher.setNeedsDisplay(tooltip: tooltip)
+                                expect(router.displayedTooltips).toAfterTimeout(beEmpty())
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
# Description
All IAM endpoints should be observed, but the tooltip is not observed. 
In this PR I add check permission to `displayPermission` for the tooltip to be observed.

## Links
SDKCF-4964

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data **before every commit**, including API endpoints and keys
- [ ] I ran `fastlane ci` without errors
