### PR TITLE
tests: improve code coverage for Router (SDKCF-6382)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 		- AlertPresentable [SDKCF-6375]
 		- ConfigurationManager [SDKCF-6451]
 		- HTTPRequestable [SDKCF-6389]
+		- Router [SDKCF-6382]
 
 ### 7.3.0 (2023-01-11)
 - Features:

--- a/Sources/RInAppMessaging/Models/Responses/Campaign.swift
+++ b/Sources/RInAppMessaging/Models/Responses/Campaign.swift
@@ -52,10 +52,10 @@ internal struct Campaign: Codable, Hashable {
         try container.encode(isOptedOut, forKey: .isOptedOut)
     }
 
-    init(data: CampaignData, asTooltip isTooltip: Bool = true) {
+    init(data: CampaignData) {
         self.data = data
         impressionsLeft = data.maxImpressions
-        tooltipData = isTooltip ? Campaign.parseTooltipData(messagePayload: data.messagePayload) : nil
+        tooltipData = Campaign.parseTooltipData(messagePayload: data.messagePayload)
     }
 
     static func == (lhs: Campaign, rhs: Campaign) -> Bool {

--- a/Sources/RInAppMessaging/Models/Responses/Campaign.swift
+++ b/Sources/RInAppMessaging/Models/Responses/Campaign.swift
@@ -52,10 +52,10 @@ internal struct Campaign: Codable, Hashable {
         try container.encode(isOptedOut, forKey: .isOptedOut)
     }
 
-    init(data: CampaignData) {
+    init(data: CampaignData, asTooltip isTooltip: Bool = true) {
         self.data = data
         impressionsLeft = data.maxImpressions
-        tooltipData = Campaign.parseTooltipData(messagePayload: data.messagePayload)
+        tooltipData = isTooltip ? Campaign.parseTooltipData(messagePayload: data.messagePayload) : nil
     }
 
     static func == (lhs: Campaign, rhs: Campaign) -> Bool {

--- a/Sources/RInAppMessaging/Router.swift
+++ b/Sources/RInAppMessaging/Router.swift
@@ -43,7 +43,7 @@ internal protocol RouterType: ErrorReportable {
 /// Handles all the displaying logic of the SDK.
 internal class Router: RouterType, ViewListenerObserver {
 
-    private enum UIConstants {
+    enum UIConstants {
         enum Tooltip {
             static let minDistFromEdge: CGFloat = 20.0
             static let targetViewSpacing: CGFloat = 0.0
@@ -313,7 +313,6 @@ internal class Router: RouterType, ViewListenerObserver {
             guard accessibilityCompatibleDisplay,
                let transitionViewClass = NSClassFromString("UITransitionView"),
                let transitionView = superview.subviews.first(where: { !$0.isKind(of: transitionViewClass) }) else {
-                
                 return superview
             }
             return transitionView
@@ -332,9 +331,6 @@ internal class Router: RouterType, ViewListenerObserver {
     }
 
     private func updateFrame(targetView: UIView, tooltipView: TooltipView, superview: UIView, position: TooltipBodyData.Position) {
-        guard targetView.superview != nil else {
-            return
-        }
         let targetViewFrame = superview.convert(targetView.frame, from: targetView.superview)
 
         switch position {

--- a/Sources/RInAppMessaging/Router.swift
+++ b/Sources/RInAppMessaging/Router.swift
@@ -43,7 +43,7 @@ internal protocol RouterType: ErrorReportable {
 /// Handles all the displaying logic of the SDK.
 internal class Router: RouterType, ViewListenerObserver {
 
-    enum UIConstants {
+    private enum UIConstants {
         enum Tooltip {
             static let minDistFromEdge: CGFloat = 20.0
             static let targetViewSpacing: CGFloat = 0.0
@@ -166,19 +166,20 @@ internal class Router: RouterType, ViewListenerObserver {
         var view: (() -> BaseView)!
         let type = campaign.data.type
 
-        if type == .modal || type == .full {
+        switch type {
+        case .modal, .full:
             let presenter = presenter as! FullViewPresenterType
             presenter.campaign = campaign
             if let associatedImageData = associatedImageData {
                 presenter.associatedImage = UIImage(data: associatedImageData)
             }
             view = type == .modal ? { ModalView(presenter: presenter) } : { FullScreenView(presenter: presenter) }
-        }
-
-        if type == .slide {
+        case .slide:
             let presenter = presenter as! SlideUpViewPresenterType
             presenter.campaign = campaign
             view = { SlideUpView(presenter: presenter) }
+        case .invalid, .html:
+            Logger.debug("Error: Campaign view type not supported")
         }
         return view
     }

--- a/Sources/RInAppMessaging/Router.swift
+++ b/Sources/RInAppMessaging/Router.swift
@@ -91,11 +91,10 @@ internal class Router: RouterType, ViewListenerObserver {
         let result = {
             return self.displayedTooltips[uiElementIdentifier] != nil
         }
-        if Thread.current == .main {
-            return result()
-        } else {
+        guard Thread.current == .main else {
             return DispatchQueue.main.sync(execute: result)
         }
+        return result()
     }
 
     func displayCampaign(_ campaign: Campaign,
@@ -293,14 +292,13 @@ internal class Router: RouterType, ViewListenerObserver {
         // For accessibilityCompatible option, campaign view must be inserted to
         // UIWindow's main subview. Private instance of UITransitionView
         // shouldn't be used for that - that's why it's omitted.
-        if accessibilityCompatibleDisplay,
+        
+        guard accessibilityCompatibleDisplay,
            let transitionViewClass = NSClassFromString("UITransitionView"),
-           let mainSubview = rootView.subviews.first(where: { !$0.isKind(of: transitionViewClass) }) {
-
-            return mainSubview
-        } else {
+           let mainSubview = rootView.subviews.first(where: { !$0.isKind(of: transitionViewClass) }) else {
             return rootView
         }
+        return mainSubview
     }
 
     private func findParentViewForTooltip(_ sourceView: UIView) -> UIView {
@@ -312,14 +310,13 @@ internal class Router: RouterType, ViewListenerObserver {
         case is UIScrollView:
             return superview
         case is UIWindow:
-            if accessibilityCompatibleDisplay,
+            guard accessibilityCompatibleDisplay,
                let transitionViewClass = NSClassFromString("UITransitionView"),
-               let transitionView = superview.subviews.first(where: { !$0.isKind(of: transitionViewClass) }) {
-
-                return transitionView
-            } else {
+               let transitionView = superview.subviews.first(where: { !$0.isKind(of: transitionViewClass) }) else {
+                
                 return superview
             }
+            return transitionView
         default:
             return findParentViewForTooltip(superview)
         }

--- a/Tests/Tests/Helpers/TestHelpers.swift
+++ b/Tests/Tests/Helpers/TestHelpers.swift
@@ -84,10 +84,7 @@ struct TestHelpers {
                                 position: TooltipBodyData.Position = .topCenter,
                                 messageBody: String? = nil,
                                 triggers: [Trigger] = []) -> Campaign {
-        let messageBodyContent = messageBody != nil ? messageBody : """
-                    {\"UIElement\" : \"\(targetViewID ?? TooltipViewIdentifierMock)\", \"position\": \"\(position.rawValue)\", \"auto-disappear\": \(autoCloseSeconds), \"redirectURL\": \"\(redirectURL)\"}
-                    """ // swiftlint:disable:previous line_length
-        return Campaign(
+        Campaign(
             data: CampaignData(
                 campaignId: id,
                 maxImpressions: maxImpressions,
@@ -99,7 +96,9 @@ struct TestHelpers {
                 isCampaignDismissable: true,
                 messagePayload: MessagePayload(
                     title: title,
-                    messageBody: messageBodyContent,
+                    messageBody: messageBody ?? """
+                    {\"UIElement\" : \"\(targetViewID ?? TooltipViewIdentifierMock)\", \"position\": \"\(position.rawValue)\", \"auto-disappear\": \(autoCloseSeconds), \"redirectURL\": \"\(redirectURL)\"}
+                    """, // swiftlint:disable:previous line_length
                     header: "testHeader",
                     titleColor: "color",
                     headerColor: "color2",

--- a/Tests/Tests/Helpers/TestHelpers.swift
+++ b/Tests/Tests/Helpers/TestHelpers.swift
@@ -81,7 +81,9 @@ struct TestHelpers {
                                 maxImpressions: Int = 2,
                                 autoCloseSeconds: Int = 0,
                                 redirectURL: String = "",
-                                triggers: [Trigger] = []) -> Campaign {
+                                position: String = "top-center",
+                                triggers: [Trigger] = [],
+                                isTooltip: Bool = true) -> Campaign {
         Campaign(
             data: CampaignData(
                 campaignId: id,
@@ -95,7 +97,7 @@ struct TestHelpers {
                 messagePayload: MessagePayload(
                     title: title,
                     messageBody: """
-                    {\"UIElement\" : \"\(targetViewID ?? TooltipViewIdentifierMock)\", \"position\": \"top-center\", \"auto-disappear\": \(autoCloseSeconds), \"redirectURL\": \"\(redirectURL)\"}
+                    {\"UIElement\" : \"\(targetViewID ?? TooltipViewIdentifierMock)\", \"position\": \"\(position)\", \"auto-disappear\": \(autoCloseSeconds), \"redirectURL\": \"\(redirectURL)\"}
                     """, // swiftlint:disable:previous line_length
                     header: "testHeader",
                     titleColor: "color",
@@ -119,7 +121,8 @@ struct TestHelpers {
                             buttons: [],
                             content: nil))
                 )
-            )
+            ),
+            asTooltip: isTooltip
         )
     }
 

--- a/Tests/Tests/Helpers/TestHelpers.swift
+++ b/Tests/Tests/Helpers/TestHelpers.swift
@@ -81,9 +81,8 @@ struct TestHelpers {
                                 maxImpressions: Int = 2,
                                 autoCloseSeconds: Int = 0,
                                 redirectURL: String = "",
-                                position: String = "top-center",
-                                triggers: [Trigger] = [],
-                                isTooltip: Bool = true) -> Campaign {
+                                position: TooltipBodyData.Position = .topCenter,
+                                triggers: [Trigger] = []) -> Campaign {
         Campaign(
             data: CampaignData(
                 campaignId: id,
@@ -97,7 +96,7 @@ struct TestHelpers {
                 messagePayload: MessagePayload(
                     title: title,
                     messageBody: """
-                    {\"UIElement\" : \"\(targetViewID ?? TooltipViewIdentifierMock)\", \"position\": \"\(position)\", \"auto-disappear\": \(autoCloseSeconds), \"redirectURL\": \"\(redirectURL)\"}
+                    {\"UIElement\" : \"\(targetViewID ?? TooltipViewIdentifierMock)\", \"position\": \"\(position.rawValue)\", \"auto-disappear\": \(autoCloseSeconds), \"redirectURL\": \"\(redirectURL)\"}
                     """, // swiftlint:disable:previous line_length
                     header: "testHeader",
                     titleColor: "color",
@@ -121,8 +120,7 @@ struct TestHelpers {
                             buttons: [],
                             content: nil))
                 )
-            ),
-            asTooltip: isTooltip
+            )
         )
     }
 

--- a/Tests/Tests/Helpers/TestHelpers.swift
+++ b/Tests/Tests/Helpers/TestHelpers.swift
@@ -82,8 +82,12 @@ struct TestHelpers {
                                 autoCloseSeconds: Int = 0,
                                 redirectURL: String = "",
                                 position: TooltipBodyData.Position = .topCenter,
+                                messageBody: String? = nil,
                                 triggers: [Trigger] = []) -> Campaign {
-        Campaign(
+        let messageBodyContent = messageBody != nil ? messageBody : """
+                    {\"UIElement\" : \"\(targetViewID ?? TooltipViewIdentifierMock)\", \"position\": \"\(position.rawValue)\", \"auto-disappear\": \(autoCloseSeconds), \"redirectURL\": \"\(redirectURL)\"}
+                    """ // swiftlint:disable:previous line_length
+        return Campaign(
             data: CampaignData(
                 campaignId: id,
                 maxImpressions: maxImpressions,
@@ -95,9 +99,7 @@ struct TestHelpers {
                 isCampaignDismissable: true,
                 messagePayload: MessagePayload(
                     title: title,
-                    messageBody: """
-                    {\"UIElement\" : \"\(targetViewID ?? TooltipViewIdentifierMock)\", \"position\": \"\(position.rawValue)\", \"auto-disappear\": \(autoCloseSeconds), \"redirectURL\": \"\(redirectURL)\"}
-                    """, // swiftlint:disable:previous line_length
+                    messageBody: messageBodyContent,
                     header: "testHeader",
                     titleColor: "color",
                     headerColor: "color2",

--- a/Tests/Tests/RouterSpec.swift
+++ b/Tests/Tests/RouterSpec.swift
@@ -291,7 +291,13 @@ class RouterSpec: QuickSpec {
                 }
 
                 it("will return false when tooltip identifier is incorrect") {
-                    expect(router.isDisplayingTooltip(with: "test")).to(beFalse())
+                    router.displayTooltip(tooltip, targetView: tooltipTargetView,
+                                          identifier: TooltipViewIdentifierMock,
+                                          imageBlob: imageBlob,
+                                          becameVisibleHandler: { _ in },
+                                          confirmation: true,
+                                          completion: { _ in })
+                    expect(router.isDisplayingTooltip(with: "incorrect_id")).to(beFalse())
                 }
 
                 it("will keep return Bool value when calling the from background thread") {

--- a/Tests/Tests/RouterSpec.swift
+++ b/Tests/Tests/RouterSpec.swift
@@ -392,6 +392,18 @@ class RouterSpec: QuickSpec {
                         window.findIAMView()?.removeFromSuperview()
                     }
 
+                    it("will not display a tooltip campaign with no tooltip data") {
+                        let tooltip = TestHelpers.generateTooltip(id: "test", messageBody: "")
+                        router.displayTooltip(tooltip,
+                                              targetView: targetView,
+                                              identifier: TooltipViewIdentifierMock,
+                                              imageBlob: imageBlob,
+                                              becameVisibleHandler: { _ in },
+                                              confirmation: true,
+                                              completion: { _ in })
+                        expect(window.findTooltipView()).toEventually(beNil())
+                    }
+
                     it("will call completion with false flag when tooltip was closed") {
                         var completionCalled = false
                         router.displayTooltip(tooltip,

--- a/Tests/Tests/RouterSpec.swift
+++ b/Tests/Tests/RouterSpec.swift
@@ -297,6 +297,7 @@ class RouterSpec: QuickSpec {
                                           becameVisibleHandler: { _ in },
                                           confirmation: true,
                                           completion: { _ in })
+                    expect(window.findTooltipView()).toEventuallyNot(beNil())
                     expect(router.isDisplayingTooltip(with: "incorrect_id")).to(beFalse())
                 }
 

--- a/Tests/Tests/RouterSpec.swift
+++ b/Tests/Tests/RouterSpec.swift
@@ -702,20 +702,6 @@ class RouterSpec: QuickSpec {
                         router.viewDidGetRemovedFromSuperview(targetView, identifier: TooltipViewIdentifierMock)
                         expect(displayedTooltip.superview).toEventually(beNil())
                     }
-
-                    it("will remove orientationObserver from NotificationCenter") {
-                        router.displayTooltip(tooltip,
-                                              targetView: targetView,
-                                              identifier: TooltipViewIdentifierMock,
-                                              imageBlob: imageBlob,
-                                              becameVisibleHandler: { _ in },
-                                              confirmation: true,
-                                              completion: { _ in })
-                        expect(window.findTooltipView()).toEventuallyNot(beNil())
-                        var displayedTooltip = window.findTooltipView()!
-                        displayedTooltip.removeFromSuperview()
-                        expect(window.findTooltipView()).toEventually(beNil())
-                    }
                 }
             }
         }

--- a/Tests/Tests/RouterSpec.swift
+++ b/Tests/Tests/RouterSpec.swift
@@ -177,9 +177,8 @@ class RouterSpec: QuickSpec {
                     expect(window.findIAMView()).toEventually(beNil())
                 }
 
-                it("will not remove the campaign that doesn't exist") {
+                it("will not crash when there are no displayed campaigns") {
                     router.discardDisplayedCampaign()
-                    expect(window.findIAMView()).toEventually(beNil())
                 }
 
                 it("will call onDismiss/completion callback with cancelled flag") {
@@ -288,6 +287,10 @@ class RouterSpec: QuickSpec {
                 }
 
                 it("will return false when tooltip is not displayed") {
+                    expect(router.isDisplayingTooltip(with: "test")).to(beFalse())
+                }
+
+                it("will return false when tooltip identifier is incorrect") {
                     expect(router.isDisplayingTooltip(with: "test")).to(beFalse())
                 }
 
@@ -630,6 +633,7 @@ class RouterSpec: QuickSpec {
                             let displayedTooltip = window.findTooltipView()!
                             expect(displayedTooltip.frame.origin).toNot(equal(tooltipLastPosition))
                             tooltipLastPosition = displayedTooltip.frame.origin
+                            displayedTooltip.removeFromSuperview()
                         }
                     }
 


### PR DESCRIPTION
# Description
- Improve Router file code coverage from 89.3 to **97.1%**.
- Doing some refactoring to make the code more testable and I think it needs a QA test to make sure Campaign and Tooltip display correctly as in the previous behavior.

## Links
SDKCF-6382

# Checklist
- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
- [x] I have added to the [changelog](../blob/master/CHANGELOG.md#Unreleased)
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data **before every commit**, including API endpoints and keys, and internal links
- [ ] I ran `fastlane ci` without errors
- [x] All project file changes are replicated in `SampleSPM/SampleSPM.xcodeproj` project
