### PR TITLE
tests: add new testing file for alert presentable (SDKCF-6375)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 		- UILabel+IAM [SDKCF-6385]
 		- CommonUtility [SDKCF-6381]
 		- CampaignDispatcher [SDKCF-6452]
+		- AlertPresentable [SDKCF-6375]
 
 ### 7.3.0 (2023-01-11)
 - Features:

--- a/RInAppMessaging.xcodeproj/project.pbxproj
+++ b/RInAppMessaging.xcodeproj/project.pbxproj
@@ -102,6 +102,8 @@
 		D92D1F2322249853008EA748 /* CampaignsValidatorSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D92D1F2122249833008EA748 /* CampaignsValidatorSpec.swift */; };
 		D92D1F262224A269008EA748 /* TestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = D92D1F242224A265008EA748 /* TestHelpers.swift */; };
 		FC92B45B29DBDEBE0053CF0E /* UILabelExtensionSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC92B45A29DBDEBE0053CF0E /* UILabelExtensionSpec.swift */; };
+		FCEB554129E5482200E60481 /* AlertPresentableSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC92B45E29DFC5C10053CF0E /* AlertPresentableSpec.swift */; };
+		FCEB554229E5482F00E60481 /* modal-controls-invalid-url.json in Resources */ = {isa = PBXBuildFile; fileRef = FCCDBF7129E0083A002EE447 /* modal-controls-invalid-url.json */; };
 		FCF93D8029C2D359000DB8CE /* EventTypeSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCF93D7F29C2D359000DB8CE /* EventTypeSpec.swift */; };
 /* End PBXBuildFile section */
 
@@ -236,6 +238,8 @@
 		D92D1F242224A265008EA748 /* TestHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestHelpers.swift; sourceTree = "<group>"; };
 		D9F418282110FD9F00E2158F /* ConfigurationSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigurationSpec.swift; sourceTree = "<group>"; };
 		FC92B45A29DBDEBE0053CF0E /* UILabelExtensionSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UILabelExtensionSpec.swift; sourceTree = "<group>"; };
+		FC92B45E29DFC5C10053CF0E /* AlertPresentableSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertPresentableSpec.swift; sourceTree = "<group>"; };
+		FCCDBF7129E0083A002EE447 /* modal-controls-invalid-url.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "modal-controls-invalid-url.json"; sourceTree = "<group>"; };
 		FCF93D7F29C2D359000DB8CE /* EventTypeSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventTypeSpec.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -292,6 +296,7 @@
 			children = (
 				453D242826A0DE5100FB9E6A /* ModalViewSpec.swift */,
 				453D243E26A4DB4900FB9E6A /* FullScreenViewSpec.swift */,
+				FC92B45E29DFC5C10053CF0E /* AlertPresentableSpec.swift */,
 				453D243F26A4DB4900FB9E6A /* SlideUpViewSpec.swift */,
 				4592B4C827026AF0004FF27B /* Resources */,
 				4592B4B42702490C004FF27B /* Helpers */,
@@ -309,6 +314,7 @@
 				453D243526A4ABD000FB9E6A /* modal-image-only.json */,
 				453D243426A4ABD000FB9E6A /* modal-text-image.json */,
 				453D243A26A4B83E00FB9E6A /* modal-controls.json */,
+				FCCDBF7129E0083A002EE447 /* modal-controls-invalid-url.json */,
 				453D244226A4DBDC00FB9E6A /* full-controls.json */,
 				453D244326A4DBDC00FB9E6A /* full-image-only.json */,
 				453D244526A4DBDC00FB9E6A /* full-text-image.json */,
@@ -646,6 +652,7 @@
 				4592B4B3270229D1004FF27B /* config.json in Resources */,
 				4592B4CA27026FB7004FF27B /* istockphoto-1047234038.jpg in Resources */,
 				453D245026A4DCD800FB9E6A /* slide-up-trigger.json in Resources */,
+				FCEB554229E5482F00E60481 /* modal-controls-invalid-url.json in Resources */,
 				453D243726A4ABD000FB9E6A /* modal-text-image.json in Resources */,
 				4592B4BA27024D0C004FF27B /* display-permission.json in Resources */,
 				453D243C26A4B83E00FB9E6A /* modal-controls.json in Resources */,
@@ -730,6 +737,7 @@
 				4592B4B627024925004FF27B /* MockServerHelper.swift in Sources */,
 				453D244026A4DB4900FB9E6A /* FullScreenViewSpec.swift in Sources */,
 				453D242926A0DE5100FB9E6A /* ModalViewSpec.swift in Sources */,
+				FCEB554129E5482200E60481 /* AlertPresentableSpec.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/RInAppMessaging.xcodeproj/project.pbxproj
+++ b/RInAppMessaging.xcodeproj/project.pbxproj
@@ -104,6 +104,7 @@
 		FC92B45B29DBDEBE0053CF0E /* UILabelExtensionSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC92B45A29DBDEBE0053CF0E /* UILabelExtensionSpec.swift */; };
 		FCEB554129E5482200E60481 /* AlertPresentableSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC92B45E29DFC5C10053CF0E /* AlertPresentableSpec.swift */; };
 		FCEB554229E5482F00E60481 /* modal-controls-invalid-url.json in Resources */ = {isa = PBXBuildFile; fileRef = FCCDBF7129E0083A002EE447 /* modal-controls-invalid-url.json */; };
+		FCEB554829E64EC800E60481 /* slide-up-trigger-invalid-url.json in Resources */ = {isa = PBXBuildFile; fileRef = FCEB554729E64EC800E60481 /* slide-up-trigger-invalid-url.json */; };
 		FCF93D8029C2D359000DB8CE /* EventTypeSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCF93D7F29C2D359000DB8CE /* EventTypeSpec.swift */; };
 /* End PBXBuildFile section */
 
@@ -240,6 +241,7 @@
 		FC92B45A29DBDEBE0053CF0E /* UILabelExtensionSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UILabelExtensionSpec.swift; sourceTree = "<group>"; };
 		FC92B45E29DFC5C10053CF0E /* AlertPresentableSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertPresentableSpec.swift; sourceTree = "<group>"; };
 		FCCDBF7129E0083A002EE447 /* modal-controls-invalid-url.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "modal-controls-invalid-url.json"; sourceTree = "<group>"; };
+		FCEB554729E64EC800E60481 /* slide-up-trigger-invalid-url.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "slide-up-trigger-invalid-url.json"; sourceTree = "<group>"; };
 		FCF93D7F29C2D359000DB8CE /* EventTypeSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventTypeSpec.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -320,6 +322,7 @@
 				453D244526A4DBDC00FB9E6A /* full-text-image.json */,
 				453D244426A4DBDC00FB9E6A /* full-text-only.json */,
 				453D244E26A4DCD800FB9E6A /* slide-up-trigger.json */,
+				FCEB554729E64EC800E60481 /* slide-up-trigger-invalid-url.json */,
 				453D245126A4DF1D00FB9E6A /* slide-up-close.json */,
 				45ECADDE29DD6B95003F75B2 /* slide-up-trigger-without-messageBody.json */,
 				4592B4B2270229D1004FF27B /* config.json */,
@@ -661,6 +664,7 @@
 				453D243226A172F600FB9E6A /* modal-text-only.json in Resources */,
 				453D244726A4DBDC00FB9E6A /* full-controls.json in Resources */,
 				453D245326A4DF1D00FB9E6A /* slide-up-close.json in Resources */,
+				FCEB554829E64EC800E60481 /* slide-up-trigger-invalid-url.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/SampleSPM/SampleSPM.xcodeproj/project.pbxproj
+++ b/SampleSPM/SampleSPM.xcodeproj/project.pbxproj
@@ -115,6 +115,8 @@
 		D924268722D91C15002F50D3 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = D924268522D91C15002F50D3 /* Localizable.strings */; };
 		D92D1F262224A269008EA748 /* TestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = D92D1F242224A265008EA748 /* TestHelpers.swift */; };
 		FC92B45D29DD27670053CF0E /* UILabelExtensionSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC92B45C29DD27670053CF0E /* UILabelExtensionSpec.swift */; };
+		FCEB554429E54B1E00E60481 /* AlertPresentableSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCEB554329E54B1D00E60481 /* AlertPresentableSpec.swift */; };
+		FCEB554629E54B3A00E60481 /* modal-controls-invalid-url.json in Resources */ = {isa = PBXBuildFile; fileRef = FCEB554529E54B3A00E60481 /* modal-controls-invalid-url.json */; };
 		FCF93D8229C30863000DB8CE /* EventTypeSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCF93D8129C30863000DB8CE /* EventTypeSpec.swift */; };
 /* End PBXBuildFile section */
 
@@ -249,6 +251,8 @@
 		D924268822D91C19002F50D3 /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ja; path = ja.lproj/Localizable.strings; sourceTree = "<group>"; };
 		D92D1F242224A265008EA748 /* TestHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestHelpers.swift; sourceTree = "<group>"; };
 		FC92B45C29DD27670053CF0E /* UILabelExtensionSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UILabelExtensionSpec.swift; sourceTree = "<group>"; };
+		FCEB554329E54B1D00E60481 /* AlertPresentableSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AlertPresentableSpec.swift; sourceTree = "<group>"; };
+		FCEB554529E54B3A00E60481 /* modal-controls-invalid-url.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "modal-controls-invalid-url.json"; sourceTree = "<group>"; };
 		FCF93D8129C30863000DB8CE /* EventTypeSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EventTypeSpec.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -322,6 +326,7 @@
 			isa = PBXGroup;
 			children = (
 				453D242826A0DE5100FB9E6A /* ModalViewSpec.swift */,
+				FCEB554329E54B1D00E60481 /* AlertPresentableSpec.swift */,
 				453D243E26A4DB4900FB9E6A /* FullScreenViewSpec.swift */,
 				453D243F26A4DB4900FB9E6A /* SlideUpViewSpec.swift */,
 				4592B4C827026AF0004FF27B /* Resources */,
@@ -340,6 +345,7 @@
 				453D243526A4ABD000FB9E6A /* modal-image-only.json */,
 				453D243426A4ABD000FB9E6A /* modal-text-image.json */,
 				453D243A26A4B83E00FB9E6A /* modal-controls.json */,
+				FCEB554529E54B3A00E60481 /* modal-controls-invalid-url.json */,
 				453D244226A4DBDC00FB9E6A /* full-controls.json */,
 				453D244326A4DBDC00FB9E6A /* full-image-only.json */,
 				453D244526A4DBDC00FB9E6A /* full-text-image.json */,
@@ -710,6 +716,7 @@
 				4592B4B3270229D1004FF27B /* config.json in Resources */,
 				4592B4CA27026FB7004FF27B /* istockphoto-1047234038.jpg in Resources */,
 				453D245026A4DCD800FB9E6A /* slide-up-trigger.json in Resources */,
+				FCEB554629E54B3A00E60481 /* modal-controls-invalid-url.json in Resources */,
 				453D243726A4ABD000FB9E6A /* modal-text-image.json in Resources */,
 				4592B4BA27024D0C004FF27B /* display-permission.json in Resources */,
 				453D243C26A4B83E00FB9E6A /* modal-controls.json in Resources */,
@@ -768,6 +775,7 @@
 				4592B4B627024925004FF27B /* MockServerHelper.swift in Sources */,
 				453D244026A4DB4900FB9E6A /* FullScreenViewSpec.swift in Sources */,
 				453D242926A0DE5100FB9E6A /* ModalViewSpec.swift in Sources */,
+				FCEB554429E54B1E00E60481 /* AlertPresentableSpec.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/SampleSPM/SampleSPM.xcodeproj/project.pbxproj
+++ b/SampleSPM/SampleSPM.xcodeproj/project.pbxproj
@@ -117,6 +117,7 @@
 		FC92B45D29DD27670053CF0E /* UILabelExtensionSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC92B45C29DD27670053CF0E /* UILabelExtensionSpec.swift */; };
 		FCEB554429E54B1E00E60481 /* AlertPresentableSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCEB554329E54B1D00E60481 /* AlertPresentableSpec.swift */; };
 		FCEB554629E54B3A00E60481 /* modal-controls-invalid-url.json in Resources */ = {isa = PBXBuildFile; fileRef = FCEB554529E54B3A00E60481 /* modal-controls-invalid-url.json */; };
+		FCEB554A29E652BD00E60481 /* slide-up-trigger-invalid-url.json in Resources */ = {isa = PBXBuildFile; fileRef = FCEB554929E652BD00E60481 /* slide-up-trigger-invalid-url.json */; };
 		FCF93D8229C30863000DB8CE /* EventTypeSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCF93D8129C30863000DB8CE /* EventTypeSpec.swift */; };
 /* End PBXBuildFile section */
 
@@ -253,6 +254,7 @@
 		FC92B45C29DD27670053CF0E /* UILabelExtensionSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UILabelExtensionSpec.swift; sourceTree = "<group>"; };
 		FCEB554329E54B1D00E60481 /* AlertPresentableSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AlertPresentableSpec.swift; sourceTree = "<group>"; };
 		FCEB554529E54B3A00E60481 /* modal-controls-invalid-url.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "modal-controls-invalid-url.json"; sourceTree = "<group>"; };
+		FCEB554929E652BD00E60481 /* slide-up-trigger-invalid-url.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "slide-up-trigger-invalid-url.json"; sourceTree = "<group>"; };
 		FCF93D8129C30863000DB8CE /* EventTypeSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EventTypeSpec.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -346,6 +348,7 @@
 				453D243426A4ABD000FB9E6A /* modal-text-image.json */,
 				453D243A26A4B83E00FB9E6A /* modal-controls.json */,
 				FCEB554529E54B3A00E60481 /* modal-controls-invalid-url.json */,
+				FCEB554929E652BD00E60481 /* slide-up-trigger-invalid-url.json */,
 				453D244226A4DBDC00FB9E6A /* full-controls.json */,
 				453D244326A4DBDC00FB9E6A /* full-image-only.json */,
 				453D244526A4DBDC00FB9E6A /* full-text-image.json */,
@@ -713,6 +716,7 @@
 				45ECADE229DD6C91003F75B2 /* slide-up-trigger-without-messageBody.json in Resources */,
 				453D244B26A4DBDC00FB9E6A /* full-text-only.json in Resources */,
 				453D244D26A4DBDC00FB9E6A /* full-text-image.json in Resources */,
+				FCEB554A29E652BD00E60481 /* slide-up-trigger-invalid-url.json in Resources */,
 				4592B4B3270229D1004FF27B /* config.json in Resources */,
 				4592B4CA27026FB7004FF27B /* istockphoto-1047234038.jpg in Resources */,
 				453D245026A4DCD800FB9E6A /* slide-up-trigger.json in Resources */,

--- a/Sources/RInAppMessaging/Views/Presenters/FullViewPresenter.swift
+++ b/Sources/RInAppMessaging/Views/Presenters/FullViewPresenter.swift
@@ -99,8 +99,8 @@ internal class FullViewPresenter: BaseViewPresenter, FullViewPresenterType, Erro
                 return
             }
 
-            UIApplication.shared.open(uriToOpen, options: [:], completionHandler: { success in
-                if !success, let view = self.view {
+            UIApplication.shared.open(uriToOpen, options: [:], completionHandler: { [view] success in
+                if !success, let view = view {
                     self.showURLError(view: view)
                 }
             })

--- a/Sources/RInAppMessaging/Views/Presenters/SlideUpViewPresenter.swift
+++ b/Sources/RInAppMessaging/Views/Presenters/SlideUpViewPresenter.swift
@@ -43,8 +43,8 @@ internal class SlideUpViewPresenter: BaseViewPresenter, SlideUpViewPresenterType
                 return
             }
 
-            UIApplication.shared.open(uriToOpen, options: [:], completionHandler: { success in
-                if !success, let view = self.view {
+            UIApplication.shared.open(uriToOpen, options: [:], completionHandler: { [view] success in
+                if !success, let view = view {
                     self.showURLError(view: view)
                 }
             })

--- a/Tests/UITests/AlertPresentableSpec.swift
+++ b/Tests/UITests/AlertPresentableSpec.swift
@@ -75,8 +75,6 @@ class AlertPresentableSpec: QuickSpec {
                     content.tap()
                     expect(app.alerts.element.staticTexts["Page not found"].exists).to(beTrue())
                     app.alerts.element.buttons["Close"].tap()
-                    iamView.buttons["exitButton"].tap()
-                    expect(iamView.exists).to(beFalse())
                 }
             }
         }

--- a/Tests/UITests/AlertPresentableSpec.swift
+++ b/Tests/UITests/AlertPresentableSpec.swift
@@ -9,9 +9,6 @@ class AlertPresentableSpec: QuickSpec {
 
         var mockServer: MockServer!
         var app: XCUIApplication!
-        var iamView: XCUIElement {
-            app.otherElements.element(matching: NSPredicate(format: "identifier BEGINSWITH[cd] 'IAMView'"))
-        }
 
         func launchAppIfNecessary(context: String) {
             mockServer.setup(route: MockServerHelper.pingRouteMock(jsonStub: context))
@@ -32,11 +29,16 @@ class AlertPresentableSpec: QuickSpec {
 
         afterEach {
             mockServer.stop()
+            app = nil
         }
 
         describe("AlertPresentable") {
 
-            context("with redirect action") {
+            context("with modal view") {
+
+                var iamView: XCUIElement {
+                    app.otherElements.element(matching: NSPredicate(format: "identifier BEGINSWITH[cd] 'IAMView'"))
+                }
 
                 beforeEach {
                     launchAppIfNecessary(context: "modal-controls-invalid-url")
@@ -50,6 +52,32 @@ class AlertPresentableSpec: QuickSpec {
                     iamView.buttons["Button0"].tap()
                     expect(app.alerts.element.staticTexts["Page not found"].exists).to(beTrue())
                     app.alerts.element.buttons["Close"].tap()
+                }
+            }
+
+            context("with slide up view") {
+
+                var iamView: XCUIElement {
+                    app.otherElements["IAMView-SlideUp"]
+                }
+                var content: XCUIElement {
+                    iamView.buttons["bodyMessage"]
+                }
+
+                beforeEach {
+                    launchAppIfNecessary(context: "slide-up-trigger-invalid-url")
+                    if !iamView.exists {
+                        app.buttons["purchase_successful"].tap()
+                        expect(iamView.exists).toEventually(beTrue(), timeout: .seconds(2))
+                    }
+                }
+
+                it("should show error alert after tapping button 1 and close campaign") {
+                    content.tap()
+                    expect(app.alerts.element.staticTexts["Page not found"].exists).to(beTrue())
+                    app.alerts.element.buttons["Close"].tap()
+                    iamView.buttons["exitButton"].tap()
+                    expect(iamView.exists).to(beFalse())
                 }
             }
         }

--- a/Tests/UITests/AlertPresentableSpec.swift
+++ b/Tests/UITests/AlertPresentableSpec.swift
@@ -14,7 +14,7 @@ class AlertPresentableSpec: QuickSpec {
             mockServer.setup(route: MockServerHelper.pingRouteMock(jsonStub: context))
             mockServer.start()
 
-            guard app == nil else {
+            guard app == nil || !app.launchArguments.joined(separator: " ").contains(context) else {
                 return
             }
             app = XCUIApplication()
@@ -29,7 +29,6 @@ class AlertPresentableSpec: QuickSpec {
 
         afterEach {
             mockServer.stop()
-            app = nil
         }
 
         describe("AlertPresentable") {

--- a/Tests/UITests/AlertPresentableSpec.swift
+++ b/Tests/UITests/AlertPresentableSpec.swift
@@ -1,0 +1,57 @@
+import XCTest
+import Quick
+import Nimble
+import class Shock.MockServer
+
+class AlertPresentableSpec: QuickSpec {
+
+    override func spec() {
+
+        var mockServer: MockServer!
+        var app: XCUIApplication!
+        var iamView: XCUIElement {
+            app.otherElements.element(matching: NSPredicate(format: "identifier BEGINSWITH[cd] 'IAMView'"))
+        }
+
+        func launchAppIfNecessary(context: String) {
+            mockServer.setup(route: MockServerHelper.pingRouteMock(jsonStub: context))
+            mockServer.start()
+
+            guard app == nil else {
+                return
+            }
+            app = XCUIApplication()
+            app.launchArguments.append("--uitesting")
+            app.launchArguments.append("-context \(context)")
+            app.launch()
+        }
+
+        beforeEach {
+            mockServer = MockServerHelper.setupNewServer(route: MockServerHelper.standardRouting)
+        }
+
+        afterEach {
+            mockServer.stop()
+        }
+
+        describe("AlertPresentable") {
+
+            context("with redirect action") {
+
+                beforeEach {
+                    launchAppIfNecessary(context: "modal-controls-invalid-url")
+                    if !iamView.exists {
+                        app.buttons["purchase_successful"].tap()
+                        expect(iamView.exists).toEventually(beTrue(), timeout: .seconds(2))
+                    }
+                }
+
+                it("should show error alert after tapping button 1 and close campaign") {
+                    iamView.buttons["Button0"].tap()
+                    expect(app.alerts.element.staticTexts["Page not found"].exists).to(beTrue())
+                    app.alerts.element.buttons["Close"].tap()
+                }
+            }
+        }
+    }
+}

--- a/Tests/UITests/ResponseStubs/modal-controls-invalid-url.json
+++ b/Tests/UITests/ResponseStubs/modal-controls-invalid-url.json
@@ -1,0 +1,88 @@
+{
+    "currentPingMillis": 0,
+    "nextPingMillis": 3600000,
+    "data": [
+        {
+            "campaignData": {
+                "campaignId": "modal-controls-invalid-url",
+                "maxImpressions": 999,
+                "type": 1,
+                "isTest": false,
+                "isCampaignDismissable": true,
+                "hasNoEndDate": false,
+                "infiniteImpressions": true,
+                "triggers": [
+                    {
+                        "type": 1,
+                        "eventType": 3,
+                        "eventName": "purchase_successful",
+                        "attributes": []
+                    }
+                ],
+                "messagePayload": {
+                    "title": "test",
+                    "messageBody": "test test test test test test test test test test test test test test test test test test test test test test test test test test test test test test test test test test test test test test test test test test test test test",
+                    "header": "Test Campaign",
+                    "titleColor": "#000000",
+                    "headerColor": "#000000",
+                    "messageBodyColor": "#000000",
+                    "backgroundColor": "#ffffff",
+                    "frameColor": "#ffffff",
+                    "resource": {
+                        "cropType": 2
+                    },
+                    "messageSettings": {
+                        "displaySettings": {
+                            "slideFrom": 1,
+                            "endTimeMillis": 9999999999999,
+                            "orientation": 1,
+                            "textAlign": 2,
+                            "optOut": true,
+                            "delay": 0,
+                            "html": false
+                        },
+                        "controlSettings": {
+                            "content": {
+                                "campaignTrigger": {
+                                    "type": 1,
+                                    "eventType": 4,
+                                    "eventName": "purchase_successful",
+                                    "attributes": []
+                                },
+                                "onClickBehavior": {
+                                    "action": 1,
+                                    "uri": "invalid_url"
+                                }
+                            },
+                            "buttons": [
+                                {
+                                    "buttonText": "btn1",
+                                    "buttonTextColor": "#000000",
+                                    "buttonBackgroundColor": "#ffffff",
+                                    "buttonBehavior": {
+                                        "action": 1,
+                                        "uri": "invalid-url"
+                                    }
+                                },
+                                {
+                                    "buttonText": "btn2",
+                                    "buttonTextColor": "#000000",
+                                    "buttonBackgroundColor": "#ffffff",
+                                    "buttonBehavior": {
+                                        "action": 1,
+                                        "uri": "https://config.url"
+                                    },
+                                    "campaignTrigger": {
+                                        "type": 1,
+                                        "eventType": 4,
+                                        "eventName": "purchase_successful",
+                                        "attributes": []
+                                    }
+                                }]
+                        }
+                    }
+                }
+            }
+        }
+    ]
+}

--- a/Tests/UITests/ResponseStubs/slide-up-trigger-invalid-url.json
+++ b/Tests/UITests/ResponseStubs/slide-up-trigger-invalid-url.json
@@ -1,0 +1,64 @@
+{
+    "currentPingMillis": 0,
+    "nextPingMillis": 3600000,
+    "data": [
+        {
+            "campaignData": {
+                "campaignId": "slide-up-trigger",
+                "maxImpressions": 999,
+                "type": 3,
+                "isTest": false,
+                "isCampaignDismissable": true,
+                "hasNoEndDate": false,
+                "infiniteImpressions": true,
+                "triggers": [
+                    {
+                        "type": 1,
+                        "eventType": 4,
+                        "eventName": "purchase_successful",
+                        "attributes": []
+                    }
+                ],
+                "messagePayload": {
+                    "title": "test",
+                    "messageBody": "test test test test test test test test test test test test test test test test test test test test test test test test test test test test test test test test test test test test test test test test test test test test test",
+                    "header": "Test Campaign",
+                    "titleColor": "#000000",
+                    "headerColor": "#000000",
+                    "messageBodyColor": "#000000",
+                    "backgroundColor": "#ffffff",
+                    "frameColor": "#ffffff",
+                    "resource": {
+                        "cropType": 2
+                    },
+                    "messageSettings": {
+                        "displaySettings": {
+                            "slideFrom": 1,
+                            "endTimeMillis": 9999999999999,
+                            "orientation": 1,
+                            "textAlign": 2,
+                            "optOut": true,
+                            "delay": 500,
+                            "html": false
+                        },
+                        "controlSettings": {
+                            "content": {
+                                "campaignTrigger": {
+                                    "type": 1,
+                                    "eventType": 4,
+                                    "eventName": "purchase_successful",
+                                    "attributes": []
+                                },
+                                "onClickBehavior": {
+                                    "action": 1,
+                                    "uri": "invalid-url"
+                                }
+                            },
+                            "buttons": []
+                        }
+                    }
+                }
+            }
+        }
+    ]
+}

--- a/Tests/UITests/ResponseStubs/slide-up-trigger-invalid-url.json
+++ b/Tests/UITests/ResponseStubs/slide-up-trigger-invalid-url.json
@@ -4,7 +4,7 @@
     "data": [
         {
             "campaignData": {
-                "campaignId": "slide-up-trigger",
+                "campaignId": "slide-up-trigger-invalid-url",
                 "maxImpressions": 999,
                 "type": 3,
                 "isTest": false,


### PR DESCRIPTION
# Description
- Add a new testing file for AlertPresentable file covering 100% code coverage for this file.
- This PR also covers displaying an alert issue that alerts not showing because of the view being dismissed. I captured the strong reference inside the closure to keep the view to show the alert.

## Links
SDKCF-6375

# Checklist
- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
- [x] I have added to the [changelog](../blob/master/CHANGELOG.md#Unreleased)
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data **before every commit**, including API endpoints and keys, and internal links
- [ ] I ran `fastlane ci` without errors
- [x] All project file changes are replicated in `SampleSPM/SampleSPM.xcodeproj` project
