### PR TITLE
test: improved code coverage for CampaignRepository.swift file (SDKCF-6387)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 		- ConfigurationService.swift [SDKCF-6388]
 		- UserDataCache.swift [SDKCF-6384]
 		- MessageMixerService.swift [SDKCF-6386]   
+		- CampaignRepository.swift [SDKCF-6387]
 
 ### 7.3.0 (2023-01-11)
 - Features:

--- a/Sources/RInAppMessaging/Repositories/CampaignRepository.swift
+++ b/Sources/RInAppMessaging/Repositories/CampaignRepository.swift
@@ -131,18 +131,12 @@ internal class CampaignRepository: CampaignRepositoryType {
 
     @discardableResult
     func decrementImpressionsLeftInCampaign(id: String) -> Campaign? {
-        guard let campaign = findCampaign(withID: id) else {
-            return nil
-        }
-        return updateImpressionsLeftInCampaign(campaign, newValue: max(0, campaign.impressionsLeft - 1))
+        updateImpressionsLeftInCampaign(withID: id, by: -1)
     }
 
     @discardableResult
     func incrementImpressionsLeftInCampaign(id: String) -> Campaign? {
-        guard let campaign = findCampaign(withID: id) else {
-            return nil
-        }
-        return updateImpressionsLeftInCampaign(campaign, newValue: campaign.impressionsLeft + 1)
+        updateImpressionsLeftInCampaign(withID: id, by: 1)
     }
 
     func loadCachedData() {
@@ -152,19 +146,14 @@ internal class CampaignRepository: CampaignRepositoryType {
 
     // MARK: - Helpers
 
-    private func findCampaign(withID id: String) -> Campaign? {
-        (allCampaigns.get() + tooltips.get()).first(where: { $0.id == id })
-    }
-
-    private func updateImpressionsLeftInCampaign(_ campaign: Campaign, newValue: Int) -> Campaign? {
+    private func updateImpressionsLeftInCampaign(withID id: String, by value: Int) -> Campaign? {
         var newList = allCampaigns.get()
-        guard let index = newList.firstIndex(where: { $0.id == campaign.id }) else {
-            Logger.debug("Campaign \(campaign.id) could not be updated - not found in the repository")
-            assertionFailure()
+        guard let index = newList.firstIndex(where: { $0.id == id }) else {
+            Logger.debug("Campaign \(id) could not be updated - not found in the repository")
             return nil
         }
-
-        let updatedCampaign = Campaign.updatedCampaign(campaign, withImpressionLeft: newValue)
+        let campaign = newList[index]
+        let updatedCampaign = Campaign.updatedCampaign(campaign, withImpressionLeft: max(0, campaign.impressionsLeft + value))
         newList[index] = updatedCampaign
         allCampaigns.set(value: newList)
 

--- a/Tests/Tests/CampaignRepositorySpec.swift
+++ b/Tests/Tests/CampaignRepositorySpec.swift
@@ -10,7 +10,9 @@ import RSDKUtilsNimble
 @testable import RInAppMessaging
 
 class CampaignRepositorySpec: QuickSpec {
+// swiftlint:disable:previous type_body_length
 
+    // swiftlint:disable:next function_body_length
     override func spec() {
         describe("CampaignRepository") {
 
@@ -80,6 +82,12 @@ class CampaignRepositorySpec: QuickSpec {
                         expect(campaignRepository.list).to(haveCount(1))
                     }
 
+                    it("check decrement impression with invalid campaign id") {
+                        syncRepository(with: [campaign])
+                        let campaign = campaignRepository.decrementImpressionsLeftInCampaign(id: testCampaign.data.campaignId)
+                        expect(campaign).to(beNil())
+                    }
+
                     it("will persist impressionsLeft value") {
                         syncRepository(with: [campaign])
                         campaignRepository.decrementImpressionsLeftInCampaign(id: campaign.id)
@@ -105,6 +113,12 @@ class CampaignRepositorySpec: QuickSpec {
                         campaignRepository.optOutCampaign(campaign)
                         syncRepository(with: [campaign])
                         expect(firstPersistedCampaign?.isOptedOut).to(beTrue())
+                    }
+
+                    it("check increment impression with invalid campaign id") {
+                        syncRepository(with: [campaign])
+                        let campaign = campaignRepository.incrementImpressionsLeftInCampaign(id: testCampaign.data.campaignId)
+                        expect(campaign).to(beNil())
                     }
 
                     it("will not override impressionsLeft value even if maxImpressions number is smaller") {
@@ -272,6 +286,12 @@ class CampaignRepositorySpec: QuickSpec {
                     syncRepository(with: [testCampaign])
                     campaignRepository.optOutCampaign(testCampaign)
                     expect(userCache?.campaignData?.first?.isOptedOut).to(beFalse())
+                }
+
+                it("optout campaign with invalid campaign") {
+                    syncRepository(with: [campaign])
+                    let campaign = campaignRepository.optOutCampaign(testCampaign)
+                    expect(campaign).to(beNil())
                 }
             }
 

--- a/Tests/Tests/CampaignRepositorySpec.swift
+++ b/Tests/Tests/CampaignRepositorySpec.swift
@@ -82,12 +82,6 @@ class CampaignRepositorySpec: QuickSpec {
                         expect(campaignRepository.list).to(haveCount(1))
                     }
 
-                    it("check decrement impression with invalid campaign id") {
-                        syncRepository(with: [campaign])
-                        let campaign = campaignRepository.decrementImpressionsLeftInCampaign(id: testCampaign.data.campaignId)
-                        expect(campaign).to(beNil())
-                    }
-
                     it("will persist impressionsLeft value") {
                         syncRepository(with: [campaign])
                         campaignRepository.decrementImpressionsLeftInCampaign(id: campaign.id)
@@ -113,12 +107,6 @@ class CampaignRepositorySpec: QuickSpec {
                         campaignRepository.optOutCampaign(campaign)
                         syncRepository(with: [campaign])
                         expect(firstPersistedCampaign?.isOptedOut).to(beTrue())
-                    }
-
-                    it("check increment impression with invalid campaign id") {
-                        syncRepository(with: [campaign])
-                        let campaign = campaignRepository.incrementImpressionsLeftInCampaign(id: testCampaign.data.campaignId)
-                        expect(campaign).to(beNil())
                     }
 
                     it("will not override impressionsLeft value even if maxImpressions number is smaller") {
@@ -288,10 +276,12 @@ class CampaignRepositorySpec: QuickSpec {
                     expect(userCache?.campaignData?.first?.isOptedOut).to(beFalse())
                 }
 
-                it("optout campaign with invalid campaign") {
-                    syncRepository(with: [campaign])
-                    let campaign = campaignRepository.optOutCampaign(testCampaign)
-                    expect(campaign).to(beNil())
+                context("when provided campaign is invalid") {
+                    it("will not mark campaign as opted out") {
+                        syncRepository(with: [campaign])
+                        let campaign = campaignRepository.optOutCampaign(testCampaign)
+                        expect(campaign).to(beNil())
+                    }
                 }
             }
 
@@ -397,6 +387,14 @@ class CampaignRepositorySpec: QuickSpec {
                         expect(userCache?.campaignData?.first?.impressionsLeft).to(equal(2))
                     }
                 }
+
+                context("when provided campaign id is invalid") {
+                    it("will not find campaign when decrement the impressionLeft value") {
+                        syncRepository(with: [campaign])
+                        let campaign = campaignRepository.decrementImpressionsLeftInCampaign(id: testCampaign.data.campaignId)
+                        expect(campaign).to(beNil())
+                    }
+                }
             }
 
             context("when incrementImpressionsLeftInCampaign is called") {
@@ -437,6 +435,14 @@ class CampaignRepositorySpec: QuickSpec {
                     syncRepository(with: [testCampaign])
                     campaignRepository.incrementImpressionsLeftInCampaign(id: testCampaign.id)
                     expect(userCache?.campaignData?.first?.impressionsLeft).to(equal(4))
+                }
+
+                context("when provided campaign id is invalid") {
+                    it("will not find campaign when increment the impressionLeft value") {
+                        syncRepository(with: [campaign])
+                        let campaign = campaignRepository.incrementImpressionsLeftInCampaign(id: testCampaign.data.campaignId)
+                        expect(campaign).to(beNil())
+                    }
                 }
             }
 


### PR DESCRIPTION
# Description
- Refactored `updateImpressionsLeftInCampaign` function
- Added coverage to some `guard else` statement

## Links
SDKCF-6387

# Checklist
- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
- [x] I have added to the [changelog](../blob/master/CHANGELOG.md#Unreleased)
- [x] I wrote/updated tests for new/changed code
- [ ] I removed all sensitive data **before every commit**, including API endpoints and keys, and internal links
- [x] I ran `fastlane ci` without errors
- [ ] All project file changes are replicated in `SampleSPM/SampleSPM.xcodeproj` project
