### PR TITLE
tests: Add testing code to cover all code in the EventMatcher (SDKCF-6390)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 	- Added a new file for EventType unit test to increase code coverage [SDKCF-6378]
 	- Added more unit test to increase code coverage [SDKCF-6379]
 	- Added testing code to cover all code in the UserInfoProvider [SDKCF-6380]
+	- Added more unit test to EventMatcher to increase code coverage [SDKCF-6390]
 
 ### 7.3.0 (2023-01-11)
 - Features:

--- a/Sources/RInAppMessaging/EventMatcher.swift
+++ b/Sources/RInAppMessaging/EventMatcher.swift
@@ -80,11 +80,10 @@ internal class EventMatcher: EventMatcherType {
         let events = matchedEvents.get()[campaign.id, default: []] + persistentEvents
         let allTriggersSatisfied = triggers.allSatisfy { isTriggerMatchingOneOfEvents($0, events: events) }
         
-        if campaign.isTooltip {
-            return allTriggersSatisfied && events.contains(where: { $0.type == .viewAppeared })
-        } else {
+        guard campaign.isTooltip else {
             return allTriggersSatisfied
         }
+        return allTriggersSatisfied && events.contains(where: { $0.type == .viewAppeared })
     }
 
     func removeSetOfMatchedEvents(_ eventsToRemove: Set<Event>, for campaign: Campaign) throws {

--- a/Tests/Tests/EventMatcherSpec.swift
+++ b/Tests/Tests/EventMatcherSpec.swift
@@ -75,8 +75,13 @@ class EventMatcherSpec: QuickSpec {
             context("when removing events") {
 
                 it("will throw error if events for given campaign weren't found") {
+                    let customEvent = CustomEvent(withName: "customEventTest", withCustomAttributes: nil)
+                    let customEventToRemove = CustomEvent(withName: "customEventToRemove", withCustomAttributes: nil)
+                    campaignRepository.list = [testCampaign]
+                    eventMatcher.matchAndStore(event: customEvent)
                     expect {
-                        try eventMatcher.removeSetOfMatchedEvents([AppStartEvent()], for: testCampaign)
+                        try eventMatcher.removeSetOfMatchedEvents([customEventToRemove],
+                                                                  for: testCampaign)
                     }.to(throwError(EventMatcherError.couldntFindRequestedSetOfEvents))
                 }
 
@@ -89,14 +94,9 @@ class EventMatcherSpec: QuickSpec {
                     }.to(throwError(EventMatcherError.couldntFindRequestedSetOfEvents))
                 }
 
-                it("will throw error if the event to remove isn't persistent event") {
-                    let customEvent = CustomEvent(withName: "customEventTest", withCustomAttributes: nil)
-                    let customEventToRemove = CustomEvent(withName: "customEventToRemove", withCustomAttributes: nil)
-                    campaignRepository.list = [testCampaign]
-                    eventMatcher.matchAndStore(event: customEvent)
+                it("will throw error if persistent event for given campaign wasn't found") {
                     expect {
-                        try eventMatcher.removeSetOfMatchedEvents([customEventToRemove],
-                                                                  for: testCampaign)
+                        try eventMatcher.removeSetOfMatchedEvents([AppStartEvent()], for: testCampaign)
                     }.to(throwError(EventMatcherError.couldntFindRequestedSetOfEvents))
                 }
 

--- a/Tests/Tests/EventMatcherSpec.swift
+++ b/Tests/Tests/EventMatcherSpec.swift
@@ -89,7 +89,7 @@ class EventMatcherSpec: QuickSpec {
                     }.to(throwError(EventMatcherError.couldntFindRequestedSetOfEvents))
                 }
 
-                it("will throw error if the event to remove isn't persistent or the event weren't found inside persistent events") {
+                it("will throw error if the event to remove isn't persistent event") {
                     let customEvent = CustomEvent(withName: "customEventTest", withCustomAttributes: nil)
                     let customEventToRemove = CustomEvent(withName: "customEventToRemove", withCustomAttributes: nil)
                     campaignRepository.list = [testCampaign]
@@ -227,7 +227,7 @@ class EventMatcherSpec: QuickSpec {
                 expect(events).to(contain(AppStartEvent()))
             }
 
-            it("will stop matching events when triggers inside campaign is nil") {
+            it("will not match any event with campaign that has no triggers") {
                 let testCampaignWithoutTrigger = TestHelpers.generateCampaign(
                     id: "test"
                 )

--- a/Tests/Tests/Helpers/TestHelpers.swift
+++ b/Tests/Tests/Helpers/TestHelpers.swift
@@ -33,7 +33,7 @@ struct TestHelpers {
                                  test: Bool = false,
                                  hasImage: Bool = false,
                                  content: Content? = nil,
-                                 triggers: [Trigger] = [],
+                                 triggers: [Trigger]? = nil,
                                  buttons: [Button] = []) -> Campaign {
         Campaign(
             data: CampaignData(


### PR DESCRIPTION
# Description
Increase code coverage in EventMatcher.swift
Include tests to cover the failure case when matching the event.

## Links
SDKCF-6390

# Checklist
- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
- [x] I have added to the [changelog](../blob/master/CHANGELOG.md#Unreleased)
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data **before every commit**, including API endpoints and keys, and internal links
- [ ] I ran `fastlane ci` without errors
- [x] All project file changes are replicated in `SampleSPM/SampleSPM.xcodeproj` project
