### PR TITLE
tests: improve the coverage to MessageMixerService.swift file (SDKCF-6386)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,14 @@
 	- Added display permission service to perform ping on tooltip dispatcher [SDKCF-4964]
 - Improvements:
 	- Created new test scheme to combine unit test and UI test results [SDKCF-6356]
-	- Added a new file for EventType unit test to increase code coverage [SDKCF-6378]
-	- Added more unit test to increase code coverage [SDKCF-6379]
-	- Added testing code to cover all code in the UserInfoProvider [SDKCF-6380]
-	- Added more unit test to EventMatcher to increase code coverage [SDKCF-6390]
-	- Added testing code to increase coverage in ConfigurationService [SDKCF-6388]
-	- Added testing code to increase coverage in UserDataCache [SDKCF-6384]   
+	- Improved unit test code coverage to
+		- EventType.swift [SDKCF-6378]
+		- CustomAttribute.swift [SDKCF-6379]
+		- UserInfoProvider.swift [SDKCF-6380]
+		- EventMatcher.swift [SDKCF-6390]
+		- ConfigurationService.swift [SDKCF-6388]
+		- UserDataCache.swift [SDKCF-6384]
+		- MessageMixerService.swift [SDKCF-6386]   
 
 ### 7.3.0 (2023-01-11)
 - Features:

--- a/Tests/Tests/Helpers/SharedMocks.swift
+++ b/Tests/Tests/Helpers/SharedMocks.swift
@@ -666,4 +666,10 @@ extension EndpointURL {
                            displayPermission: emptyURL,
                            impression: emptyURL)
     }
+
+    static var invalid: Self {
+        return EndpointURL(ping: nil,
+                           displayPermission: nil,
+                           impression: nil)
+    }
 }

--- a/Tests/Tests/Helpers/SharedMocks.swift
+++ b/Tests/Tests/Helpers/SharedMocks.swift
@@ -668,8 +668,8 @@ extension EndpointURL {
     }
 
     static var invalid: Self {
-        return EndpointURL(ping: nil,
-                           displayPermission: nil,
-                           impression: nil)
+        EndpointURL(ping: nil,
+                    displayPermission: nil,
+                    impression: nil)
     }
 }

--- a/Tests/Tests/MessageMixerServiceSpec.swift
+++ b/Tests/Tests/MessageMixerServiceSpec.swift
@@ -221,6 +221,24 @@ class MessageMixerServiceSpec: QuickSpec {
                         }
                     }
                 }
+
+                context("configuration doesn't have valid ping endpoint") {
+                    it("will return invalid configuration error") {
+                        waitUntil { done in
+                            let configData = ConfigEndpointData(rolloutPercentage: 100, endpoints: .invalid)
+                            configurationRepository.saveRemoteConfiguration(configData)
+                            let result = service.ping()
+                            let error = result.getError()
+                            expect(error).toNot(beNil())
+                            guard case .invalidConfiguration = error else {
+                                fail("Unexpected error type \(String(describing: error)). Expected .invalidConfiguration")
+                                done()
+                                return
+                            }
+                            done()
+                        }
+                    }
+                }
             }
 
             context("when making a request") {


### PR DESCRIPTION
# Description
- Added coverage to invalid configuration `guard else`  condition 

## Links
- SDKCF-6386

# Checklist
- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
- [x] I have added to the [changelog](../blob/master/CHANGELOG.md#Unreleased)
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data **before every commit**, including API endpoints and keys, and internal links
- [x] I ran `fastlane ci` without errors
- [ ] All project file changes are replicated in `SampleSPM/SampleSPM.xcodeproj` project
