### PR TITLE
fix: fix incorrect ui for custom event (SDKCF-5026)

### DIFF
--- a/RInAppMessaging.xcodeproj/project.pbxproj
+++ b/RInAppMessaging.xcodeproj/project.pbxproj
@@ -108,6 +108,7 @@
 		FCCEE5E12A11DE2E002ADC8C /* SecondView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCCEE5DD2A11DE2E002ADC8C /* SecondView.swift */; };
 		FCCEE5E22A11DE2E002ADC8C /* TabBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCCEE5DE2A11DE2E002ADC8C /* TabBarView.swift */; };
 		FCCEE5E32A11DE2E002ADC8C /* MainView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCCEE5DF2A11DE2E002ADC8C /* MainView.swift */; };
+		FCD01EB12A1F32F3005BC09A /* View+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCD01EB02A1F32F3005BC09A /* View+Extension.swift */; };
 		FCEB554129E5482200E60481 /* AlertPresentableSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC92B45E29DFC5C10053CF0E /* AlertPresentableSpec.swift */; };
 		FCEB554229E5482F00E60481 /* modal-controls-invalid-url.json in Resources */ = {isa = PBXBuildFile; fileRef = FCCDBF7129E0083A002EE447 /* modal-controls-invalid-url.json */; };
 		FCEB554829E64EC800E60481 /* slide-up-trigger-invalid-url.json in Resources */ = {isa = PBXBuildFile; fileRef = FCEB554729E64EC800E60481 /* slide-up-trigger-invalid-url.json */; };
@@ -253,6 +254,7 @@
 		FCCEE5DD2A11DE2E002ADC8C /* SecondView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SecondView.swift; sourceTree = "<group>"; };
 		FCCEE5DE2A11DE2E002ADC8C /* TabBarView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TabBarView.swift; sourceTree = "<group>"; };
 		FCCEE5DF2A11DE2E002ADC8C /* MainView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MainView.swift; sourceTree = "<group>"; };
+		FCD01EB02A1F32F3005BC09A /* View+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+Extension.swift"; sourceTree = "<group>"; };
 		FCEB554729E64EC800E60481 /* slide-up-trigger-invalid-url.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "slide-up-trigger-invalid-url.json"; sourceTree = "<group>"; };
 		FCF93D7F29C2D359000DB8CE /* EventTypeSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventTypeSpec.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -520,6 +522,7 @@
 			isa = PBXGroup;
 			children = (
 				D24EDF732941459700F9EC5E /* String+Conversion.swift */,
+				FCD01EB02A1F32F3005BC09A /* View+Extension.swift */,
 				FC6C13C22A11D32D00758AF2 /* EventHelper.swift */,
 			);
 			path = Helpers;
@@ -801,6 +804,7 @@
 				FC2CA49B2A0CDE110096EAF7 /* AppStarterViewController.swift in Sources */,
 				FCCEE5E12A11DE2E002ADC8C /* SecondView.swift in Sources */,
 				FCCEE5D92A11DE27002ADC8C /* CustomEventViewController.swift in Sources */,
+				FCD01EB12A1F32F3005BC09A /* View+Extension.swift in Sources */,
 				D24EDF742941459700F9EC5E /* String+Conversion.swift in Sources */,
 				FCCEE5E02A11DE2E002ADC8C /* CustomEventView.swift in Sources */,
 			);

--- a/Sample/Helpers/View+Extension.swift
+++ b/Sample/Helpers/View+Extension.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+#if canImport(UIKit)
+@available(iOS 13.0, *)
+extension View {
+    func hideKeyboard() {
+        UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
+    }
+}
+#endif

--- a/Sample/SwiftUI/CustomEventView.swift
+++ b/Sample/SwiftUI/CustomEventView.swift
@@ -7,8 +7,7 @@ struct CustomEventView: View {
     @State private var isAlertPresented = false
     @State private var isErrorAlertPresented = false
     @State private var eventName: String = ""
-    /// - Note: Init with one empty attribute for UI purpose
-    @State private var attributes = [EventAttribute()]
+    @State private var attributes: [EventAttribute] = []
     @State private var editingTextFieldIndex = 0
 
     var body: some View {
@@ -72,6 +71,7 @@ struct CustomEventView: View {
                 Spacer()
             }
             Button("SEND") {
+                hideKeyboard()
                 sendEvent()
             }.padding()
             Spacer().frame(height: 400)
@@ -79,10 +79,7 @@ struct CustomEventView: View {
         .alert(isPresented: $isErrorAlertPresented, content: {
             Alert(title: Text("Invalid input format"))
         }).onDisappear {
-            /// re-init to reset attribute content and filled with one empty attribute for UI purpose
-            attributes = [
-                EventAttribute()
-            ]
+            attributes = []
             eventName = ""
         }
     }

--- a/SampleSPM/SampleSPM.xcodeproj/project.pbxproj
+++ b/SampleSPM/SampleSPM.xcodeproj/project.pbxproj
@@ -114,6 +114,7 @@
 		D920D8CB2277B965008FB38D /* SecondPageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D920D8CA2277B965008FB38D /* SecondPageViewController.swift */; };
 		D924268722D91C15002F50D3 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = D924268522D91C15002F50D3 /* Localizable.strings */; };
 		D92D1F262224A269008EA748 /* TestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = D92D1F242224A265008EA748 /* TestHelpers.swift */; };
+		FC6E19412A2087FC00B89165 /* View+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC6E19402A2087FC00B89165 /* View+Extension.swift */; };
 		FC817F0D2A0A2D8E00EE3919 /* SecondView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC817F0C2A0A2D8E00EE3919 /* SecondView.swift */; };
 		FC92B45D29DD27670053CF0E /* UILabelExtensionSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC92B45C29DD27670053CF0E /* UILabelExtensionSpec.swift */; };
 		FCCEE5D12A11D4C8002ADC8C /* EventHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCCEE5D02A11D4C7002ADC8C /* EventHelper.swift */; };
@@ -257,6 +258,7 @@
 		D924268622D91C15002F50D3 /* Base */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = Base; path = Base.lproj/Localizable.strings; sourceTree = "<group>"; };
 		D924268822D91C19002F50D3 /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ja; path = ja.lproj/Localizable.strings; sourceTree = "<group>"; };
 		D92D1F242224A265008EA748 /* TestHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestHelpers.swift; sourceTree = "<group>"; };
+		FC6E19402A2087FC00B89165 /* View+Extension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "View+Extension.swift"; sourceTree = "<group>"; };
 		FC817F0C2A0A2D8E00EE3919 /* SecondView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecondView.swift; sourceTree = "<group>"; };
 		FC92B45C29DD27670053CF0E /* UILabelExtensionSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UILabelExtensionSpec.swift; sourceTree = "<group>"; };
 		FCCEE5D02A11D4C7002ADC8C /* EventHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EventHelper.swift; sourceTree = "<group>"; };
@@ -552,6 +554,7 @@
 			isa = PBXGroup;
 			children = (
 				FCCEE5D02A11D4C7002ADC8C /* EventHelper.swift */,
+				FC6E19402A2087FC00B89165 /* View+Extension.swift */,
 				D24EDF782941512D00F9EC5E /* String+Conversion.swift */,
 			);
 			path = Helpers;
@@ -839,6 +842,7 @@
 				D234A747291C63000086AC80 /* MockServerHelper.swift in Sources */,
 				607FACD61AFB9204008FA782 /* AppDelegate.swift in Sources */,
 				D24EDF792941512D00F9EC5E /* String+Conversion.swift in Sources */,
+				FC6E19412A2087FC00B89165 /* View+Extension.swift in Sources */,
 				FCD21A2C29FBBBB50056237E /* TabBarView.swift in Sources */,
 				D24EDF762941506000F9EC5E /* CustomEventViewController.swift in Sources */,
 			);


### PR DESCRIPTION
# Description
Fix incorrect UI for a custom event.
- Remove the initial empty field on the custom view
- Fix the keyboard not hidden when submitting a custom event

## Links
SDKCF-5026

# Checklist
- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
- [x] I have added to the [changelog](../blob/master/CHANGELOG.md#Unreleased)
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data **before every commit**, including API endpoints and keys, and internal links
- [ ] I ran `fastlane ci` without errors
- [x] All project file changes are replicated in `SampleSPM/SampleSPM.xcodeproj` project
