### PR TITLE
build: update Swift version support for package to 5.7.1, remove version pinning for Swiftlint, add nested rules for Tests (SDKCF-6515)

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -8,6 +8,8 @@ included:
 disabled_rules:
 - identifier_name
 - nesting
+- todo
+- blanket_disable_command
 
 opt_in_rules:
 - empty_count
@@ -43,7 +45,11 @@ file_length:
     ignore_comment_only_lines: true
 
 cyclomatic_complexity:
-    warning: 15
+    warning: 25
     error: 25
+
+large_tuple:
+    warning: 3
+    error: 3
 
 reporter: "xcode"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## Changelog
 
 ### Unreleased
+- **Breaking changes:**
+    - Update Swift version support for package to 5.7.1 [SDKCF-6515]
 - Bug fixes:
 	- Removed "last user" cache to avoid overwriting anonymous user cache during init [SDKCF-6409]
 	- Added display permission service to perform ping on tooltip dispatcher [SDKCF-4964]

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.4
+// swift-tools-version:5.7.1
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -15,12 +15,12 @@ let package = Package(
             targets: ["RInAppMessaging"])
     ],
     dependencies: [
-        .package(name: "RSDKUtils", url: "https://github.com/rakutentech/ios-sdkutils.git", .upToNextMajor(from: "4.0.0"))
+        .package(url: "https://github.com/rakutentech/ios-sdkutils.git", .upToNextMajor(from: "4.0.0"))
     ],
     targets: [
         .target(
             name: "RInAppMessaging",
-            dependencies: [.product(name: "RSDKUtilsMain", package: "RSDKUtils")],
+            dependencies: [.product(name: "RSDKUtilsMain", package: "ios-sdkutils")],
             resources: [.process("Resources")]
         )
     ],

--- a/Podfile
+++ b/Podfile
@@ -7,7 +7,7 @@ project 'RInAppMessaging', 'UITests' => :debug
 
 target 'RInAppMessaging_Example' do
   pod 'RInAppMessaging', :path => '.'
-  pod 'SwiftLint', '~> 0.48.0' # Version 0.49+ requires macOS 12 and Swift 5.6
+  pod 'SwiftLint', '~> 0.50'
   pod 'RSDKUtils', '~> 4.0', :testspecs => ['Nimble', 'TestHelpers']
   pod 'Shock', '~> 6.1.2'
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -23,7 +23,7 @@ PODS:
   - Shock (6.1.3):
     - GRMustache.swift (~> 4.0.1)
     - SwiftNIOHTTP1 (~> 2.40.0)
-  - SwiftLint (0.48.0)
+  - SwiftLint (0.51.0)
   - SwiftNIO (2.40.0):
     - _NIODataStructures (= 2.40.0)
     - CNIOAtomics (= 2.40.0)
@@ -75,7 +75,7 @@ DEPENDENCIES:
   - RSDKUtils/Nimble (~> 4.0)
   - RSDKUtils/TestHelpers (~> 4.0)
   - Shock (~> 6.1.2)
-  - SwiftLint (~> 0.48.0)
+  - SwiftLint (~> 0.50)
 
 SPEC REPOS:
   trunk:
@@ -112,10 +112,10 @@ SPEC CHECKSUMS:
   GRMustache.swift: a6436504284b22b4b05daf5f46f77bd3fe00a9a2
   Nimble: 5316ef81a170ce87baf72dd961f22f89a602ff84
   Quick: 749aa754fd1e7d984f2000fe051e18a3a9809179
-  RInAppMessaging: 8004adf0f7f304025313ea443c43e7312e505c54
+  RInAppMessaging: 9f0f29df36d79aa7a33cf0c5f5e4ff7676840d81
   RSDKUtils: e2a63eb729298706abe02e735436a2586c65e164
   Shock: 34def30d5e729f6c1eea2a5b5c2d024b875af86c
-  SwiftLint: 284cea64b6187c5d6bd83e9a548a64104d546447
+  SwiftLint: 1b7561918a19e23bfed960e40759086e70f4dba5
   SwiftNIO: 829958aab300642625091f82fc2f49cb7cf4ef24
   SwiftNIOConcurrencyHelpers: 697370136789b1074e4535eaae75cbd7f900370e
   SwiftNIOCore: 473fdfe746534d7aa25766916459eeaf6f92ef49
@@ -123,6 +123,6 @@ SPEC CHECKSUMS:
   SwiftNIOHTTP1: ef56706550a1dc135ea69d65215b9941e643c23b
   SwiftNIOPosix: b49af4bdbecaadfadd5c93dfe28594d6722b75e4
 
-PODFILE CHECKSUM: ba836bb3aedb46889c29bc776cf374dc8596080b
+PODFILE CHECKSUM: ab6619ebb1d933652ad9c47b1c330909f098fb41
 
 COCOAPODS: 1.12.1

--- a/README.md
+++ b/README.md
@@ -10,9 +10,12 @@ This module supports iOS 12.0 and above. It has been tested with iOS 12.5 and ab
 
 # Requirements
 
-Xcode 12.5.x or Xcode 13+
+Xcode >= 14.1 is supported.
 
-Swift >= 5.4 is supported.
+Swift >= 5.7.1 is supported.
+
+Xcode >= 14.1 and Swift >= 5.7.1 are required to build RInAppMessaging SDK version 7.4.x.
+[Apple's App Store submission requirement starts April 25, 2023](https://developer.apple.com/news/?id=jd9wcyov)
 
 Note: The SDK may build on earlier Xcode versions but it is not officially supported or tested.
 

--- a/RInAppMessaging.podspec
+++ b/RInAppMessaging.podspec
@@ -7,7 +7,7 @@ Pod::Spec.new do |s|
   s.authors          = 'Rakuten Ecosystem Mobile'
   s.source           = { :git => "https://github.com/rakutentech/ios-inappmessaging.git", :tag => s.version.to_s }  
   s.ios.deployment_target = '12.0'
-  s.swift_versions = ['5.4', '5.5']
+  s.swift_versions = ['5.7.1']
 
   s.dependency 'RSDKUtils', '~> 4.0'
   s.source_files = 'Sources/RInAppMessaging/**/*.swift'

--- a/RInAppMessaging.xcodeproj/project.pbxproj
+++ b/RInAppMessaging.xcodeproj/project.pbxproj
@@ -744,6 +744,7 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "\"${PODS_ROOT}/SwiftLint/swiftlint\" lint --config \"${SRCROOT}/.swiftlint.yml\" --strict\n";
+			shellScript = "\"${PODS_ROOT}/SwiftLint/swiftlint\" lint --strict\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/Tests/.swiftlint.yml
+++ b/Tests/.swiftlint.yml
@@ -1,0 +1,4 @@
+disabled_rules:
+- type_body_length
+- function_body_length
+- force_cast

--- a/Tests/Tests/ViewListenerSpec.swift
+++ b/Tests/Tests/ViewListenerSpec.swift
@@ -262,7 +262,6 @@ private class ViewListenerObserverObject: ViewListenerObserver {
     var wasViewDidChangeSuperviewCalled = false
     var wasViewDidMoveToWindowCalled = false
     var wasViewDidGetRemovedFromSuperview = false
-    // swiftlint:disable:next large_tuple
     var wasViewDidUpdateIdentifierCalledWithArgs: (from: String?, to: String?, view: UIView)?
 
     func viewDidChangeSuperview(_ view: UIView, identifier: String) {


### PR DESCRIPTION
# Description
- Updated Swift version support for package to 5.7.1
- Removed version pinning for Swiftlint
- Added nested rules for Tests target

## Links
[SDKCF-6515](https://jira.rakuten-it.com/jira/browse/SDKCF-6515)

# Checklist
- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
- [x] I have added to the [changelog](../blob/master/CHANGELOG.md#Unreleased)
- [ ] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data **before every commit**, including API endpoints and keys, and internal links
- [ ] I ran `fastlane ci` without errors
- [ ] All project file changes are replicated in `SampleSPM/SampleSPM.xcodeproj` project
