### PR TITLE
tests: improve unit test code coverage for SlideUpViewPresenter.swift (SDKCF-6383)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 		- UserDataCache.swift [SDKCF-6384]
 		- MessageMixerService.swift [SDKCF-6386]   
 		- CampaignRepository.swift [SDKCF-6387]
+		- SlideUpViewPresenter.swift [SDKCF-6383]   
 
 ### 7.3.0 (2023-01-11)
 - Features:

--- a/RInAppMessaging.xcodeproj/project.pbxproj
+++ b/RInAppMessaging.xcodeproj/project.pbxproj
@@ -82,6 +82,8 @@
 		45DC6D0927A4501300B28C13 /* TooltipPresenterSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45DC6D0827A4501300B28C13 /* TooltipPresenterSpec.swift */; };
 		45EA720525B71FA2001B2049 /* UIApplicationExtensionSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45EA720425B71FA2001B2049 /* UIApplicationExtensionSpec.swift */; };
 		45EA720D25B72002001B2049 /* UIViewExtensionSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45EA720C25B72002001B2049 /* UIViewExtensionSpec.swift */; };
+		45ECADDF29DD6B96003F75B2 /* slide-up-trigger-without-messageBody.json in Resources */ = {isa = PBXBuildFile; fileRef = 45ECADDE29DD6B95003F75B2 /* slide-up-trigger-without-messageBody.json */; };
+		45ECADE029DD6B96003F75B2 /* slide-up-trigger-without-messageBody.json in Resources */ = {isa = PBXBuildFile; fileRef = 45ECADDE29DD6B95003F75B2 /* slide-up-trigger-without-messageBody.json */; };
 		4B1A88AB274F6896002724B6 /* dummy-font.otf in Resources */ = {isa = PBXBuildFile; fileRef = 4B1A88AA274F6891002724B6 /* dummy-font.otf */; };
 		4BBE7EAF274F1A6A0039D2BF /* UIFontExtensionSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BBE7EAE274F1A6A0039D2BF /* UIFontExtensionSpec.swift */; };
 		607FACD61AFB9204008FA782 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 607FACD51AFB9204008FA782 /* AppDelegate.swift */; };
@@ -205,6 +207,7 @@
 		45DC6D0827A4501300B28C13 /* TooltipPresenterSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TooltipPresenterSpec.swift; sourceTree = "<group>"; };
 		45EA720425B71FA2001B2049 /* UIApplicationExtensionSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIApplicationExtensionSpec.swift; sourceTree = "<group>"; };
 		45EA720C25B72002001B2049 /* UIViewExtensionSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIViewExtensionSpec.swift; sourceTree = "<group>"; };
+		45ECADDE29DD6B95003F75B2 /* slide-up-trigger-without-messageBody.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "slide-up-trigger-without-messageBody.json"; sourceTree = "<group>"; };
 		4B1A88AA274F6891002724B6 /* dummy-font.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "dummy-font.otf"; sourceTree = "<group>"; };
 		4BBE7EAE274F1A6A0039D2BF /* UIFontExtensionSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIFontExtensionSpec.swift; sourceTree = "<group>"; };
 		607FACD01AFB9204008FA782 /* RInAppMessaging_Example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = RInAppMessaging_Example.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -310,6 +313,7 @@
 				453D244426A4DBDC00FB9E6A /* full-text-only.json */,
 				453D244E26A4DCD800FB9E6A /* slide-up-trigger.json */,
 				453D245126A4DF1D00FB9E6A /* slide-up-close.json */,
+				45ECADDE29DD6B95003F75B2 /* slide-up-trigger-without-messageBody.json */,
 				4592B4B2270229D1004FF27B /* config.json */,
 				4592B4B927024D0C004FF27B /* display-permission.json */,
 			);
@@ -633,6 +637,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				45ECADE029DD6B96003F75B2 /* slide-up-trigger-without-messageBody.json in Resources */,
 				453D244B26A4DBDC00FB9E6A /* full-text-only.json in Resources */,
 				453D244D26A4DBDC00FB9E6A /* full-text-image.json in Resources */,
 				4592B4B3270229D1004FF27B /* config.json in Resources */,
@@ -666,6 +671,7 @@
 				D920D8C92277B80F008FB38D /* SecondPageViewController.xib in Resources */,
 				45073FA8277CDBF0007CB732 /* ping.json in Resources */,
 				607FACDB1AFB9204008FA782 /* Main.storyboard in Resources */,
+				45ECADDF29DD6B96003F75B2 /* slide-up-trigger-without-messageBody.json in Resources */,
 				607FACE01AFB9204008FA782 /* LaunchScreen.xib in Resources */,
 				607FACDD1AFB9204008FA782 /* Images.xcassets in Resources */,
 				45073FA5277CDBC6007CB732 /* display-permission.json in Resources */,

--- a/SampleSPM/SampleSPM.xcodeproj/project.pbxproj
+++ b/SampleSPM/SampleSPM.xcodeproj/project.pbxproj
@@ -36,6 +36,7 @@
 		4592B4CA27026FB7004FF27B /* istockphoto-1047234038.jpg in Resources */ = {isa = PBXBuildFile; fileRef = 4592B4C627026AE8004FF27B /* istockphoto-1047234038.jpg */; };
 		45B5723F25ACE90F005A80F7 /* IntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45B5723E25ACE90F005A80F7 /* IntegrationTests.swift */; };
 		45BDFD052421EE7B004DEA0C /* SharedMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45BDFD042421EE7B004DEA0C /* SharedMocks.swift */; };
+		45ECADE229DD6C91003F75B2 /* slide-up-trigger-without-messageBody.json in Resources */ = {isa = PBXBuildFile; fileRef = 45ECADE129DD6C91003F75B2 /* slide-up-trigger-without-messageBody.json */; };
 		45FA8FDE272C26C8005166FD /* RInAppMessaging in Frameworks */ = {isa = PBXBuildFile; productRef = 45FA8FDD272C26C8005166FD /* RInAppMessaging */; };
 		45FA8FE0272C2835005166FD /* RInAppMessaging in Frameworks */ = {isa = PBXBuildFile; productRef = 45FA8FDF272C2835005166FD /* RInAppMessaging */; };
 		45FA8FE2272C283B005166FD /* RInAppMessaging in Frameworks */ = {isa = PBXBuildFile; productRef = 45FA8FE1272C283B005166FD /* RInAppMessaging */; };
@@ -176,6 +177,7 @@
 		45B5723E25ACE90F005A80F7 /* IntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntegrationTests.swift; sourceTree = "<group>"; };
 		45B5724025ACE90F005A80F7 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		45BDFD042421EE7B004DEA0C /* SharedMocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedMocks.swift; sourceTree = "<group>"; };
+		45ECADE129DD6C91003F75B2 /* slide-up-trigger-without-messageBody.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "slide-up-trigger-without-messageBody.json"; sourceTree = "<group>"; };
 		45FA8FDA272C2698005166FD /* ios-inappmessaging */ = {isa = PBXFileReference; lastKnownFileType = folder; name = "ios-inappmessaging"; path = ..; sourceTree = "<group>"; };
 		607FACD01AFB9204008FA782 /* RInAppMessaging_Example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = RInAppMessaging_Example.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		607FACD41AFB9204008FA782 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = Info.plist; path = ../SampleSPM/Info.plist; sourceTree = "<group>"; };
@@ -342,6 +344,7 @@
 				453D244426A4DBDC00FB9E6A /* full-text-only.json */,
 				453D244E26A4DCD800FB9E6A /* slide-up-trigger.json */,
 				453D245126A4DF1D00FB9E6A /* slide-up-close.json */,
+				45ECADE129DD6C91003F75B2 /* slide-up-trigger-without-messageBody.json */,
 				4592B4B2270229D1004FF27B /* config.json */,
 				4592B4B927024D0C004FF27B /* display-permission.json */,
 			);
@@ -698,6 +701,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				45ECADE229DD6C91003F75B2 /* slide-up-trigger-without-messageBody.json in Resources */,
 				453D244B26A4DBDC00FB9E6A /* full-text-only.json in Resources */,
 				453D244D26A4DBDC00FB9E6A /* full-text-image.json in Resources */,
 				4592B4B3270229D1004FF27B /* config.json in Resources */,

--- a/Tests/UITests/ResponseStubs/slide-up-trigger-without-messageBody.json
+++ b/Tests/UITests/ResponseStubs/slide-up-trigger-without-messageBody.json
@@ -4,29 +4,28 @@
     "data": [
         {
             "campaignData": {
-                "campaignId": "slide-up-redirect",
+                "campaignId": "slide-up-trigger-invalid-messagepayload",
                 "maxImpressions": 999,
                 "type": 3,
                 "isTest": false,
-                "isCampaignDismissable": true,
+                "isCampaignDismissable": false,
                 "hasNoEndDate": false,
                 "infiniteImpressions": true,
                 "triggers": [
                     {
                         "type": 1,
-                        "eventType": 2,
-                        "eventName": "Login Successful Event",
+                        "eventType": 4,
+                        "eventName": "purchase_successful",
                         "attributes": []
                     }
                 ],
                 "messagePayload": {
                     "title": "test",
-                    "messageBody": "test",
                     "header": "Test Campaign",
                     "titleColor": "#000000",
                     "headerColor": "#000000",
-                    "messageBodyColor": "",
-                    "backgroundColor": "",
+                    "messageBodyColor": "#000000",
+                    "backgroundColor": "#ffffff",
                     "frameColor": "#ffffff",
                     "resource": {
                         "cropType": 2
@@ -38,11 +37,17 @@
                             "orientation": 1,
                             "textAlign": 2,
                             "optOut": true,
-                            "delay": 0,
+                            "delay": 500,
                             "html": false
                         },
                         "controlSettings": {
                             "content": {
+                                "campaignTrigger": {
+                                    "type": 1,
+                                    "eventType": 4,
+                                    "eventName": "purchase_successful",
+                                    "attributes": []
+                                },
                                 "onClickBehavior": {
                                     "action": 3,
                                     "uri": null

--- a/Tests/UITests/SlideUpViewSpec.swift
+++ b/Tests/UITests/SlideUpViewSpec.swift
@@ -40,6 +40,19 @@ class SlideUpViewSpec: QuickSpec {
 
         describe("Slide-up campaign view") {
 
+            context("trigger action with invalid message payload") {
+
+                beforeEach {
+                    launchAppIfNecessary(context: "slide-up-trigger-without-messageBody")
+                    expect(iamView.exists).to(beFalse())
+                    app.buttons["purchase_successful"].tap()
+                }
+
+                it("should not construct the slideup view") {
+                    expect(iamView.exists).toAfterTimeout(beFalse(), timeout: 2)
+                }
+            }
+
             context("when clicking X button") {
 
                 beforeEach {


### PR DESCRIPTION
# Description
- Added slide-up-trigger-without-messageBody.json file with an invalid response
- Added coverage to guard else statement in viewDidInitialize()

## Links
SDKCF-6383

# Checklist
- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
- [x] I have added to the [changelog](../blob/master/CHANGELOG.md#Unreleased)
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data **before every commit**, including API endpoints and keys, and internal links
- [x] I ran `fastlane ci` without errors
- [x] All project file changes are replicated in `SampleSPM/SampleSPM.xcodeproj` project
