### PR TITLE
refactor: removed unused legacy code from Event classes (SDKCF-6376)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 	- Added display permission service to perform ping on tooltip dispatcher [SDKCF-4964]
 - Improvements:
 	- Created new test scheme to combine unit test and UI test results [SDKCF-6356]
+	- Refactored Event classes and removed unused code [SDKCF-6376]
 	- Improved unit test code coverage to
 		- EventType.swift [SDKCF-6378]
 		- CustomAttribute.swift [SDKCF-6379]

--- a/Sources/RInAppMessaging/Events/AppStartEvent.swift
+++ b/Sources/RInAppMessaging/Events/AppStartEvent.swift
@@ -22,12 +22,4 @@ import Foundation
                    name: Constants.Event.appStart,
                    timestamp: timestamp)
     }
-
-    required public init(from decoder: Decoder) throws {
-        fatalError("init(from:) has not been implemented")
-    }
-
-    override public func encode(to encoder: Encoder) throws {
-        try super.encode(to: encoder)
-    }
 }

--- a/Sources/RInAppMessaging/Events/CustomEvent.swift
+++ b/Sources/RInAppMessaging/Events/CustomEvent.swift
@@ -40,14 +40,6 @@ import Foundation
                    timestamp: timestamp)
     }
 
-    required public init(from decoder: Decoder) throws {
-        fatalError("init(from:) has not been implemented")
-    }
-
-    override public func encode(to encoder: Encoder) throws {
-        try super.encode(to: encoder)
-    }
-
     public override func isEqual(_ object: Any?) -> Bool {
         guard let object = object as? CustomEvent else {
             return false

--- a/Sources/RInAppMessaging/Events/Event.swift
+++ b/Sources/RInAppMessaging/Events/Event.swift
@@ -3,7 +3,7 @@ import Foundation
 /// Event object that acts as the super class for other pre-defined Event classes.
 /// Implements Codable in order for it to be encoded/decoded
 /// as a data type and store/load from a property list.
-@objc public class Event: NSObject, Codable {
+@objc public class Event: NSObject {
 
     private enum CodingKeys: String, CodingKey {
         case type, timestamp, name

--- a/Sources/RInAppMessaging/Events/LoginSuccessfulEvent.swift
+++ b/Sources/RInAppMessaging/Events/LoginSuccessfulEvent.swift
@@ -22,12 +22,4 @@ import Foundation
                    name: Constants.Event.loginSuccessful,
                    timestamp: timestamp)
     }
-
-    required public init(from decoder: Decoder) throws {
-        fatalError("init(from:) has not been implemented")
-    }
-
-    override public func encode(to encoder: Encoder) throws {
-        try super.encode(to: encoder)
-    }
 }

--- a/Sources/RInAppMessaging/Events/PurchaseSuccessfulEvent.swift
+++ b/Sources/RInAppMessaging/Events/PurchaseSuccessfulEvent.swift
@@ -59,14 +59,6 @@ import Foundation
                        timestamp: timestamp)
     }
 
-    required public init(from decoder: Decoder) throws {
-        fatalError("init(from:) has not been implemented")
-    }
-
-    override public func encode(to encoder: Encoder) throws {
-        try super.encode(to: encoder)
-    }
-
     @objc @discardableResult
     public func setPurchaseAmount(_ purchaseAmount: Int) -> PurchaseSuccessfulEvent {
         self.purchaseAmount = purchaseAmount

--- a/Sources/RInAppMessaging/Events/ViewAppearedEvent.swift
+++ b/Sources/RInAppMessaging/Events/ViewAppearedEvent.swift
@@ -10,12 +10,4 @@ internal class ViewAppearedEvent: Event {
         super.init(type: EventType.viewAppeared,
                    name: Constants.Event.viewAppeared)
     }
-
-    required public init(from decoder: Decoder) throws {
-        throw CocoaError(.featureUnsupported)
-    }
-
-    override public func encode(to encoder: Encoder) throws {
-        throw CocoaError(.featureUnsupported)
-    }
 }


### PR DESCRIPTION
# Description
 Removed unused legacy code from Event classes to improve code coverage. Will be raising a separate PR to improve code coverages for Event class files

## Links
SDKCF-6376

# Checklist
- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
- [x] I have added to the [changelog](../blob/master/CHANGELOG.md#Unreleased)
- [ ] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data **before every commit**, including API endpoints and keys, and internal links
- [ ] I ran `fastlane ci` without errors
- [x] All project file changes are replicated in `SampleSPM/SampleSPM.xcodeproj` project
