### PR TITLE
fix: fix Tooltip event handling (SDKCF-5025)

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,7 +289,8 @@ let actionButton = UIButton()
 actionButton.accessibilityIdentifier = "tooltip.1"
 ```
 ##### SwiftUI:
-To attach tooltip to a SwiftUI view, use `canHaveTooltip()` modifier.
+To attach tooltip to a SwiftUI view, use `canHaveTooltip()` modifier.  
+**Important:** This modifier must be called AFTER `RInAppMessaging.configure()`. Otherwise the tooltip will not appear.
 ```swift
 import RInAppMessaging
 (...)

--- a/RInAppMessaging.xcodeproj/project.pbxproj
+++ b/RInAppMessaging.xcodeproj/project.pbxproj
@@ -76,7 +76,7 @@
 		45D4DA4F240F5597009B9B37 /* ViewPresenterSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45D4DA4E240F5597009B9B37 /* ViewPresenterSpec.swift */; };
 		45DA01AD23D5831900A27CC6 /* ConfigurationManagerSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45DA01AC23D5831900A27CC6 /* ConfigurationManagerSpec.swift */; };
 		45DC6D0127A33BB300B28C13 /* TooltipDispatcherSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45DC6D0027A33BB300B28C13 /* TooltipDispatcherSpec.swift */; };
-		45DC6D0327A41CE700B28C13 /* TooltipManagerSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45DC6D0227A41CE700B28C13 /* TooltipManagerSpec.swift */; };
+		45DC6D0327A41CE700B28C13 /* TooltipEventSenderSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45DC6D0227A41CE700B28C13 /* TooltipEventSenderSpec.swift */; };
 		45DC6D0527A426C000B28C13 /* ViewListenerSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45DC6D0427A426C000B28C13 /* ViewListenerSpec.swift */; };
 		45DC6D0727A44CA900B28C13 /* TooltipViewSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45DC6D0627A44CA800B28C13 /* TooltipViewSpec.swift */; };
 		45DC6D0927A4501300B28C13 /* TooltipPresenterSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45DC6D0827A4501300B28C13 /* TooltipPresenterSpec.swift */; };
@@ -211,7 +211,7 @@
 		45D4DA4E240F5597009B9B37 /* ViewPresenterSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ViewPresenterSpec.swift; sourceTree = "<group>"; };
 		45DA01AC23D5831900A27CC6 /* ConfigurationManagerSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigurationManagerSpec.swift; sourceTree = "<group>"; };
 		45DC6D0027A33BB300B28C13 /* TooltipDispatcherSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TooltipDispatcherSpec.swift; sourceTree = "<group>"; };
-		45DC6D0227A41CE700B28C13 /* TooltipManagerSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TooltipManagerSpec.swift; sourceTree = "<group>"; };
+		45DC6D0227A41CE700B28C13 /* TooltipEventSenderSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TooltipEventSenderSpec.swift; sourceTree = "<group>"; };
 		45DC6D0427A426C000B28C13 /* ViewListenerSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewListenerSpec.swift; sourceTree = "<group>"; };
 		45DC6D0627A44CA800B28C13 /* TooltipViewSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TooltipViewSpec.swift; sourceTree = "<group>"; };
 		45DC6D0827A4501300B28C13 /* TooltipPresenterSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TooltipPresenterSpec.swift; sourceTree = "<group>"; };
@@ -471,7 +471,7 @@
 				45ADA541247D206B00A9E2A3 /* RouterSpec.swift */,
 				4534947123C6ABF700189A81 /* SerializationSpec.swift */,
 				45DC6D0027A33BB300B28C13 /* TooltipDispatcherSpec.swift */,
-				45DC6D0227A41CE700B28C13 /* TooltipManagerSpec.swift */,
+				45DC6D0227A41CE700B28C13 /* TooltipEventSenderSpec.swift */,
 				45DC6D0827A4501300B28C13 /* TooltipPresenterSpec.swift */,
 				45DC6D0627A44CA800B28C13 /* TooltipViewSpec.swift */,
 				45EA720425B71FA2001B2049 /* UIApplicationExtensionSpec.swift */,
@@ -833,7 +833,7 @@
 				45357AF7245AD49E007D8FDC /* HttpRequestableSpec.swift in Sources */,
 				459B227C245289F300D218CE /* ConfigurationServiceSpec.swift in Sources */,
 				45DA01AD23D5831900A27CC6 /* ConfigurationManagerSpec.swift in Sources */,
-				45DC6D0327A41CE700B28C13 /* TooltipManagerSpec.swift in Sources */,
+				45DC6D0327A41CE700B28C13 /* TooltipEventSenderSpec.swift in Sources */,
 				45DC6D0927A4501300B28C13 /* TooltipPresenterSpec.swift in Sources */,
 				FC92B45B29DBDEBE0053CF0E /* UILabelExtensionSpec.swift in Sources */,
 				4BBE7EAF274F1A6A0039D2BF /* UIFontExtensionSpec.swift in Sources */,

--- a/Sample/SwiftUI/TabBarView.swift
+++ b/Sample/SwiftUI/TabBarView.swift
@@ -14,10 +14,12 @@ struct TabBarView: View {
                     Text("Main")
                 }
                 .accessibility(identifier: "tabbar.button.1")
+                .canHaveTooltipIfAvailable(identifier: "tabbar.button.1")
                 CustomEventView().tabItem {
                     Text("Custom Event")
                 }
                 .accessibility(identifier: "tabbar.button.2")
+                .canHaveTooltipIfAvailable(identifier: "tabbar.button.2")
             }
         }
     }
@@ -27,5 +29,16 @@ struct TabBarView: View {
 struct TabView_Previews: PreviewProvider {
     static var previews: some View {
         TabBarView()
+    }
+}
+
+@available(iOS 13.0, *)
+extension View {
+    func canHaveTooltipIfAvailable(identifier: String) -> some View {
+        if #available(iOS 15.0, *) {
+            return canHaveTooltip(identifier: identifier)
+        } else {
+            return self
+        }
     }
 }

--- a/SampleSPM/SampleSPM.xcodeproj/project.pbxproj
+++ b/SampleSPM/SampleSPM.xcodeproj/project.pbxproj
@@ -64,7 +64,7 @@
 		D234A71A291C62CE0086AC80 /* HttpRequestableSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D234A6EC291C62C90086AC80 /* HttpRequestableSpec.swift */; };
 		D234A71B291C62CE0086AC80 /* MainContainerSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D234A6ED291C62C90086AC80 /* MainContainerSpec.swift */; };
 		D234A71C291C62CE0086AC80 /* RouterSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D234A6EE291C62C90086AC80 /* RouterSpec.swift */; };
-		D234A71D291C62CE0086AC80 /* TooltipManagerSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D234A6EF291C62C90086AC80 /* TooltipManagerSpec.swift */; };
+		D234A71D291C62CE0086AC80 /* TooltipEventSenderSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D234A6EF291C62C90086AC80 /* TooltipEventSenderSpec.swift */; };
 		D234A71E291C62CE0086AC80 /* ViewPresenterSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D234A6F0291C62C90086AC80 /* ViewPresenterSpec.swift */; };
 		D234A71F291C62CE0086AC80 /* HeaderAttributesBuilderSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D234A6F1291C62CA0086AC80 /* HeaderAttributesBuilderSpec.swift */; };
 		D234A720291C62CE0086AC80 /* CustomEventValidationSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D234A6F2291C62CA0086AC80 /* CustomEventValidationSpec.swift */; };
@@ -205,7 +205,7 @@
 		D234A6EC291C62C90086AC80 /* HttpRequestableSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HttpRequestableSpec.swift; sourceTree = "<group>"; };
 		D234A6ED291C62C90086AC80 /* MainContainerSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MainContainerSpec.swift; sourceTree = "<group>"; };
 		D234A6EE291C62C90086AC80 /* RouterSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RouterSpec.swift; sourceTree = "<group>"; };
-		D234A6EF291C62C90086AC80 /* TooltipManagerSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TooltipManagerSpec.swift; sourceTree = "<group>"; };
+		D234A6EF291C62C90086AC80 /* TooltipEventSenderSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TooltipEventSenderSpec.swift; sourceTree = "<group>"; };
 		D234A6F0291C62C90086AC80 /* ViewPresenterSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ViewPresenterSpec.swift; sourceTree = "<group>"; };
 		D234A6F1291C62CA0086AC80 /* HeaderAttributesBuilderSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HeaderAttributesBuilderSpec.swift; sourceTree = "<group>"; };
 		D234A6F2291C62CA0086AC80 /* CustomEventValidationSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CustomEventValidationSpec.swift; sourceTree = "<group>"; };
@@ -510,7 +510,7 @@
 				D234A6EE291C62C90086AC80 /* RouterSpec.swift */,
 				D234A717291C62CE0086AC80 /* SerializationSpec.swift */,
 				D234A6FC291C62CB0086AC80 /* TooltipDispatcherSpec.swift */,
-				D234A6EF291C62C90086AC80 /* TooltipManagerSpec.swift */,
+				D234A6EF291C62C90086AC80 /* TooltipEventSenderSpec.swift */,
 				D234A711291C62CE0086AC80 /* TooltipPresenterSpec.swift */,
 				D234A708291C62CD0086AC80 /* TooltipViewSpec.swift */,
 				D234A709291C62CD0086AC80 /* UIApplicationExtensionSpec.swift */,
@@ -884,7 +884,7 @@
 				D234A744291C62CF0086AC80 /* UIFontExtensionSpec.swift in Sources */,
 				D234A739291C62CF0086AC80 /* CampaignsListManagerSpec.swift in Sources */,
 				D234A72C291C62CF0086AC80 /* ViewSpec.swift in Sources */,
-				D234A71D291C62CE0086AC80 /* TooltipManagerSpec.swift in Sources */,
+				D234A71D291C62CE0086AC80 /* TooltipEventSenderSpec.swift in Sources */,
 				D234A729291C62CF0086AC80 /* ErrorReportableSpec.swift in Sources */,
 				D234A73A291C62CF0086AC80 /* InAppMessagingModuleSpec.swift in Sources */,
 				D234A73D291C62CF0086AC80 /* ConfigurationRepositorySpec.swift in Sources */,

--- a/Sources/RInAppMessaging/DependencyManager/MainContainer.swift
+++ b/Sources/RInAppMessaging/DependencyManager/MainContainer.swift
@@ -80,13 +80,19 @@ internal enum MainContainerFactory {
                                   campaignRepository: manager.resolve(type: CampaignRepositoryType.self)!,
                                   viewListener: manager.resolve(type: ViewListenerType.self)!)
             }),
-            ContainerElement(type: TooltipManagerType.self, factory: {
-                TooltipManager(viewListener: manager.resolve(type: ViewListenerType.self)!,
-                               campaignRepository: manager.resolve(type: CampaignRepositoryType.self)!)
+            ContainerElement(type: TooltipEventSenderType.self, factory: {
+                TooltipEventSender(viewListener: manager.resolve(type: ViewListenerType.self)!,
+                                   campaignRepository: manager.resolve(type: CampaignRepositoryType.self)!)
             }),
             ContainerElement(type: ViewListenerType.self, factory: {
                 ViewListener.currentInstance
-            })]
+            }),
+            ContainerElement(type: SwiftUIViewEventHandlerType.self, factory: {
+                SwiftUIViewEventHandler(router: manager.resolve(type: RouterType.self)!,
+                                        dispatcher: manager.resolve(type: TooltipDispatcherType.self)!,
+                                        eventSender: manager.resolve(type: TooltipEventSenderType.self)!)
+            })
+        ]
 
         // transient containers
         elements.append(contentsOf: [

--- a/Sources/RInAppMessaging/Events/ViewAppearedEvent.swift
+++ b/Sources/RInAppMessaging/Events/ViewAppearedEvent.swift
@@ -3,7 +3,7 @@ import Foundation
 /// A special event for internal handling of Tooltip display cycle
 internal class ViewAppearedEvent: Event {
 
-    let viewIdentifier: String
+    internal let viewIdentifier: String
 
     init(viewIdentifier: String) {
         self.viewIdentifier = viewIdentifier

--- a/Sources/RInAppMessaging/Extensions/View+IAM.swift
+++ b/Sources/RInAppMessaging/Extensions/View+IAM.swift
@@ -2,7 +2,7 @@ import Foundation
 import SwiftUI
 
 @available(iOS 13.0, *)
-extension View {
+internal extension View {
     /// Hide or show the view based on a boolean value.
     ///
     /// Example for visibility:
@@ -26,5 +26,13 @@ extension View {
         } else {
             self
         }
+    }
+}
+
+@available(iOS 15.0, *)
+public extension View {
+    func canHaveTooltip(identifier: String) -> some View {
+        RInAppMessaging.notifyIfModuleNotInitialized()
+        return modifier(TooltipViewModifier(identifier: identifier))
     }
 }

--- a/Sources/RInAppMessaging/Tooltip/SwiftUIViewEventHandler.swift
+++ b/Sources/RInAppMessaging/Tooltip/SwiftUIViewEventHandler.swift
@@ -1,0 +1,37 @@
+import Foundation
+import UIKit
+
+internal protocol SwiftUIViewEventHandlerType: AnyObject {
+    func didAppear(identifier: String)
+    func didDisappear(identifier: String)
+    func didCreateTooltipView(_ tooltipView: TooltipView, identifier: String)
+}
+
+// This class handles SwiftUI tooltip target view events.
+internal final class SwiftUIViewEventHandler: SwiftUIViewEventHandlerType {
+
+    private let router: RouterType
+    private let dispatcher: TooltipDispatcherType
+    private let eventSender: TooltipEventSenderType
+
+    init(router: RouterType,
+         dispatcher: TooltipDispatcherType,
+         eventSender: TooltipEventSenderType) {
+        self.router = router
+        self.dispatcher = dispatcher
+        self.eventSender = eventSender
+    }
+
+    func didCreateTooltipView(_ tooltipView: TooltipView, identifier: String) {
+        dispatcher.registerSwiftUITooltip(identifier: identifier, uiView: tooltipView)
+    }
+
+    func didAppear(identifier: String) {
+        dispatcher.refreshActiveTooltip(identifier: identifier, targetView: nil) // restore undismissed tooltip
+        eventSender.verifySwiftUIViewAppearance(identifier: identifier)
+    }
+
+    func didDisappear(identifier: String) {
+        router.hideDisplayedTooltip(with: identifier)
+    }
+}

--- a/Sources/RInAppMessaging/Tooltip/TooltipEventSender.swift
+++ b/Sources/RInAppMessaging/Tooltip/TooltipEventSender.swift
@@ -1,11 +1,11 @@
 import Foundation
 import class UIKit.UIView
 
-protocol TooltipManagerType: AnyObject {
-    func verifySwiftUITooltip(identifier: String)
+protocol TooltipEventSenderType: AnyObject {
+    func verifySwiftUIViewAppearance(identifier: String)
 }
 
-class TooltipManager: TooltipManagerType, ViewListenerObserver, CampaignRepositoryDelegate {
+class TooltipEventSender: TooltipEventSenderType, ViewListenerObserver, CampaignRepositoryDelegate {
 
     private let viewListener: ViewListenerType
     private let campaignRepository: CampaignRepositoryType
@@ -20,7 +20,7 @@ class TooltipManager: TooltipManagerType, ViewListenerObserver, CampaignReposito
         viewListener.addObserver(self)
     }
 
-    func verifySwiftUITooltip(identifier: String) {
+    func verifySwiftUIViewAppearance(identifier: String) {
         guard let tooltip = campaignRepository.tooltipsList.first(where: {
                   guard let tooltipData = $0.tooltipData else {
                       return false
@@ -35,7 +35,7 @@ class TooltipManager: TooltipManagerType, ViewListenerObserver, CampaignReposito
         RInAppMessaging.logEvent(ViewAppearedEvent(viewIdentifier: identifier))
     }
 
-    private func verify(view: UIView, identifier: String) {
+    private func verifyAppearance(of view: UIView, identifier: String) {
         guard view.superview != nil,
               let tooltip = campaignRepository.tooltipsList.first(where: {
                   guard let tooltipData = $0.tooltipData else {
@@ -56,24 +56,24 @@ class TooltipManager: TooltipManagerType, ViewListenerObserver, CampaignReposito
 }
 
 // MARK: - CampaignRepositoryDelegate
-extension TooltipManager {
+extension TooltipEventSender {
 
     func didUpdateCampaignList() {
         viewListener.iterateOverDisplayedViews { view, identifier, _ in
-            self.verify(view: view, identifier: identifier)
+            self.verifyAppearance(of: view, identifier: identifier)
         }
     }
 }
 
 // MARK: - ViewListenerObserver
-extension TooltipManager {
+extension TooltipEventSender {
 
     func viewDidChangeSuperview(_ view: UIView, identifier: String) {
-        verify(view: view, identifier: identifier)
+        verifyAppearance(of: view, identifier: identifier)
     }
 
     func viewDidMoveToWindow(_ view: UIView, identifier: String) {
-        verify(view: view, identifier: identifier)
+        verifyAppearance(of: view, identifier: identifier)
     }
 
     func viewDidGetRemovedFromSuperview(_ view: UIView, identifier: String) {
@@ -84,6 +84,6 @@ extension TooltipManager {
         guard let identifier = to else {
             return
         }
-        verify(view: view, identifier: identifier)
+        verifyAppearance(of: view, identifier: identifier)
     }
 }

--- a/Sources/RInAppMessaging/Tooltip/ViewListener.swift
+++ b/Sources/RInAppMessaging/Tooltip/ViewListener.swift
@@ -24,6 +24,7 @@ internal protocol ViewListenerObserver: AnyObject {
 /// A class responsible for tracking UIView changes in the hierarchy.
 /// All changes are reported to registered ViewListenerObserver objects.
 /// This class is based on swizzling and MUST be used as a singleton to aviod unexpected behaviour.
+/// - Note: SwiftUI owned windows are not supported.
 internal final class ViewListener: ViewListenerType {
 
     // A static singleton-like value is necessary for UIView methods to access this class

--- a/Tests/Tests/EventMatcherSpec.swift
+++ b/Tests/Tests/EventMatcherSpec.swift
@@ -267,7 +267,7 @@ class EventMatcherSpec: QuickSpec {
                     eventMatcher.matchAndStore(event: AppStartEvent())
                     eventMatcher.matchAndStore(event: LoginSuccessfulEvent())
                     eventMatcher.matchAndStore(event: CustomEvent(withName: "customEventTest", withCustomAttributes: []))
-                    expect(eventMatcher.containsAllMatchedEvents(for: testCampaign)).to(beTrue())
+                    expect(eventMatcher.containsAllRequiredEvents(for: testCampaign)).to(beTrue())
                 }
 
                 it("will return true if more events than required were stored") {
@@ -276,16 +276,16 @@ class EventMatcherSpec: QuickSpec {
                     eventMatcher.matchAndStore(event: LoginSuccessfulEvent())
                     eventMatcher.matchAndStore(event: PurchaseSuccessfulEvent())
                     eventMatcher.matchAndStore(event: CustomEvent(withName: "customEventTest", withCustomAttributes: []))
-                    expect(eventMatcher.containsAllMatchedEvents(for: testCampaign)).to(beTrue())
+                    expect(eventMatcher.containsAllRequiredEvents(for: testCampaign)).to(beTrue())
                 }
 
                 it("will return false if not all required events were stored") {
                     eventMatcher.matchAndStore(event: AppStartEvent())
-                    expect(eventMatcher.containsAllMatchedEvents(for: testCampaign)).to(beFalse())
+                    expect(eventMatcher.containsAllRequiredEvents(for: testCampaign)).to(beFalse())
                 }
 
                 it("will return false if none of required events were stored") {
-                    expect(eventMatcher.containsAllMatchedEvents(for: testCampaign)).to(beFalse())
+                    expect(eventMatcher.containsAllRequiredEvents(for: testCampaign)).to(beFalse())
                 }
 
                 it("will return false campaign has no triggers (which is an invalid state)") {
@@ -293,7 +293,7 @@ class EventMatcherSpec: QuickSpec {
                     campaignRepository.list = [campaign]
                     eventMatcher.matchAndStore(event: AppStartEvent())
                     eventMatcher.matchAndStore(event: LoginSuccessfulEvent())
-                    expect(eventMatcher.containsAllMatchedEvents(for: campaign)).to(beFalse())
+                    expect(eventMatcher.containsAllRequiredEvents(for: campaign)).to(beFalse())
                 }
 
                 context("with a tooltip") {
@@ -304,19 +304,19 @@ class EventMatcherSpec: QuickSpec {
                     it("will return false if has all events matching triggers but without matching ViewAppearedEvent") {
                         eventMatcher.matchAndStore(event: AppStartEvent())
                         eventMatcher.matchAndStore(event: LoginSuccessfulEvent())
-                        expect(eventMatcher.containsAllMatchedEvents(for: testTooltip)).to(beFalse())
+                        expect(eventMatcher.containsAllRequiredEvents(for: testTooltip)).to(beFalse())
                     }
 
                     it("will return false if has matching ViewAppearedEvent but without events matching triggers") {
                         eventMatcher.matchAndStore(event: ViewAppearedEvent(viewIdentifier: TooltipViewIdentifierMock))
-                        expect(eventMatcher.containsAllMatchedEvents(for: testTooltip)).to(beFalse())
+                        expect(eventMatcher.containsAllRequiredEvents(for: testTooltip)).to(beFalse())
                     }
 
                     it("will return true if all required events are stored") {
                         eventMatcher.matchAndStore(event: AppStartEvent())
                         eventMatcher.matchAndStore(event: ViewAppearedEvent(viewIdentifier: TooltipViewIdentifierMock))
                         eventMatcher.matchAndStore(event: LoginSuccessfulEvent())
-                        expect(eventMatcher.containsAllMatchedEvents(for: testTooltip)).to(beTrue())
+                        expect(eventMatcher.containsAllRequiredEvents(for: testTooltip)).to(beTrue())
                     }
                 }
             }

--- a/Tests/Tests/Helpers/SharedMocks.swift
+++ b/Tests/Tests/Helpers/SharedMocks.swift
@@ -117,7 +117,7 @@ class EventMatcherMock: EventMatcherType {
 
     func matchedEvents(for campaign: Campaign) -> [Event] { return [] }
 
-    func containsAllMatchedEvents(for campaign: Campaign) -> Bool {
+    func containsAllRequiredEvents(for: Campaign) -> Bool {
         simulateMatchingSuccess
     }
 

--- a/Tests/Tests/Helpers/SharedMocks.swift
+++ b/Tests/Tests/Helpers/SharedMocks.swift
@@ -336,6 +336,7 @@ class RouterMock: RouterType {
     var displayedCampaignsCount = 0
     var wasDiscardCampaignCalled = false
     var wasDisplayCampaignCalled = false
+    var wasHideTooltipCalled = false
     var lastIdentifierOfDiscardedTooltip: String?
     var displayTime = TimeInterval(0.1)
     weak var errorDelegate: ErrorDelegate?
@@ -415,6 +416,10 @@ class RouterMock: RouterType {
 
     func isDisplayingTooltip(with uiElementIdentifier: String) -> Bool {
         false
+    }
+
+    func hideDisplayedTooltip(with uiElementIdentifier: String) {
+        wasHideTooltipCalled = true
     }
 }
 
@@ -551,6 +556,7 @@ final class UNUserNotificationCenterMock: RemoteNotificationRequestable {
 }
 
 final class TooltipDispatcherMock: TooltipDispatcherType {
+
     private(set) var needsDisplayTooltips = [Campaign]()
     weak var delegate: TooltipDispatcherDelegate?
 
@@ -559,6 +565,9 @@ final class TooltipDispatcherMock: TooltipDispatcherType {
     }
 
     func registerSwiftUITooltip(identifier: String, uiView: TooltipView) {
+    }
+
+    func refreshActiveTooltip(identifier: String, targetView: UIView?) {
     }
 }
 

--- a/Tests/Tests/MainContainerSpec.swift
+++ b/Tests/Tests/MainContainerSpec.swift
@@ -39,8 +39,9 @@ class MainContainerSpec: QuickSpec {
                     dependencyManager.resolve(type: UserDataCacheable.self),
                     dependencyManager.resolve(type: ViewListenerType.self),
                     dependencyManager.resolve(type: TooltipDispatcherType.self),
-                    dependencyManager.resolve(type: TooltipManagerType.self),
-                    dependencyManager.resolve(type: TooltipPresenterType.self)
+                    dependencyManager.resolve(type: TooltipEventSenderType.self),
+                    dependencyManager.resolve(type: TooltipPresenterType.self),
+                    dependencyManager.resolve(type: SwiftUIViewEventHandlerType.self)
                 ]
             }
 

--- a/Tests/Tests/TooltipDispatcherSpec.swift
+++ b/Tests/Tests/TooltipDispatcherSpec.swift
@@ -164,7 +164,7 @@ class TooltipDispatcherSpec: QuickSpec {
 
                 it("will remove the tooltip from queue") {
                     router.completeDisplayingTooltip(cancelled: false)
-                    expect(dispatcher.queuedTooltips).toEventuallyNot(contain(tooltip))
+                    expect(dispatcher.activeTooltips).toEventuallyNot(contain(tooltip))
                 }
             }
 

--- a/Tests/Tests/TooltipEventSenderSpec.swift
+++ b/Tests/Tests/TooltipEventSenderSpec.swift
@@ -5,12 +5,12 @@ import class UIKit.UIView
 
 @testable import RInAppMessaging
 
-class TooltipManagerSpec: QuickSpec {
+class TooltipEventSenderSpec: QuickSpec {
 
     override func spec() {
-        describe("TooltipManager") {
+        describe("TooltipEventSender") {
 
-            var manager: TooltipManager!
+            var eventSender: TooltipEventSender!
             var iamModule: InAppMessagingModuleMock!
             var viewListener: ViewListenerMock!
             var campaignRepository: CampaignRepositoryMock!
@@ -19,8 +19,8 @@ class TooltipManagerSpec: QuickSpec {
                 viewListener = ViewListenerMock()
                 iamModule = InAppMessagingModuleMock()
                 campaignRepository = CampaignRepositoryMock()
-                manager = TooltipManager(viewListener: viewListener,
-                                         campaignRepository: campaignRepository)
+                eventSender = TooltipEventSender(viewListener: viewListener,
+                                             campaignRepository: campaignRepository)
                 RInAppMessaging.setModule(iamModule)
             }
 
@@ -31,7 +31,7 @@ class TooltipManagerSpec: QuickSpec {
             context("when calling didUpdateCampaignList") {
 
                 it("will iterate over displayed views") {
-                    manager.didUpdateCampaignList()
+                    eventSender.didUpdateCampaignList()
                     expect(viewListener.wasIterateOverDisplayedViewsCalled).to(beTrue())
                 }
 
@@ -46,7 +46,7 @@ class TooltipManagerSpec: QuickSpec {
                     viewListener.displayedViews = [view1, view2]
                     campaignRepository.list = [TestHelpers.generateTooltip(id: "test")]
 
-                    manager.didUpdateCampaignList()
+                    eventSender.didUpdateCampaignList()
                     expect(iamModule.loggedEvent).toEventuallyNot(beNil())
                     expect(iamModule.loggedEvent?.type).to(equal(.viewAppeared))
                     expect((iamModule.loggedEvent as? ViewAppearedEvent)?.viewIdentifier).to(equal(TooltipViewIdentifierMock))
@@ -55,7 +55,7 @@ class TooltipManagerSpec: QuickSpec {
 
             context("when calling viewDidChangeSuperview") {
                 it("will not iterate over displayed views") {
-                    manager.viewDidChangeSuperview(UIView(), identifier: "id")
+                    eventSender.viewDidChangeSuperview(UIView(), identifier: "id")
                     expect(viewListener.wasIterateOverDisplayedViewsCalled).to(beFalse())
                 }
 
@@ -66,7 +66,7 @@ class TooltipManagerSpec: QuickSpec {
                     superview.addSubview(view)
                     campaignRepository.list = [TestHelpers.generateTooltip(id: "test")]
 
-                    manager.viewDidChangeSuperview(view, identifier: TooltipViewIdentifierMock)
+                    eventSender.viewDidChangeSuperview(view, identifier: TooltipViewIdentifierMock)
                     expect(iamModule.loggedEvent).toEventuallyNot(beNil())
                     expect(iamModule.loggedEvent?.type).to(equal(.viewAppeared))
                     expect((iamModule.loggedEvent as? ViewAppearedEvent)?.viewIdentifier).to(equal(TooltipViewIdentifierMock))
@@ -75,7 +75,7 @@ class TooltipManagerSpec: QuickSpec {
 
             context("when calling viewDidMoveToWindow") {
                 it("will not iterate over displayed views") {
-                    manager.viewDidMoveToWindow(UIView(), identifier: "id")
+                    eventSender.viewDidMoveToWindow(UIView(), identifier: "id")
                     expect(viewListener.wasIterateOverDisplayedViewsCalled).to(beFalse())
                 }
 
@@ -86,7 +86,7 @@ class TooltipManagerSpec: QuickSpec {
                     superview.addSubview(view)
                     campaignRepository.list = [TestHelpers.generateTooltip(id: "test")]
 
-                    manager.viewDidMoveToWindow(view, identifier: TooltipViewIdentifierMock)
+                    eventSender.viewDidMoveToWindow(view, identifier: TooltipViewIdentifierMock)
                     expect(iamModule.loggedEvent).toEventuallyNot(beNil())
                     expect(iamModule.loggedEvent?.type).to(equal(.viewAppeared))
                     expect((iamModule.loggedEvent as? ViewAppearedEvent)?.viewIdentifier).to(equal(TooltipViewIdentifierMock))
@@ -95,7 +95,7 @@ class TooltipManagerSpec: QuickSpec {
 
             context("when calling viewDidUpdateIdentifier") {
                 it("will not iterate over displayed views") {
-                    manager.viewDidUpdateIdentifier(from: nil, to: "id", view: UIView())
+                    eventSender.viewDidUpdateIdentifier(from: nil, to: "id", view: UIView())
                     expect(viewListener.wasIterateOverDisplayedViewsCalled).to(beFalse())
                 }
 
@@ -106,7 +106,7 @@ class TooltipManagerSpec: QuickSpec {
                     superview.addSubview(view)
                     campaignRepository.list = [TestHelpers.generateTooltip(id: "test")]
 
-                    manager.viewDidUpdateIdentifier(from: "old-id", to: TooltipViewIdentifierMock, view: view)
+                    eventSender.viewDidUpdateIdentifier(from: "old-id", to: TooltipViewIdentifierMock, view: view)
                     expect(iamModule.loggedEvent).toEventuallyNot(beNil())
                     expect(iamModule.loggedEvent?.type).to(equal(.viewAppeared))
                     expect((iamModule.loggedEvent as? ViewAppearedEvent)?.viewIdentifier).to(equal(TooltipViewIdentifierMock))


### PR DESCRIPTION
# Description
This PR fixes issue with tooltip campaigns appearing too many times (UIKit) or not appearing again when view was reloaded (SwiftUI)

## Links
SDKCF-5025

# Checklist
- [X] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
- [X] I have added to the [changelog](../blob/master/CHANGELOG.md#Unreleased)
- [X] I wrote/updated tests for new/changed code
- [X] I removed all sensitive data **before every commit**, including API endpoints and keys, and internal links
- [X] I ran `fastlane ci` without errors
- [X] All project file changes are replicated in `SampleSPM/SampleSPM.xcodeproj` project
