### PR TITLE
fix: fix incorrect alert display (SDKCF-5026)

### DIFF
--- a/Sample/SwiftUI/MainView.swift
+++ b/Sample/SwiftUI/MainView.swift
@@ -46,8 +46,14 @@ struct MainView: View {
                 Button("Init with Tooltip") {
                     initSDK(enableTooltipFeature: true)
                 }
+                .alert(isPresented: $isErrorAlertPresented) {
+                    Alert(title: Text("Error"), message: Text("IAM SDK is already initialized"))
+                }
                 Button("Init w/o Tooltip") {
                     initSDK(enableTooltipFeature: false)
+                }
+                .alert(isPresented: $isOnFinishedAlertPresented) {
+                    Alert(title: Text("Init successful"))
                 }
                 Button("Open modal page") {
                     isPresentSecondView = true
@@ -58,12 +64,6 @@ struct MainView: View {
         .sheet(isPresented: $isPresentSecondView, content: {
             SecondView()
         })
-        .alert(isPresented: $isErrorAlertPresented) {
-            Alert(title: Text("Error"), message: Text("IAM SDK is already initialized"))
-        }
-        .alert(isPresented: $isErrorAlertPresented) {
-            Alert(title: Text("Init successful"))
-        }
     }
 
     private func initSDK(enableTooltipFeature: Bool) {


### PR DESCRIPTION
# Description
Fix incorrect display alert when SDK has been initialized.

## Links
SDKCF-5026

# Checklist
- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
- [ ] I have added to the [changelog](../blob/master/CHANGELOG.md#Unreleased)
- [ ] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data **before every commit**, including API endpoints and keys, and internal links
- [ ] I ran `fastlane ci` without errors
- [ ] All project file changes are replicated in `SampleSPM/SampleSPM.xcodeproj` project
