### PR TITLE
tests: add new testing code for user data cache (SDKCF-6384)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 	- Added testing code to cover all code in the UserInfoProvider [SDKCF-6380]
 	- Added more unit test to EventMatcher to increase code coverage [SDKCF-6390]
 	- Added testing code to increase coverage in ConfigurationService [SDKCF-6388]
+	- Added testing code to increase coverage in UserDataCache [SDKCF-6384]   
 
 ### 7.3.0 (2023-01-11)
 - Features:

--- a/Tests/Tests/UserDataCacheSpec.swift
+++ b/Tests/Tests/UserDataCacheSpec.swift
@@ -85,6 +85,22 @@ class UserDataCacheSpec: QuickSpec {
                 expect(userContainer).to(beNil())
             }
 
+            it("will remove all user cached data for registered user") {
+                let userCache = UserDataCache(userDefaults: userDefaults)
+                let userIdentifier = [UserIdentifier(type: .userId, identifier: "testUser")]
+
+                let campaigns = TestHelpers.MockResponse.withGeneratedCampaigns(count: 2, test: false, delay: 0).data
+                userCache.cacheCampaignData(campaigns, userIdentifiers: userIdentifier)
+                let displayPermission = DisplayPermissionResponse(display: true, performPing: false)
+                userCache.cacheDisplayPermissionData(displayPermission, campaignID: campaigns[0].id, userIdentifiers: userIdentifier)
+
+                userCache.deleteUserData(identifiers: userIdentifier)
+                let userContainer = userCache.getUserData(identifiers: userIdentifier)
+
+                expect(userContainer?.campaignData).to(beNil())
+                expect(userContainer?.displayPermissionData(for: campaigns[0])).to(beNil())
+            }
+
             context("when two threads call cacheCampaignData") {
                 it("will not crash") {
                     let queue1 = DispatchQueue(label: "UserDataCacheQueue1")


### PR DESCRIPTION
# Description

Improved coverage of `UserDataCache` from 90.3% → **97.2%**

1. This catch block will never be executed, encoding will never fail because we use a pre-defined model in our project that the data will always be valid:
```swift
catch {
    Logger.debug("UserDataCache encoding failed! \(error)")
    assertionFailure()
}
```

2. This `: assertionFailure()` will never be executed because its Environment.isUnitTestEnvironment is always true when running the unit tests. 
```swift
Environment.isUnitTestEnvironment ? () : assertionFailure()
```


## Links
SDKCF-6384

# Checklist
- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
- [x] I have added to the [changelog](../blob/master/CHANGELOG.md#Unreleased)
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data **before every commit**, including API endpoints and keys, and internal links
- [ ] I ran `fastlane ci` without errors
- [x] All project file changes are replicated in `SampleSPM/SampleSPM.xcodeproj` project
