### PR TITLE
tests: improve code coverage for http requestable (SDKCF-6389)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 		- CampaignDispatcher [SDKCF-6452]
 		- AlertPresentable [SDKCF-6375]
 		- ConfigurationManager [SDKCF-6451]
+		- HTTPRequestable [SDKCF-6389]
 
 ### 7.3.0 (2023-01-11)
 - Features:

--- a/Tests/Tests/HttpRequestableSpec.swift
+++ b/Tests/Tests/HttpRequestableSpec.swift
@@ -26,7 +26,10 @@ class HttpRequestableSpec: QuickSpec {
             }
 
             afterEach {
-                httpRequestable = nil // force deallocation of .httpSessionMock
+                // force deallocation of httpSessionMock
+                httpRequestable.httpSessionMock.responseData = nil
+                httpRequestable.httpSessionMock.responseError = nil
+                httpRequestable.httpSessionMock.sentRequest = nil
             }
 
             context("when calling requestFromServerSync") {
@@ -348,9 +351,9 @@ class HttpRequestableSpec: QuickSpec {
                     }
                 }
 
-                it("will whrow assertion if calling the method on the main thread") {
+                it("will throw assertion if calling the method on the main thread") {
                     expect(httpRequestable.requestFromServerSync(
-                        url: URL(string: "")!,
+                        url: URL(string: "https://test.url")!,
                         httpMethod: .get,
                         parameters: nil,
                         addtionalHeaders: nil)).to(throwAssertion())

--- a/Tests/Tests/HttpRequestableSpec.swift
+++ b/Tests/Tests/HttpRequestableSpec.swift
@@ -320,6 +320,41 @@ class HttpRequestableSpec: QuickSpec {
                         }
                     }
                 }
+
+                it("will using empty string for error message as a default when failed to encode error message as .utf8") {
+                    let data = "テスト".data(using: .japaneseEUC)!
+                    let response = HTTPURLResponse(
+                        url: URL(string: "https://test.url")!,
+                        statusCode: 404,
+                        httpVersion: nil,
+                        headerFields: nil)
+
+                    httpRequestable.httpSessionMock.responseData = data
+                    httpRequestable.httpSessionMock.httpResponse = response
+
+                    waitUntil { done in
+                        requestQueue.async {
+                            let result = httpRequestable.requestFromServerSync(
+                                url: URL(string: "https://test.url")!,
+                                httpMethod: .put,
+                                parameters: nil,
+                                addtionalHeaders: nil)
+
+                            expect {
+                                try result.get()
+                            }.to(throwError())
+                            done()
+                        }
+                    }
+                }
+
+                it("will whrow assertion if calling the method on the main thread") {
+                    expect(httpRequestable.requestFromServerSync(
+                        url: URL(string: "")!,
+                        httpMethod: .get,
+                        parameters: nil,
+                        addtionalHeaders: nil)).to(throwAssertion())
+                }
             }
 
             context("when calling requestFromServer") {

--- a/Tests/Tests/HttpRequestableSpec.swift
+++ b/Tests/Tests/HttpRequestableSpec.swift
@@ -20,13 +20,13 @@ class HttpRequestableSpec: QuickSpec {
 
             let requestQueue = DispatchQueue(label: "iam.test.request")
             var httpRequestable: HttpRequestableObject!
+            let url = URL(string: "https://test.url")!
 
             beforeEach {
                 httpRequestable = HttpRequestableObject()
             }
 
             afterEach {
-                // force deallocation of httpSessionMock
                 httpRequestable.httpSessionMock.responseData = nil
                 httpRequestable.httpSessionMock.responseError = nil
                 httpRequestable.httpSessionMock.sentRequest = nil
@@ -35,7 +35,6 @@ class HttpRequestableSpec: QuickSpec {
             context("when calling requestFromServerSync") {
 
                 it("will send a reqest using provided URL") {
-                    let url = URL(string: "https://test.url")!
                     waitUntil { done in
                         requestQueue.async {
                             _ = httpRequestable.requestFromServerSync(url: url,
@@ -54,7 +53,7 @@ class HttpRequestableSpec: QuickSpec {
                 it("will send a reqest using provided method") {
                     waitUntil { done in
                         requestQueue.async {
-                            _ = httpRequestable.requestFromServerSync(url: URL(string: "https://test.url")!,
+                            _ = httpRequestable.requestFromServerSync(url: url,
                                                                       httpMethod: .put,
                                                                       parameters: nil,
                                                                       addtionalHeaders: nil)
@@ -72,7 +71,7 @@ class HttpRequestableSpec: QuickSpec {
                     httpRequestable.bodyData = data
                     waitUntil { done in
                         requestQueue.async {
-                            _ = httpRequestable.requestFromServerSync(url: URL(string: "https://test.url")!,
+                            _ = httpRequestable.requestFromServerSync(url: url,
                                                                       httpMethod: .put,
                                                                       parameters: nil,
                                                                       addtionalHeaders: nil)
@@ -88,7 +87,7 @@ class HttpRequestableSpec: QuickSpec {
                 it("will always send requests with application/json Content-Type header") {
                     waitUntil { done in
                         requestQueue.async {
-                            _ = httpRequestable.requestFromServerSync(url: URL(string: "https://test.url")!,
+                            _ = httpRequestable.requestFromServerSync(url: url,
                                                                       httpMethod: .put,
                                                                       parameters: nil,
                                                                       addtionalHeaders: nil)
@@ -106,7 +105,7 @@ class HttpRequestableSpec: QuickSpec {
                                     HeaderAttribute(key: "a", value: "2")]
                     waitUntil { done in
                         requestQueue.async {
-                            _ = httpRequestable.requestFromServerSync(url: URL(string: "https://test.url")!,
+                            _ = httpRequestable.requestFromServerSync(url: url,
                                                                       httpMethod: .put,
                                                                       parameters: nil,
                                                                       addtionalHeaders: headers)
@@ -128,7 +127,7 @@ class HttpRequestableSpec: QuickSpec {
                     waitUntil { done in
                         requestQueue.async {
                             let result = httpRequestable.requestFromServerSync(
-                                url: URL(string: "https://test.url")!,
+                                url: url,
                                 httpMethod: .put,
                                 parameters: nil,
                                 addtionalHeaders: nil)
@@ -156,7 +155,7 @@ class HttpRequestableSpec: QuickSpec {
                     waitUntil { done in
                         requestQueue.async {
                             let result = httpRequestable.requestFromServerSync(
-                                url: URL(string: "https://test.url")!,
+                                url: url,
                                 httpMethod: .put,
                                 parameters: nil,
                                 addtionalHeaders: nil)
@@ -183,7 +182,7 @@ class HttpRequestableSpec: QuickSpec {
 
                         httpRequestable.httpSessionMock.responseData = "data".data(using: .ascii)!
                         httpRequestable.httpSessionMock.httpResponse = HTTPURLResponse(
-                            url: URL(string: "https://test.url")!,
+                            url: url,
                             statusCode: Int(code),
                             httpVersion: nil,
                             headerFields: nil)
@@ -191,7 +190,7 @@ class HttpRequestableSpec: QuickSpec {
                         waitUntil { done in
                             requestQueue.async {
                                 let result = httpRequestable.requestFromServerSync(
-                                    url: URL(string: "https://test.url")!,
+                                    url: url,
                                     httpMethod: .put,
                                     parameters: nil,
                                     addtionalHeaders: nil)
@@ -220,7 +219,7 @@ class HttpRequestableSpec: QuickSpec {
                     waitUntil { done in
                         requestQueue.async {
                             let result = httpRequestable.requestFromServerSync(
-                                url: URL(string: "https://test.url")!,
+                                url: url,
                                 httpMethod: .put,
                                 parameters: nil,
                                 addtionalHeaders: nil)
@@ -242,7 +241,7 @@ class HttpRequestableSpec: QuickSpec {
                 it("will return an error if no data was returned") {
                     httpRequestable.httpSessionMock.responseData = nil
                     httpRequestable.httpSessionMock.httpResponse = HTTPURLResponse(
-                        url: URL(string: "https://test.url")!,
+                        url: url,
                         statusCode: 200,
                         httpVersion: nil,
                         headerFields: nil)
@@ -250,7 +249,7 @@ class HttpRequestableSpec: QuickSpec {
                     waitUntil { done in
                         requestQueue.async {
                             let result = httpRequestable.requestFromServerSync(
-                                url: URL(string: "https://test.url")!,
+                                url: url,
                                 httpMethod: .put,
                                 parameters: nil,
                                 addtionalHeaders: nil)
@@ -274,7 +273,7 @@ class HttpRequestableSpec: QuickSpec {
 
                         httpRequestable.httpSessionMock.responseData = "data".data(using: .ascii)!
                         httpRequestable.httpSessionMock.httpResponse = HTTPURLResponse(
-                            url: URL(string: "https://test.url")!,
+                            url: url,
                             statusCode: code,
                             httpVersion: nil,
                             headerFields: nil)
@@ -282,7 +281,7 @@ class HttpRequestableSpec: QuickSpec {
                         waitUntil { done in
                             requestQueue.async {
                                 let result = httpRequestable.requestFromServerSync(
-                                    url: URL(string: "https://test.url")!,
+                                    url: url,
                                     httpMethod: .put,
                                     parameters: nil,
                                     addtionalHeaders: nil)
@@ -299,7 +298,7 @@ class HttpRequestableSpec: QuickSpec {
                 it("will return response and data objects when call succeeded") {
                     let data = "data".data(using: .ascii)!
                     let response = HTTPURLResponse(
-                        url: URL(string: "https://test.url")!,
+                        url: url,
                         statusCode: 200,
                         httpVersion: nil,
                         headerFields: nil)
@@ -310,7 +309,7 @@ class HttpRequestableSpec: QuickSpec {
                     waitUntil { done in
                         requestQueue.async {
                             let result = httpRequestable.requestFromServerSync(
-                                url: URL(string: "https://test.url")!,
+                                url: url,
                                 httpMethod: .put,
                                 parameters: nil,
                                 addtionalHeaders: nil)
@@ -327,7 +326,7 @@ class HttpRequestableSpec: QuickSpec {
                 it("will using empty string for error message as a default when failed to encode error message as .utf8") {
                     let data = "テスト".data(using: .japaneseEUC)!
                     let response = HTTPURLResponse(
-                        url: URL(string: "https://test.url")!,
+                        url: url,
                         statusCode: 404,
                         httpVersion: nil,
                         headerFields: nil)
@@ -338,7 +337,7 @@ class HttpRequestableSpec: QuickSpec {
                     waitUntil { done in
                         requestQueue.async {
                             let result = httpRequestable.requestFromServerSync(
-                                url: URL(string: "https://test.url")!,
+                                url: url,
                                 httpMethod: .put,
                                 parameters: nil,
                                 addtionalHeaders: nil)
@@ -351,9 +350,11 @@ class HttpRequestableSpec: QuickSpec {
                     }
                 }
 
+                // throwAssertion() captures a strong reference to the httpRequestable and never releases it
+                // making it impossible to deallocate the httpSessionMock reusable instance
                 it("will throw assertion if calling the method on the main thread") {
                     expect(httpRequestable.requestFromServerSync(
-                        url: URL(string: "https://test.url")!,
+                        url: url,
                         httpMethod: .get,
                         parameters: nil,
                         addtionalHeaders: nil)).to(throwAssertion())
@@ -363,7 +364,6 @@ class HttpRequestableSpec: QuickSpec {
             context("when calling requestFromServer") {
 
                 it("will send a reqest using provided URL") {
-                    let url = URL(string: "https://test.url")!
                     waitUntil { done in
                         httpRequestable.requestFromServer(url: url,
                                                           httpMethod: .put,
@@ -379,7 +379,7 @@ class HttpRequestableSpec: QuickSpec {
 
                 it("will send a reqest using provided method") {
                     waitUntil { done in
-                        httpRequestable.requestFromServer(url: URL(string: "https://test.url")!,
+                        httpRequestable.requestFromServer(url: url,
                                                           httpMethod: .put,
                                                           parameters: nil,
                                                           addtionalHeaders: nil,
@@ -395,7 +395,7 @@ class HttpRequestableSpec: QuickSpec {
                     let data = "data".data(using: .ascii)!
                     httpRequestable.bodyData = data
                     waitUntil { done in
-                        httpRequestable.requestFromServer(url: URL(string: "https://test.url")!,
+                        httpRequestable.requestFromServer(url: url,
                                                           httpMethod: .put,
                                                           parameters: nil,
                                                           addtionalHeaders: nil,
@@ -409,7 +409,7 @@ class HttpRequestableSpec: QuickSpec {
 
                 it("will always send requests with application/json Content-Type header") {
                     waitUntil { done in
-                        httpRequestable.requestFromServer(url: URL(string: "https://test.url")!,
+                        httpRequestable.requestFromServer(url: url,
                                                           httpMethod: .put,
                                                           parameters: nil,
                                                           addtionalHeaders: nil,
@@ -425,7 +425,7 @@ class HttpRequestableSpec: QuickSpec {
                     let headers = [HeaderAttribute(key: "1", value: "abc"),
                                    HeaderAttribute(key: "a", value: "2")]
                     waitUntil { done in
-                        httpRequestable.requestFromServer(url: URL(string: "https://test.url")!,
+                        httpRequestable.requestFromServer(url: url,
                                                           httpMethod: .put,
                                                           parameters: nil,
                                                           addtionalHeaders: headers,
@@ -446,7 +446,7 @@ class HttpRequestableSpec: QuickSpec {
                     var result: HttpRequestable.RequestResult?
                     waitUntil { done in
                         httpRequestable.requestFromServer(
-                            url: URL(string: "https://test.url")!,
+                            url: url,
                             httpMethod: .put,
                             parameters: nil,
                             addtionalHeaders: nil,
@@ -475,7 +475,7 @@ class HttpRequestableSpec: QuickSpec {
                     var result: HttpRequestable.RequestResult?
                     waitUntil { done in
                         httpRequestable.requestFromServer(
-                            url: URL(string: "https://test.url")!,
+                            url: url,
                             httpMethod: .put,
                             parameters: nil,
                             addtionalHeaders: nil,
@@ -503,7 +503,7 @@ class HttpRequestableSpec: QuickSpec {
 
                         httpRequestable.httpSessionMock.responseData = "data".data(using: .ascii)!
                         httpRequestable.httpSessionMock.httpResponse = HTTPURLResponse(
-                            url: URL(string: "https://test.url")!,
+                            url: url,
                             statusCode: Int(code),
                             httpVersion: nil,
                             headerFields: nil)
@@ -511,7 +511,7 @@ class HttpRequestableSpec: QuickSpec {
                         var result: HttpRequestable.RequestResult?
                         waitUntil { done in
                             httpRequestable.requestFromServer(
-                                url: URL(string: "https://test.url")!,
+                                url: url,
                                 httpMethod: .put,
                                 parameters: nil,
                                 addtionalHeaders: nil,
@@ -541,7 +541,7 @@ class HttpRequestableSpec: QuickSpec {
                     var result: HttpRequestable.RequestResult?
                     waitUntil { done in
                         httpRequestable.requestFromServer(
-                            url: URL(string: "https://test.url")!,
+                            url: url,
                             httpMethod: .put,
                             parameters: nil,
                             addtionalHeaders: nil,
@@ -564,7 +564,7 @@ class HttpRequestableSpec: QuickSpec {
                 it("will return an error if no data was returned") {
                     httpRequestable.httpSessionMock.responseData = nil
                     httpRequestable.httpSessionMock.httpResponse = HTTPURLResponse(
-                        url: URL(string: "https://test.url")!,
+                        url: url,
                         statusCode: 200,
                         httpVersion: nil,
                         headerFields: nil)
@@ -572,7 +572,7 @@ class HttpRequestableSpec: QuickSpec {
                     var result: HttpRequestable.RequestResult?
                     waitUntil { done in
                         httpRequestable.requestFromServer(
-                            url: URL(string: "https://test.url")!,
+                            url: url,
                             httpMethod: .put,
                             parameters: nil,
                             addtionalHeaders: nil,
@@ -597,7 +597,7 @@ class HttpRequestableSpec: QuickSpec {
 
                         httpRequestable.httpSessionMock.responseData = "data".data(using: .ascii)!
                         httpRequestable.httpSessionMock.httpResponse = HTTPURLResponse(
-                            url: URL(string: "https://test.url")!,
+                            url: url,
                             statusCode: code,
                             httpVersion: nil,
                             headerFields: nil)
@@ -605,7 +605,7 @@ class HttpRequestableSpec: QuickSpec {
                         var result: HttpRequestable.RequestResult?
                         waitUntil { done in
                             httpRequestable.requestFromServer(
-                                url: URL(string: "https://test.url")!,
+                                url: url,
                                 httpMethod: .put,
                                 parameters: nil,
                                 addtionalHeaders: nil,
@@ -625,7 +625,7 @@ class HttpRequestableSpec: QuickSpec {
                 it("will return response and data objects when call succeeded") {
                     let data = "data".data(using: .ascii)!
                     let response = HTTPURLResponse(
-                        url: URL(string: "https://test.url")!,
+                        url: url,
                         statusCode: 200,
                         httpVersion: nil,
                         headerFields: nil)
@@ -636,7 +636,7 @@ class HttpRequestableSpec: QuickSpec {
                     var result: HttpRequestable.RequestResult?
                     waitUntil { done in
                         httpRequestable.requestFromServer(
-                            url: URL(string: "https://test.url")!,
+                            url: url,
                             httpMethod: .put,
                             parameters: nil,
                             addtionalHeaders: nil,


### PR DESCRIPTION
# Description
Improve HttpRequestable file code coverage to 97.9%.

This code will never be executed because the completion handler is always called within `requestFromServer` function, considering removing this part will cover this file to 100% code coverage.
```swift
        guard let unwrappedResult = result else {
            Logger.debug("Error: Didn't get any result - completion handler not called!")
            assertionFailure()
            return .failure(.unknown)
        }
```

## Links
SDKCF-6389

# Checklist
- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
- [x] I have added to the [changelog](../blob/master/CHANGELOG.md#Unreleased)
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data **before every commit**, including API endpoints and keys, and internal links
- [ ] I ran `fastlane ci` without errors
- [x] All project file changes are replicated in `SampleSPM/SampleSPM.xcodeproj` project
