### PR TITLE
chore: use pod swiftlint version as default

### DIFF
--- a/RInAppMessaging.xcodeproj/project.pbxproj
+++ b/RInAppMessaging.xcodeproj/project.pbxproj
@@ -708,7 +708,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/SwiftLint/swiftlint\" lint --config \"${SRCROOT}/.swiftlint.yml\"\n";
+			shellScript = "\"${PODS_ROOT}/SwiftLint/swiftlint\" lint --config \"${SRCROOT}/.swiftlint.yml\" --strict\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/Tests/Tests/CampaignRepositorySpec.swift
+++ b/Tests/Tests/CampaignRepositorySpec.swift
@@ -9,10 +9,8 @@ import RSDKUtilsNimble
 
 @testable import RInAppMessaging
 
-// swiftlint:disable:next type_body_length
 class CampaignRepositorySpec: QuickSpec {
 
-    // swiftlint:disable:next function_body_length
     override func spec() {
         describe("CampaignRepository") {
 

--- a/Tests/Tests/ConfigurationServiceSpec.swift
+++ b/Tests/Tests/ConfigurationServiceSpec.swift
@@ -12,7 +12,6 @@ import class RSDKUtils.URLSessionMock
 
 private let configURL = URL(string: "http://config.url")!
 
-// swiftlint:disable:next type_body_length
 class ConfigurationServiceSpec: QuickSpec {
 
     override func spec() {

--- a/Tests/Tests/ReadyCampaignDispatcherSpec.swift
+++ b/Tests/Tests/ReadyCampaignDispatcherSpec.swift
@@ -10,10 +10,8 @@ import class RSDKUtils.URLSessionMock
 
 @testable import RInAppMessaging
 
-// swiftlint:disable:next type_body_length
 class ReadyCampaignDispatcherSpec: QuickSpec {
 
-    // swiftlint:disable:next function_body_length
     override func spec() {
         describe("CampaignDispatcher") {
             var dispatcher: CampaignDispatcher!


### PR DESCRIPTION
# Description
Set `--strict` parameter in xcode build phase
This PR will fix failing Xcode 12.5 build on bitrise

## Links
n/a

# Checklist
- [X] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
- [ ] I have added to the [changelog](../blob/master/CHANGELOG.md#Unreleased)
- [ ] I wrote/updated tests for new/changed code
- [X] I removed all sensitive data **before every commit**, including API endpoints and keys, and internal links
- [X] I ran `fastlane ci` without errors
- [ ] All project file changes are replicated in `SampleSPM/SampleSPM.xcodeproj` project
