### PR TITLE
tests: Add testing code to cover all code in the UserInfoProvider (SDKCF-6380)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 	- Created new test scheme to combine unit test and UI test results [SDKCF-6356]
 	- Added a new file for EventType unit test to increase code coverage [SDKCF-6378]
 	- Added more unit test to increase code coverage [SDKCF-6379]
+	- Added testing code to cover all code in the UserInfoProvider [SDKCF-6380]
 
 ### 7.3.0 (2023-01-11)
 - Features:

--- a/Sources/RInAppMessaging/UserInfoProvider.swift
+++ b/Sources/RInAppMessaging/UserInfoProvider.swift
@@ -66,8 +66,14 @@ func == (lhs: UserInfoProvider?, rhs: UserInfoProvider?) -> Bool {
 
 @inlinable
 func != (lhs: UserInfoProvider?, rhs: UserInfoProvider?) -> Bool {
-    let equalsResult = lhs == rhs
-    return !equalsResult
+    switch (lhs, rhs) {
+    case let (l?, r?):
+        return l != r
+    case (nil, nil):
+        return false
+    default:
+        return true
+    }
 }
 
 @inlinable

--- a/Sources/RInAppMessaging/UserInfoProvider.swift
+++ b/Sources/RInAppMessaging/UserInfoProvider.swift
@@ -72,7 +72,7 @@ func != (lhs: UserInfoProvider?, rhs: UserInfoProvider?) -> Bool {
     case (nil, nil):
         return false
     default:
-        return true
+        return false
     }
 }
 

--- a/Tests/Tests/UserInfoProviderSpec.swift
+++ b/Tests/Tests/UserInfoProviderSpec.swift
@@ -157,6 +157,106 @@ class UserInfoProviderSpec: QuickSpec {
                     expect(userInfoProviderA == userInfoProviderB).to(beTrue())
                 }
             }
+
+            context("when checking inequality") {
+                var userInfoProviderA: UserInfoProviderMock!
+                var userInfoProviderB: UserInfoProviderMock!
+
+                beforeEach {
+                    userInfoProviderA = UserInfoProviderMock()
+                    userInfoProviderB = UserInfoProviderMock()
+                }
+
+                it("will return true for nil object") {
+                    userInfoProviderA = nil
+                    userInfoProviderB = nil
+                    expect(userInfoProviderA != userInfoProviderB).to(beFalse())
+                }
+
+                it("will return true for nil and empty objects") {
+                    userInfoProviderA = nil
+                    expect(userInfoProviderA != userInfoProviderB).to(beTrue())
+                }
+
+                it("will return false for different userIds") {
+                    userInfoProviderA.userID = "userA"
+                    userInfoProviderB.userID = "userA"
+                    expect(userInfoProviderA != userInfoProviderB).to(beFalse())
+                }
+
+                it("will return false for nil end empty userId") {
+                    userInfoProviderA.userID = nil
+                    userInfoProviderB.userID = ""
+                    expect(userInfoProviderA != userInfoProviderB).to(beFalse())
+                }
+
+                it("will return true for different userIds") {
+                    userInfoProviderA.userID = "userA"
+                    userInfoProviderB.userID = "userB"
+                    expect(userInfoProviderA != userInfoProviderB).to(beTrue())
+                }
+
+                it("will return false for the same idTrackingIdentifiers") {
+                    userInfoProviderA.idTrackingIdentifier = "tracking-id"
+                    userInfoProviderB.idTrackingIdentifier = "tracking-id"
+                    expect(userInfoProviderA != userInfoProviderB).to(beFalse())
+                }
+
+                it("will return false for nil end empty isTrackingIdentifier") {
+                    userInfoProviderA.idTrackingIdentifier = nil
+                    userInfoProviderB.idTrackingIdentifier = ""
+                    expect(userInfoProviderA != userInfoProviderB).to(beFalse())
+                }
+
+                it("will return true for different idTrackingIdentifiers") {
+                    userInfoProviderA.idTrackingIdentifier = "identityA"
+                    userInfoProviderB.idTrackingIdentifier = "identityB"
+                    expect(userInfoProviderA != userInfoProviderB).to(beTrue())
+                }
+
+                // Disclaimer: User is not defined by its access token
+                it("will return false for the same accessTokens") {
+                    userInfoProviderA.accessToken = "token"
+                    userInfoProviderB.accessToken = "token"
+                    expect(userInfoProviderA != userInfoProviderB).to(beFalse())
+                }
+
+                it("will return false for nil end empty accessToken") {
+                    userInfoProviderA.accessToken = nil
+                    userInfoProviderB.accessToken = ""
+                    expect(userInfoProviderA != userInfoProviderB).to(beFalse())
+                }
+
+                it("will return false for different accessTokens") {
+                    userInfoProviderA.accessToken = "tokenA"
+                    userInfoProviderB.accessToken = "tokenB"
+                    expect(userInfoProviderA != userInfoProviderB).to(beFalse())
+                }
+
+                it("will return true if one identifier is different") {
+                    userInfoProviderA.userID = "userA"
+                    userInfoProviderB.userID = "userB"
+                    userInfoProviderA.idTrackingIdentifier = "tracking-id"
+                    userInfoProviderB.idTrackingIdentifier = "tracking-id"
+                    expect(userInfoProviderA != userInfoProviderB).to(beTrue())
+
+                    userInfoProviderA.userID = "user"
+                    userInfoProviderB.userID = "user"
+                    userInfoProviderA.idTrackingIdentifier = "tracking-id-A"
+                    userInfoProviderB.idTrackingIdentifier = "tracking-id-B"
+                    expect(userInfoProviderA != userInfoProviderB).to(beTrue())
+                }
+
+                it("will return false if only accessToken is different") {
+                    userInfoProviderA.idTrackingIdentifier = "tracking-id"
+                    userInfoProviderB.idTrackingIdentifier = "tracking-id"
+                    userInfoProviderA.userID = "user"
+                    userInfoProviderB.userID = "user"
+                    userInfoProviderA.accessToken = "tokenA"
+                    userInfoProviderB.accessToken = "tokenB"
+                    expect(userInfoProviderA != userInfoProviderB).to(beFalse())
+                }
+            }
         }
     }
 }

--- a/Tests/Tests/UserInfoProviderSpec.swift
+++ b/Tests/Tests/UserInfoProviderSpec.swift
@@ -173,9 +173,9 @@ class UserInfoProviderSpec: QuickSpec {
                     expect(userInfoProviderA != userInfoProviderB).to(beFalse())
                 }
 
-                it("will return true for nil and empty objects") {
+                it("will return false for nil and empty objects") {
                     userInfoProviderA = nil
-                    expect(userInfoProviderA != userInfoProviderB).to(beTrue())
+                    expect(userInfoProviderA != userInfoProviderB).to(beFalse())
                 }
 
                 it("will return false for different userIds") {

--- a/Tests/Tests/UserInfoProviderSpec.swift
+++ b/Tests/Tests/UserInfoProviderSpec.swift
@@ -167,7 +167,7 @@ class UserInfoProviderSpec: QuickSpec {
                     userInfoProviderB = UserInfoProviderMock()
                 }
 
-                it("will return true for nil object") {
+                it("will return false for nil object") {
                     userInfoProviderA = nil
                     userInfoProviderB = nil
                     expect(userInfoProviderA != userInfoProviderB).to(beFalse())


### PR DESCRIPTION
# Description
Increase code coverage in UserInfoProvider.swift
Include tests to cover `!=` when comparing the object.

## Links
SDKCF-6380

# Checklist
- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
- [x] I have added to the [changelog](../blob/master/CHANGELOG.md#Unreleased)
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data **before every commit**, including API endpoints and keys, and internal links
- [ ] I ran `fastlane ci` without errors
- [x] All project file changes are replicated in `SampleSPM/SampleSPM.xcodeproj` project
