### PR TITLE
tests: improved the unit test code coverage to SlideUpViewPresenter.swift (SDKCF-6383)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,11 @@
 	- Added display permission service to perform ping on tooltip dispatcher [SDKCF-4964]
 - Improvements:
 	- Created new test scheme to combine unit test and UI test results [SDKCF-6356]
-	- Added a new file for EventType unit test to increase code coverage [SDKCF-6378]
-	- Added more unit test to increase code coverage [SDKCF-6379]
-	- Added testing code to cover all code in the UserInfoProvider [SDKCF-6380]
+	- Improved unit test code coverage to
+		- EventType.swift [SDKCF-6378]
+		- CustomAttribute.swift [SDKCF-6379]
+		- UserInfoProvider.swift [SDKCF-6380]
+		- SlideUpViewPresenter.swift [SDKCF-6383]
 
 ### 7.3.0 (2023-01-11)
 - Features:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 		- CustomAttribute.swift [SDKCF-6379]
 		- UserInfoProvider.swift [SDKCF-6380]
 		- EventMatcher.swift [SDKCF-6390]
+		- ConfigurationService.swift [SDKCF-6388]
 		- SlideUpViewPresenter.swift [SDKCF-6383]
 
 ### 7.3.0 (2023-01-11)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 		- EventType.swift [SDKCF-6378]
 		- CustomAttribute.swift [SDKCF-6379]
 		- UserInfoProvider.swift [SDKCF-6380]
+		- EventMatcher.swift [SDKCF-6390]
 		- SlideUpViewPresenter.swift [SDKCF-6383]
 
 ### 7.3.0 (2023-01-11)

--- a/RInAppMessaging.xcodeproj/project.pbxproj
+++ b/RInAppMessaging.xcodeproj/project.pbxproj
@@ -73,6 +73,7 @@
 		45BDFD032421D311004DEA0C /* CampaignsListManagerSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45BDFD022421D311004DEA0C /* CampaignsListManagerSpec.swift */; };
 		45BDFD052421EE7B004DEA0C /* SharedMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45BDFD042421EE7B004DEA0C /* SharedMocks.swift */; };
 		45BDFD0724232714004DEA0C /* PublicAPISpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45BDFD0624232714004DEA0C /* PublicAPISpec.swift */; };
+		45D064D029D2ECE10009DFB2 /* slide-up-trigger-without-messageBody.json in Resources */ = {isa = PBXBuildFile; fileRef = 45D064CE29D2ECE10009DFB2 /* slide-up-trigger-without-messageBody.json */; };
 		45D4DA4F240F5597009B9B37 /* ViewPresenterSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45D4DA4E240F5597009B9B37 /* ViewPresenterSpec.swift */; };
 		45DA01AD23D5831900A27CC6 /* ConfigurationManagerSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45DA01AC23D5831900A27CC6 /* ConfigurationManagerSpec.swift */; };
 		45DC6D0127A33BB300B28C13 /* TooltipDispatcherSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45DC6D0027A33BB300B28C13 /* TooltipDispatcherSpec.swift */; };
@@ -196,6 +197,7 @@
 		45BDFD022421D311004DEA0C /* CampaignsListManagerSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CampaignsListManagerSpec.swift; sourceTree = "<group>"; };
 		45BDFD042421EE7B004DEA0C /* SharedMocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedMocks.swift; sourceTree = "<group>"; };
 		45BDFD0624232714004DEA0C /* PublicAPISpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PublicAPISpec.swift; sourceTree = "<group>"; };
+		45D064CE29D2ECE10009DFB2 /* slide-up-trigger-without-messageBody.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "slide-up-trigger-without-messageBody.json"; sourceTree = "<group>"; };
 		45D4DA4E240F5597009B9B37 /* ViewPresenterSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ViewPresenterSpec.swift; sourceTree = "<group>"; };
 		45DA01AC23D5831900A27CC6 /* ConfigurationManagerSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigurationManagerSpec.swift; sourceTree = "<group>"; };
 		45DC6D0027A33BB300B28C13 /* TooltipDispatcherSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TooltipDispatcherSpec.swift; sourceTree = "<group>"; };
@@ -312,6 +314,7 @@
 				453D245126A4DF1D00FB9E6A /* slide-up-close.json */,
 				4592B4B2270229D1004FF27B /* config.json */,
 				4592B4B927024D0C004FF27B /* display-permission.json */,
+				45D064CE29D2ECE10009DFB2 /* slide-up-trigger-without-messageBody.json */,
 			);
 			path = ResponseStubs;
 			sourceTree = "<group>";
@@ -645,6 +648,7 @@
 				453D243926A4ABD000FB9E6A /* modal-image-only.json in Resources */,
 				453D243226A172F600FB9E6A /* modal-text-only.json in Resources */,
 				453D244726A4DBDC00FB9E6A /* full-controls.json in Resources */,
+				45D064D029D2ECE10009DFB2 /* slide-up-trigger-without-messageBody.json in Resources */,
 				453D245326A4DF1D00FB9E6A /* slide-up-close.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/SampleSPM/SampleSPM.xcodeproj/project.pbxproj
+++ b/SampleSPM/SampleSPM.xcodeproj/project.pbxproj
@@ -36,6 +36,7 @@
 		4592B4CA27026FB7004FF27B /* istockphoto-1047234038.jpg in Resources */ = {isa = PBXBuildFile; fileRef = 4592B4C627026AE8004FF27B /* istockphoto-1047234038.jpg */; };
 		45B5723F25ACE90F005A80F7 /* IntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45B5723E25ACE90F005A80F7 /* IntegrationTests.swift */; };
 		45BDFD052421EE7B004DEA0C /* SharedMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45BDFD042421EE7B004DEA0C /* SharedMocks.swift */; };
+		45D064D529D5571D0009DFB2 /* slide-up-trigger-without-messageBody.json in Resources */ = {isa = PBXBuildFile; fileRef = 45D064D429D5571D0009DFB2 /* slide-up-trigger-without-messageBody.json */; };
 		45FA8FDE272C26C8005166FD /* RInAppMessaging in Frameworks */ = {isa = PBXBuildFile; productRef = 45FA8FDD272C26C8005166FD /* RInAppMessaging */; };
 		45FA8FE0272C2835005166FD /* RInAppMessaging in Frameworks */ = {isa = PBXBuildFile; productRef = 45FA8FDF272C2835005166FD /* RInAppMessaging */; };
 		45FA8FE2272C283B005166FD /* RInAppMessaging in Frameworks */ = {isa = PBXBuildFile; productRef = 45FA8FE1272C283B005166FD /* RInAppMessaging */; };
@@ -176,6 +177,7 @@
 		45B5723E25ACE90F005A80F7 /* IntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntegrationTests.swift; sourceTree = "<group>"; };
 		45B5724025ACE90F005A80F7 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		45BDFD042421EE7B004DEA0C /* SharedMocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedMocks.swift; sourceTree = "<group>"; };
+		45D064D429D5571D0009DFB2 /* slide-up-trigger-without-messageBody.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "slide-up-trigger-without-messageBody.json"; sourceTree = "<group>"; };
 		45FA8FDA272C2698005166FD /* ios-inappmessaging */ = {isa = PBXFileReference; lastKnownFileType = folder; name = "ios-inappmessaging"; path = ..; sourceTree = "<group>"; };
 		607FACD01AFB9204008FA782 /* RInAppMessaging_Example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = RInAppMessaging_Example.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		607FACD41AFB9204008FA782 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = Info.plist; path = ../SampleSPM/Info.plist; sourceTree = "<group>"; };
@@ -342,6 +344,7 @@
 				453D244426A4DBDC00FB9E6A /* full-text-only.json */,
 				453D244E26A4DCD800FB9E6A /* slide-up-trigger.json */,
 				453D245126A4DF1D00FB9E6A /* slide-up-close.json */,
+				45D064D429D5571D0009DFB2 /* slide-up-trigger-without-messageBody.json */,
 				4592B4B2270229D1004FF27B /* config.json */,
 				4592B4B927024D0C004FF27B /* display-permission.json */,
 			);
@@ -698,6 +701,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				45D064D529D5571D0009DFB2 /* slide-up-trigger-without-messageBody.json in Resources */,
 				453D244B26A4DBDC00FB9E6A /* full-text-only.json in Resources */,
 				453D244D26A4DBDC00FB9E6A /* full-text-image.json in Resources */,
 				4592B4B3270229D1004FF27B /* config.json in Resources */,

--- a/Sources/RInAppMessaging/EventMatcher.swift
+++ b/Sources/RInAppMessaging/EventMatcher.swift
@@ -80,11 +80,10 @@ internal class EventMatcher: EventMatcherType {
         let events = matchedEvents.get()[campaign.id, default: []] + persistentEvents
         let allTriggersSatisfied = triggers.allSatisfy { isTriggerMatchingOneOfEvents($0, events: events) }
         
-        if campaign.isTooltip {
-            return allTriggersSatisfied && events.contains(where: { $0.type == .viewAppeared })
-        } else {
+        guard campaign.isTooltip else {
             return allTriggersSatisfied
         }
+        return allTriggersSatisfied && events.contains(where: { $0.type == .viewAppeared })
     }
 
     func removeSetOfMatchedEvents(_ eventsToRemove: Set<Event>, for campaign: Campaign) throws {

--- a/Sources/RInAppMessaging/Views/Presenters/SlideUpViewPresenter.swift
+++ b/Sources/RInAppMessaging/Views/Presenters/SlideUpViewPresenter.swift
@@ -43,11 +43,7 @@ internal class SlideUpViewPresenter: BaseViewPresenter, SlideUpViewPresenterType
                 return
             }
 
-            UIApplication.shared.open(uriToOpen, options: [:], completionHandler: { success in
-                if !success, let view = self.view {
-                    self.showURLError(view: view)
-                }
-            })
+            UIApplication.shared.open(uriToOpen)
         }
 
         logImpression(type: .clickContent)

--- a/Sources/RInAppMessaging/Views/Presenters/SlideUpViewPresenter.swift
+++ b/Sources/RInAppMessaging/Views/Presenters/SlideUpViewPresenter.swift
@@ -43,7 +43,11 @@ internal class SlideUpViewPresenter: BaseViewPresenter, SlideUpViewPresenterType
                 return
             }
 
-            UIApplication.shared.open(uriToOpen)
+            UIApplication.shared.open(uriToOpen, options: [:], completionHandler: { success in
+                            if !success, let view = self.view {
+                                self.showURLError(view: view)
+                            }
+                        })
         }
 
         logImpression(type: .clickContent)

--- a/Sources/RInAppMessaging/Views/Presenters/SlideUpViewPresenter.swift
+++ b/Sources/RInAppMessaging/Views/Presenters/SlideUpViewPresenter.swift
@@ -44,10 +44,10 @@ internal class SlideUpViewPresenter: BaseViewPresenter, SlideUpViewPresenterType
             }
 
             UIApplication.shared.open(uriToOpen, options: [:], completionHandler: { success in
-                            if !success, let view = self.view {
-                                self.showURLError(view: view)
-                            }
-                        })
+                if !success, let view = self.view {
+                    self.showURLError(view: view)
+                }
+            })
         }
 
         logImpression(type: .clickContent)

--- a/Tests/Tests/ConfigurationServiceSpec.swift
+++ b/Tests/Tests/ConfigurationServiceSpec.swift
@@ -254,6 +254,21 @@ class ConfigurationServiceSpec: QuickSpec {
                 }
             }
 
+            context("when building request body") {
+
+                it("will return RequestError.bodyIsNil with parameters") {
+                    let result = service.buildHttpBody(with: ["key": "value"])
+                    let error = result.getError() as? RequestError
+                    expect(error).toNot(beNil())
+                }
+
+                it("will return RequestError.bodyIsNil when parameters is nil") {
+                    let result = service.buildHttpBody(with: nil)
+                    let error = result.getError() as? RequestError
+                    expect(error).toNot(beNil())
+                }
+            }
+
             context("when making a request") {
                 beforeEach {
                     BundleInfoMock.reset()
@@ -337,6 +352,18 @@ class ConfigurationServiceSpec: QuickSpec {
                     it("will return RequestError.missingMetadata error if host app version is missing") {
                         BundleInfoMock.appVersionMock = nil
                         makeRequestAndEvaluateMetadataError()
+                    }
+
+                    it("will throwAssertion when SubscriptionID is missing") {
+                        configRepository.saveIAMModuleConfiguration(InAppMessagingModuleConfiguration(configURLString: "http:config.url",
+                                                                                                      subscriptionID: nil,
+                                                                                                      isTooltipFeatureEnabled: true))
+                        waitUntil { done in
+                            requestQueue.async {
+                                expect(service.getConfigData()).to(throwAssertion())
+                                done()
+                            }
+                        }
                     }
                 }
                 context("and config url is invalid") {

--- a/Tests/Tests/EventMatcherSpec.swift
+++ b/Tests/Tests/EventMatcherSpec.swift
@@ -19,6 +19,10 @@ class EventMatcherSpec: QuickSpec {
                     Trigger(type: .event,
                             eventType: .loginSuccessful,
                             eventName: "loginSuccessfulTest",
+                            attributes: []),
+                    Trigger(type: .event,
+                            eventType: .custom,
+                            eventName: "customEventTest",
                             attributes: [])
                 ]
             )
@@ -71,8 +75,13 @@ class EventMatcherSpec: QuickSpec {
             context("when removing events") {
 
                 it("will throw error if events for given campaign weren't found") {
+                    let customEvent = CustomEvent(withName: "customEventTest", withCustomAttributes: nil)
+                    let customEventToRemove = CustomEvent(withName: "customEventToRemove", withCustomAttributes: nil)
+                    campaignRepository.list = [testCampaign]
+                    eventMatcher.matchAndStore(event: customEvent)
                     expect {
-                        try eventMatcher.removeSetOfMatchedEvents([AppStartEvent()], for: testCampaign)
+                        try eventMatcher.removeSetOfMatchedEvents([customEventToRemove],
+                                                                  for: testCampaign)
                     }.to(throwError(EventMatcherError.couldntFindRequestedSetOfEvents))
                 }
 
@@ -82,6 +91,12 @@ class EventMatcherSpec: QuickSpec {
                     expect {
                         try eventMatcher.removeSetOfMatchedEvents([AppStartEvent(), LoginSuccessfulEvent()],
                                                                   for: testCampaign)
+                    }.to(throwError(EventMatcherError.couldntFindRequestedSetOfEvents))
+                }
+
+                it("will throw error if persistent event for given campaign wasn't found") {
+                    expect {
+                        try eventMatcher.removeSetOfMatchedEvents([AppStartEvent()], for: testCampaign)
                     }.to(throwError(EventMatcherError.couldntFindRequestedSetOfEvents))
                 }
 
@@ -212,6 +227,16 @@ class EventMatcherSpec: QuickSpec {
                 expect(events).to(contain(AppStartEvent()))
             }
 
+            it("will not match any event with campaign that has no triggers") {
+                let testCampaignWithoutTrigger = TestHelpers.generateCampaign(
+                    id: "test"
+                )
+                campaignRepository.list = [testCampaignWithoutTrigger]
+                eventMatcher.matchAndStore(event: LoginSuccessfulEvent())
+                let events = eventMatcher.matchedEvents(for: testCampaignWithoutTrigger)
+                expect(events).to(beEmpty())
+            }
+
             it("will properly match non-persistent events") {
                 campaignRepository.list = [testCampaign]
                 eventMatcher.matchAndStore(event: LoginSuccessfulEvent())
@@ -241,6 +266,7 @@ class EventMatcherSpec: QuickSpec {
                 it("will return true if all required events were stored") {
                     eventMatcher.matchAndStore(event: AppStartEvent())
                     eventMatcher.matchAndStore(event: LoginSuccessfulEvent())
+                    eventMatcher.matchAndStore(event: CustomEvent(withName: "customEventTest", withCustomAttributes: []))
                     expect(eventMatcher.containsAllMatchedEvents(for: testCampaign)).to(beTrue())
                 }
 
@@ -249,6 +275,7 @@ class EventMatcherSpec: QuickSpec {
                     eventMatcher.matchAndStore(event: LoginSuccessfulEvent())
                     eventMatcher.matchAndStore(event: LoginSuccessfulEvent())
                     eventMatcher.matchAndStore(event: PurchaseSuccessfulEvent())
+                    eventMatcher.matchAndStore(event: CustomEvent(withName: "customEventTest", withCustomAttributes: []))
                     expect(eventMatcher.containsAllMatchedEvents(for: testCampaign)).to(beTrue())
                 }
 

--- a/Tests/Tests/Helpers/TestHelpers.swift
+++ b/Tests/Tests/Helpers/TestHelpers.swift
@@ -33,7 +33,7 @@ struct TestHelpers {
                                  test: Bool = false,
                                  hasImage: Bool = false,
                                  content: Content? = nil,
-                                 triggers: [Trigger] = [],
+                                 triggers: [Trigger]? = nil,
                                  buttons: [Button] = []) -> Campaign {
         Campaign(
             data: CampaignData(

--- a/Tests/UITests/ResponseStubs/slide-up-trigger-without-messageBody.json
+++ b/Tests/UITests/ResponseStubs/slide-up-trigger-without-messageBody.json
@@ -4,29 +4,28 @@
     "data": [
         {
             "campaignData": {
-                "campaignId": "slide-up-redirect",
+                "campaignId": "slide-up-trigger-invalid-messagepayload",
                 "maxImpressions": 999,
                 "type": 3,
                 "isTest": false,
-                "isCampaignDismissable": true,
+                "isCampaignDismissable": false,
                 "hasNoEndDate": false,
                 "infiniteImpressions": true,
                 "triggers": [
                     {
                         "type": 1,
-                        "eventType": 2,
-                        "eventName": "Login Successful Event",
+                        "eventType": 4,
+                        "eventName": "purchase_successful",
                         "attributes": []
                     }
                 ],
                 "messagePayload": {
                     "title": "test",
-                    "messageBody": "test",
                     "header": "Test Campaign",
                     "titleColor": "#000000",
                     "headerColor": "#000000",
-                    "messageBodyColor": "",
-                    "backgroundColor": "",
+                    "messageBodyColor": "#000000",
+                    "backgroundColor": "#ffffff",
                     "frameColor": "#ffffff",
                     "resource": {
                         "cropType": 2
@@ -38,14 +37,20 @@
                             "orientation": 1,
                             "textAlign": 2,
                             "optOut": true,
-                            "delay": 0,
+                            "delay": 500,
                             "html": false
                         },
                         "controlSettings": {
                             "content": {
+                                "campaignTrigger": {
+                                    "type": 1,
+                                    "eventType": 4,
+                                    "eventName": "purchase_successful",
+                                    "attributes": []
+                                },
                                 "onClickBehavior": {
-                                    "action": 1,
-                                    "uri": "http://localhost:6789/image.jpg"
+                                    "action": 3,
+                                    "uri": null
                                 }
                             },
                             "buttons": []

--- a/Tests/UITests/SlideUpViewSpec.swift
+++ b/Tests/UITests/SlideUpViewSpec.swift
@@ -40,6 +40,20 @@ class SlideUpViewSpec: QuickSpec {
 
         describe("Slide-up campaign view") {
 
+            context("trigger action with invalid message payload") {
+
+                beforeEach {
+                    launchAppIfNecessary(context: "slide-up-trigger-without-messageBody")
+                    if !iamView.exists {
+                        app.buttons["purchase_successful"].tap()
+                    }
+                }
+
+                it("should not construct the slideup view") {
+                    expect(iamView.exists).to(beFalse())
+                }
+            }
+
             context("when clicking X button") {
 
                 beforeEach {

--- a/Tests/UITests/SlideUpViewSpec.swift
+++ b/Tests/UITests/SlideUpViewSpec.swift
@@ -44,13 +44,12 @@ class SlideUpViewSpec: QuickSpec {
 
                 beforeEach {
                     launchAppIfNecessary(context: "slide-up-trigger-without-messageBody")
-                    if !iamView.exists {
-                        app.buttons["purchase_successful"].tap()
-                    }
+                    expect(iamView.exists).to(beFalse())
+                    app.buttons["purchase_successful"].tap()
                 }
 
                 it("should not construct the slideup view") {
-                    expect(iamView.exists).to(beFalse())
+                    expect(iamView.exists).toAfterTimeout(beFalse(), timeout: 2)
                 }
             }
 


### PR DESCRIPTION
# Description
- Added `slide-up-trigger-without-messageBody.json` file with an invalid response
- Added coverage to `guard else` statement in `viewDidInitialize()`
- Removed unused `completionHandler` 

## Links
- SDKCF-6383

# Checklist
- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
- [x] I have added to the [changelog](../blob/master/CHANGELOG.md#Unreleased)
- [x] I wrote/updated tests for new/changed code
- [ ] I removed all sensitive data **before every commit**, including API endpoints and keys, and internal links
- [x] I ran `fastlane ci` without errors
- [x] All project file changes are replicated in `SampleSPM/SampleSPM.xcodeproj` project
