### PR TITLE
tests: add new testing file EventType (SDKCF-6378)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 	- Removed "last user" cache to avoid overwriting anonymous user cache during init [SDKCF-6409]
 - Improvements:
 	- Created new test scheme to combine unit test and UI test results [SDKCF-6356]
-    - Added a new file for EventType unit test to increase code coverage [SDKCF-6378]   
+	- Added a new file for EventType unit test to increase code coverage [SDKCF-6378]
 
 ### 7.3.0 (2023-01-11)
 - Features:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 	- Removed "last user" cache to avoid overwriting anonymous user cache during init [SDKCF-6409]
 - Improvements:
 	- Created new test scheme to combine unit test and UI test results [SDKCF-6356]
+    - Added a new file for EventType unit test to increase code coverage [SDKCF-6378]   
 
 ### 7.3.0 (2023-01-11)
 - Features:

--- a/RInAppMessaging.xcodeproj/project.pbxproj
+++ b/RInAppMessaging.xcodeproj/project.pbxproj
@@ -99,6 +99,7 @@
 		D924268722D91C15002F50D3 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = D924268522D91C15002F50D3 /* Localizable.strings */; };
 		D92D1F2322249853008EA748 /* CampaignsValidatorSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D92D1F2122249833008EA748 /* CampaignsValidatorSpec.swift */; };
 		D92D1F262224A269008EA748 /* TestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = D92D1F242224A265008EA748 /* TestHelpers.swift */; };
+		FCF93D8029C2D359000DB8CE /* EventTypeSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCF93D7F29C2D359000DB8CE /* EventTypeSpec.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -230,6 +231,7 @@
 		D92D1F2122249833008EA748 /* CampaignsValidatorSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CampaignsValidatorSpec.swift; sourceTree = "<group>"; };
 		D92D1F242224A265008EA748 /* TestHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestHelpers.swift; sourceTree = "<group>"; };
 		D9F418282110FD9F00E2158F /* ConfigurationSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigurationSpec.swift; sourceTree = "<group>"; };
+		FCF93D7F29C2D359000DB8CE /* EventTypeSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventTypeSpec.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -422,6 +424,7 @@
 				45ADA53D247CFE9E00A9E2A3 /* ConfigurationRepositorySpec.swift */,
 				459B227B245289F300D218CE /* ConfigurationServiceSpec.swift */,
 				D9F418282110FD9F00E2158F /* ConfigurationSpec.swift */,
+				FCF93D7F29C2D359000DB8CE /* EventTypeSpec.swift */,
 				45491058247F58660019864D /* CustomAttributeSpec.swift */,
 				459DE86B2407B5750002F451 /* CustomEventValidationSpec.swift */,
 				459B228124528A7D00D218CE /* DisplayPermissionServiceSpec.swift */,
@@ -751,6 +754,7 @@
 				456FE1E72428513200304872 /* ErrorReportableSpec.swift in Sources */,
 				4538BCF6262AE8FA009952BE /* UserDataCacheSpec.swift in Sources */,
 				45BDFD052421EE7B004DEA0C /* SharedMocks.swift in Sources */,
+				FCF93D8029C2D359000DB8CE /* EventTypeSpec.swift in Sources */,
 				45B3CC8427871C01005BA3F7 /* BundleSpec.swift in Sources */,
 				459B228024528A6900D218CE /* ImpressionServiceSpec.swift in Sources */,
 				4557A8B1257E544C00C9D241 /* AccountRepositorySpec.swift in Sources */,

--- a/SampleSPM/SampleSPM.xcodeproj/project.pbxproj
+++ b/SampleSPM/SampleSPM.xcodeproj/project.pbxproj
@@ -113,6 +113,7 @@
 		D920D8CB2277B965008FB38D /* SecondPageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D920D8CA2277B965008FB38D /* SecondPageViewController.swift */; };
 		D924268722D91C15002F50D3 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = D924268522D91C15002F50D3 /* Localizable.strings */; };
 		D92D1F262224A269008EA748 /* TestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = D92D1F242224A265008EA748 /* TestHelpers.swift */; };
+		FCF93D8229C30863000DB8CE /* EventTypeSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCF93D8129C30863000DB8CE /* EventTypeSpec.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -244,6 +245,7 @@
 		D924268622D91C15002F50D3 /* Base */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = Base; path = Base.lproj/Localizable.strings; sourceTree = "<group>"; };
 		D924268822D91C19002F50D3 /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ja; path = ja.lproj/Localizable.strings; sourceTree = "<group>"; };
 		D92D1F242224A265008EA748 /* TestHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestHelpers.swift; sourceTree = "<group>"; };
+		FCF93D8129C30863000DB8CE /* EventTypeSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EventTypeSpec.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -465,6 +467,7 @@
 				D234A6F4291C62CA0086AC80 /* CustomAttributeSpec.swift */,
 				D234A6F2291C62CA0086AC80 /* CustomEventValidationSpec.swift */,
 				D234A703291C62CC0086AC80 /* DisplayPermissionServiceSpec.swift */,
+				FCF93D8129C30863000DB8CE /* EventTypeSpec.swift */,
 				D234A6FB291C62CB0086AC80 /* ErrorReportableSpec.swift */,
 				D234A6F5291C62CA0086AC80 /* EventMatcherSpec.swift */,
 				D234A6F1291C62CA0086AC80 /* HeaderAttributesBuilderSpec.swift */,
@@ -791,6 +794,7 @@
 				D234A72F291C62CF0086AC80 /* MatchingUtilitySpec.swift in Sources */,
 				D234A72E291C62CF0086AC80 /* BackoffSpec.swift in Sources */,
 				D234A723291C62CF0086AC80 /* EventMatcherSpec.swift in Sources */,
+				FCF93D8229C30863000DB8CE /* EventTypeSpec.swift in Sources */,
 				D234A742291C62CF0086AC80 /* CampaignsValidatorSpec.swift in Sources */,
 				D234A743291C62CF0086AC80 /* ViewListenerSpec.swift in Sources */,
 				D234A71F291C62CE0086AC80 /* HeaderAttributesBuilderSpec.swift in Sources */,

--- a/Tests/Tests/EventTypeSpec.swift
+++ b/Tests/Tests/EventTypeSpec.swift
@@ -1,0 +1,45 @@
+import Quick
+import Nimble
+@testable import RInAppMessaging
+
+class EventTypeSpec: QuickSpec {
+
+    override func spec() {
+
+        describe("EventType") {
+
+            context("when accessing name") {
+
+                it("should return invalid") {
+                    let type = EventType.invalid
+                    expect(type.name).to(equal("invalid"))
+                }
+
+                it("should return app_start") {
+                    let type = EventType.appStart
+                    expect(type.name).to(equal("app_start"))
+                }
+
+                it("should return login_successful") {
+                    let type = EventType.loginSuccessful
+                    expect(type.name).to(equal("login_successful"))
+                }
+
+                it("should return purchase_successful") {
+                    let type = EventType.purchaseSuccessful
+                    expect(type.name).to(equal("purchase_successful"))
+                }
+
+                it("should return custom") {
+                    let type = EventType.custom
+                    expect(type.name).to(equal("custom"))
+                }
+
+                it("should return view_appeared") {
+                    let type = EventType.viewAppeared
+                    expect(type.name).to(equal("view_appeared"))
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
# Description
Increase code coverage in `EventType.swift`
Add a new file for EventTypea and add tests for the name property.

## Links
SDKCF-6378

# Checklist
- [x] I have read the [contributing guidelines](../CONTRIBUTING.md).
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data **before every commit**, including API endpoints and keys
- [ ] I ran `fastlane ci` without errors
