### PR TITLE
tests: improve Code Coverage of ConfigurationService (SDKCF-6388)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 	- Added more unit test to increase code coverage [SDKCF-6379]
 	- Added testing code to cover all code in the UserInfoProvider [SDKCF-6380]
 	- Added more unit test to EventMatcher to increase code coverage [SDKCF-6390]
+	- Added testing code to increase coverage in ConfigurationService [SDKCF-6388]
 
 ### 7.3.0 (2023-01-11)
 - Features:

--- a/Tests/Tests/ConfigurationServiceSpec.swift
+++ b/Tests/Tests/ConfigurationServiceSpec.swift
@@ -254,6 +254,15 @@ class ConfigurationServiceSpec: QuickSpec {
                 }
             }
 
+            context("when building request body") {
+
+                it("will return RequestError.bodyIsNil") {
+                    let result = service.buildHttpBody(with: nil)
+                    let error = result.getError() as? RequestError
+                    expect(error).toNot(beNil())
+                }
+            }
+
             context("when making a request") {
                 beforeEach {
                     BundleInfoMock.reset()

--- a/Tests/Tests/ConfigurationServiceSpec.swift
+++ b/Tests/Tests/ConfigurationServiceSpec.swift
@@ -256,7 +256,13 @@ class ConfigurationServiceSpec: QuickSpec {
 
             context("when building request body") {
 
-                it("will return RequestError.bodyIsNil") {
+                it("will return RequestError.bodyIsNil with parameters") {
+                    let result = service.buildHttpBody(with: ["key": "value"])
+                    let error = result.getError() as? RequestError
+                    expect(error).toNot(beNil())
+                }
+
+                it("will return RequestError.bodyIsNil when parameters is nil") {
                     let result = service.buildHttpBody(with: nil)
                     let error = result.getError() as? RequestError
                     expect(error).toNot(beNil())
@@ -346,6 +352,18 @@ class ConfigurationServiceSpec: QuickSpec {
                     it("will return RequestError.missingMetadata error if host app version is missing") {
                         BundleInfoMock.appVersionMock = nil
                         makeRequestAndEvaluateMetadataError()
+                    }
+
+                    it("will throwAssertion when SubscriptionID is missing") {
+                        configRepository.saveIAMModuleConfiguration(InAppMessagingModuleConfiguration(configURLString: "http:config.url",
+                                                                                                      subscriptionID: nil,
+                                                                                                      isTooltipFeatureEnabled: true))
+                        waitUntil { done in
+                            requestQueue.async {
+                                expect(service.getConfigData()).to(throwAssertion())
+                                done()
+                            }
+                        }
                     }
                 }
                 context("and config url is invalid") {


### PR DESCRIPTION
# Description
Improved coverage of `ConfigurationService` to **98.9%**
This else line cannot failed, because it's already checked in the previous line if it's link is a valid URL:
```swift
guard let url = urlComponents?.url else {
    return .failure(RequestError.urlIsNil)
}
```

## Links
SDKCF-6388

# Checklist
- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
- [x] I have added to the [changelog](../blob/master/CHANGELOG.md#Unreleased)
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data **before every commit**, including API endpoints and keys, and internal links
- [ ] I ran `fastlane ci` without errors
- [x] All project file changes are replicated in `SampleSPM/SampleSPM.xcodeproj` project
