### PR TITLE
fix: fix sdkversion retrieval for spm (SDKCF-6622)

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -10,7 +10,7 @@ Create pull request to make the following changes:
 1. Update version number in `openapi.yaml`
 1. Update version number in `.jazzy.yaml`
 1. Update version number in `RInAppMessaging.podspec`
-1. Update version number in `Sources/RInAppMessaging/RInAppMessaging/Constants.swift` under `sdkVersion` constant
+1. Update version number in `Sources/RInAppMessaging/Constants.swift` under `sdkVersion` constant
 1. Add version number to `_versions` file
 
 ## Deploy

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -10,7 +10,7 @@ Create pull request to make the following changes:
 1. Update version number in `openapi.yaml`
 1. Update version number in `.jazzy.yaml`
 1. Update version number in `RInAppMessaging.podspec`
-1. Update version number in `Sources/RInAppMessaging/Resources/Versions.plist` under `IAMCurrentModuleVersion` key
+1. Update version number in `Sources/RInAppMessaging/RInAppMessaging/Constants.swift` under `sdkVersion` constant
 1. Add version number to `_versions` file
 
 ## Deploy

--- a/RInAppMessaging.xcodeproj/project.pbxproj
+++ b/RInAppMessaging.xcodeproj/project.pbxproj
@@ -99,6 +99,7 @@
 		D92D1F262224A269008EA748 /* TestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = D92D1F242224A265008EA748 /* TestHelpers.swift */; };
 		E686BF522A2692CD00D4E3E9 /* TooltipViewSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = E686BF512A2692CD00D4E3E9 /* TooltipViewSpec.swift */; };
 		E686BF562A2692DD00D4E3E9 /* tooltip-data.json in Resources */ = {isa = PBXBuildFile; fileRef = E686BF532A2692DD00D4E3E9 /* tooltip-data.json */; };
+		FC22BEE82A4153AD004F637B /* ConstantSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC22BEE72A4153AD004F637B /* ConstantSpec.swift */; };
 		FC2CA49B2A0CDE110096EAF7 /* AppStarterViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC2CA49A2A0CDE110096EAF7 /* AppStarterViewController.swift */; };
 		FC6C13C32A11D32D00758AF2 /* EventHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC6C13C22A11D32D00758AF2 /* EventHelper.swift */; };
 		FC92B45B29DBDEBE0053CF0E /* UILabelExtensionSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC92B45A29DBDEBE0053CF0E /* UILabelExtensionSpec.swift */; };
@@ -245,6 +246,7 @@
 		D9F418282110FD9F00E2158F /* ConfigurationSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigurationSpec.swift; sourceTree = "<group>"; };
 		E686BF512A2692CD00D4E3E9 /* TooltipViewSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TooltipViewSpec.swift; sourceTree = "<group>"; };
 		E686BF532A2692DD00D4E3E9 /* tooltip-data.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "tooltip-data.json"; sourceTree = "<group>"; };
+		FC22BEE72A4153AD004F637B /* ConstantSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConstantSpec.swift; sourceTree = "<group>"; };
 		FC2CA49A2A0CDE110096EAF7 /* AppStarterViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppStarterViewController.swift; sourceTree = "<group>"; };
 		FC6C13C22A11D32D00758AF2 /* EventHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventHelper.swift; sourceTree = "<group>"; };
 		FC92B45A29DBDEBE0053CF0E /* UILabelExtensionSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UILabelExtensionSpec.swift; sourceTree = "<group>"; };
@@ -448,6 +450,7 @@
 				4557A8B0257E544C00C9D241 /* AccountRepositorySpec.swift */,
 				C9827557262C423C00476505 /* BackoffSpec.swift */,
 				45B3CC8327871C01005BA3F7 /* BundleSpec.swift */,
+				FC22BEE72A4153AD004F637B /* ConstantSpec.swift */,
 				45563B0624064D78004EAFD3 /* CampaignRepositorySpec.swift */,
 				45BDFD022421D311004DEA0C /* CampaignsListManagerSpec.swift */,
 				D92D1F2122249833008EA748 /* CampaignsValidatorSpec.swift */,
@@ -864,6 +867,7 @@
 				45DC6D0727A44CA900B28C13 /* TooltipViewSpec.swift in Sources */,
 				459DE86C2407B5750002F451 /* CustomEventValidationSpec.swift in Sources */,
 				45563B0724064D78004EAFD3 /* CampaignRepositorySpec.swift in Sources */,
+				FC22BEE82A4153AD004F637B /* ConstantSpec.swift in Sources */,
 				455FEBE227F214640064470D /* UIColorExtensionSpec.swift in Sources */,
 				456FE1EB2428C51E00304872 /* CommonUtilitySpec.swift in Sources */,
 				4538BAE326282DE4009952BE /* ConfigEndpointResponseSpec.swift in Sources */,

--- a/SampleSPM/SampleSPM.xcodeproj/project.pbxproj
+++ b/SampleSPM/SampleSPM.xcodeproj/project.pbxproj
@@ -116,6 +116,7 @@
 		D92D1F262224A269008EA748 /* TestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = D92D1F242224A265008EA748 /* TestHelpers.swift */; };
 		E6DDD1222A2F3A44005365DA /* TooltipViewSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6DDD1212A2F3A44005365DA /* TooltipViewSpec.swift */; };
 		E6DDD1242A2F3A64005365DA /* tooltip-data.json in Resources */ = {isa = PBXBuildFile; fileRef = E6DDD1232A2F3A64005365DA /* tooltip-data.json */; };
+		FC22BEEA2A4155AD004F637B /* ConstantSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC22BEE92A4155AD004F637B /* ConstantSpec.swift */; };
 		FC6E19412A2087FC00B89165 /* View+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC6E19402A2087FC00B89165 /* View+Extension.swift */; };
 		FC817F0D2A0A2D8E00EE3919 /* SecondView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC817F0C2A0A2D8E00EE3919 /* SecondView.swift */; };
 		FC92B45D29DD27670053CF0E /* UILabelExtensionSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC92B45C29DD27670053CF0E /* UILabelExtensionSpec.swift */; };
@@ -262,6 +263,7 @@
 		D92D1F242224A265008EA748 /* TestHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestHelpers.swift; sourceTree = "<group>"; };
 		E6DDD1212A2F3A44005365DA /* TooltipViewSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TooltipViewSpec.swift; sourceTree = "<group>"; };
 		E6DDD1232A2F3A64005365DA /* tooltip-data.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "tooltip-data.json"; sourceTree = "<group>"; };
+		FC22BEE92A4155AD004F637B /* ConstantSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConstantSpec.swift; sourceTree = "<group>"; };
 		FC6E19402A2087FC00B89165 /* View+Extension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "View+Extension.swift"; sourceTree = "<group>"; };
 		FC817F0C2A0A2D8E00EE3919 /* SecondView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecondView.swift; sourceTree = "<group>"; };
 		FC92B45C29DD27670053CF0E /* UILabelExtensionSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UILabelExtensionSpec.swift; sourceTree = "<group>"; };
@@ -487,6 +489,7 @@
 				D234A6FA291C62CB0086AC80 /* AccountRepositorySpec.swift */,
 				D234A700291C62CB0086AC80 /* BackoffSpec.swift */,
 				D234A6EA291C62C90086AC80 /* BundleSpec.swift */,
+				FC22BEE92A4155AD004F637B /* ConstantSpec.swift */,
 				D234A6F7291C62CA0086AC80 /* CampaignRepositorySpec.swift */,
 				D234A70B291C62CD0086AC80 /* CampaignsListManagerSpec.swift */,
 				D234A714291C62CE0086AC80 /* CampaignsValidatorSpec.swift */,
@@ -902,6 +905,7 @@
 				D234A73D291C62CF0086AC80 /* ConfigurationRepositorySpec.swift in Sources */,
 				D92D1F262224A269008EA748 /* TestHelpers.swift in Sources */,
 				D234A734291C62CF0086AC80 /* CommonUtilitySpec.swift in Sources */,
+				FC22BEEA2A4155AD004F637B /* ConstantSpec.swift in Sources */,
 				D234A719291C62CE0086AC80 /* ImpressionServiceSpec.swift in Sources */,
 				D234A722291C62CF0086AC80 /* CustomAttributeSpec.swift in Sources */,
 				D234A721291C62CF0086AC80 /* ConfigEndpointResponseSpec.swift in Sources */,

--- a/Sources/RInAppMessaging/Constants.swift
+++ b/Sources/RInAppMessaging/Constants.swift
@@ -44,7 +44,7 @@ internal enum Constants {
     }
 
     enum Versions {
-        static let sdkVersionKey = "IAMCurrentModuleVersion"
+        static let sdkVersion = "8.1.0-snapshot"
     }
 
     enum RAnalytics {

--- a/Sources/RInAppMessaging/Resources/Versions.plist
+++ b/Sources/RInAppMessaging/Resources/Versions.plist
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-	<key>IAMCurrentModuleVersion</key>
-	<string>8.1.0-snapshot</string>
-</dict>
-</plist>

--- a/Sources/RInAppMessaging/Services/ConfigurationService.swift
+++ b/Sources/RInAppMessaging/Services/ConfigurationService.swift
@@ -77,17 +77,17 @@ internal struct ConfigurationService: ConfigurationServiceType, HttpRequestable 
 extension ConfigurationService {
     private func getConfigRequest() throws -> GetConfigRequest {
         guard let appVersion = bundleInfo.appVersion,
-              let appId = bundleInfo.applicationId,
-              let sdkVersion = bundleInfo.inAppSdkVersion else {
+              let appId = bundleInfo.applicationId else {
             Logger.debug("failed creating a request body")
             throw RequestError.missingMetadata
         }
+        
         return GetConfigRequest(
             locale: Locale.current.normalizedIdentifier,
             appVersion: appVersion,
             platform: .ios,
             appId: appId,
-            sdkVersion: sdkVersion
+            sdkVersion: Constants.Versions.sdkVersion
         )
     }
 

--- a/Sources/RInAppMessaging/Services/DisplayPermissionService.swift
+++ b/Sources/RInAppMessaging/Services/DisplayPermissionService.swift
@@ -83,9 +83,7 @@ extension DisplayPermissionService {
     func buildHttpBody(with parameters: [String: Any]?) -> Result<Data, Error> {
 
         guard let subscriptionId = configurationRepository.getSubscriptionID(),
-              let appVersion = bundleInfo.appVersion,
-              let sdkVersion = bundleInfo.inAppSdkVersion
-        else {
+              let appVersion = bundleInfo.appVersion else {
             Logger.debug("error while building request body for display permssion - missing metadata")
             return .failure(RequestError.missingMetadata)
         }
@@ -99,7 +97,7 @@ extension DisplayPermissionService {
                                                          userIdentifiers: accountRepository.getUserIdentifiers(),
                                                          platform: .ios,
                                                          appVersion: appVersion,
-                                                         sdkVersion: sdkVersion,
+                                                         sdkVersion: Constants.Versions.sdkVersion,
                                                          locale: Locale.current.normalizedIdentifier,
                                                          lastPingInMilliseconds: campaignRepository.lastSyncInMilliseconds ?? 0)
         do {

--- a/Sources/RInAppMessaging/Services/ImpressionService.swift
+++ b/Sources/RInAppMessaging/Services/ImpressionService.swift
@@ -108,8 +108,7 @@ extension ImpressionService {
 
     func buildHttpBody(with parameters: [String: Any]?) -> Result<Data, Error> {
 
-        guard let appVersion = bundleInfo.appVersion,
-              let sdkVersion = bundleInfo.inAppSdkVersion
+        guard let appVersion = bundleInfo.appVersion
         else {
             reportError(description: "Error building impressions request body", data: nil)
             return .failure(RequestError.missingMetadata)
@@ -120,12 +119,11 @@ extension ImpressionService {
             reportError(description: "Error building impressions request body", data: nil)
             return .failure(RequestError.missingParameters)
         }
-
         let impressionRequest = ImpressionRequest(
             campaignId: campaign.campaignId,
             isTest: campaign.isTest,
             appVersion: appVersion,
-            sdkVersion: sdkVersion,
+            sdkVersion: Constants.Versions.sdkVersion,
             impressions: impressions,
             userIdentifiers: accountRepository.getUserIdentifiers()
         )

--- a/Sources/RInAppMessaging/Utilities/BundleInfo.swift
+++ b/Sources/RInAppMessaging/Utilities/BundleInfo.swift
@@ -20,16 +20,6 @@ internal class BundleInfo {
         bundle.infoDictionary?["CFBundleShortVersionString"] as? String
     }
 
-    class var inAppSdkVersion: String? {
-        guard let versionsPlistURL = Bundle.sdkAssets?.url(forResource: "Versions", withExtension: "plist"),
-              let plistData = try? Data(contentsOf: versionsPlistURL),
-              let versions = try? PropertyListSerialization.propertyList(from: plistData, format: nil) as? [String: Any] else {
-                  assertionFailure("Can't read Versions.plist in Resources folder")
-                  return nil
-              }
-        return versions[Constants.Versions.sdkVersionKey] as? String
-    }
-
     class var inAppSubscriptionId: String? {
         bundle.infoDictionary?[Constants.Info.subscriptionIDKey] as? String
     }

--- a/Tests/Tests/BundleSpec.swift
+++ b/Tests/Tests/BundleSpec.swift
@@ -26,12 +26,6 @@ class BundleSpec: QuickSpec {
                 expect(bundleInfo.appVersion).to(equal("1.2.3"))
             }
 
-            it("should return a valid inAppSdkVersion") {
-                // swiftlint:disable:next line_length
-                let semverRegex = #"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$"#
-                expect(bundleInfo.inAppSdkVersion).to(match(semverRegex))
-            }
-
             it("should return expected inAppSubscriptionId") {
                 bundleMock.infoDictionaryMock[Constants.Info.subscriptionIDKey] = "sub-id"
                 expect(bundleInfo.inAppSubscriptionId).to(equal("sub-id"))

--- a/Tests/Tests/ConfigurationServiceSpec.swift
+++ b/Tests/Tests/ConfigurationServiceSpec.swift
@@ -301,7 +301,7 @@ class ConfigurationServiceSpec: QuickSpec {
                     expect(request?.appVersion).to(equal(BundleInfoMock.appVersion))
                     expect(request?.platform).to(equal(.ios))
                     expect(request?.appId).to(equal(BundleInfoMock.applicationId))
-                    expect(request?.sdkVersion).to(equal(BundleInfoMock.inAppSdkVersion))
+                    expect(request?.sdkVersion).to(equal(Constants.Versions.sdkVersion))
                 }
 
                 it("will send subscription id in header") {
@@ -341,11 +341,6 @@ class ConfigurationServiceSpec: QuickSpec {
 
                     it("will return RequestError.missingMetadata error if application id is missing") {
                         BundleInfoMock.applicationIdMock = nil
-                        makeRequestAndEvaluateMetadataError()
-                    }
-
-                    it("will return RequestError.missingMetadata error if sdk version is missing") {
-                        BundleInfoMock.inAppSdkVersionMock = nil
                         makeRequestAndEvaluateMetadataError()
                     }
 

--- a/Tests/Tests/ConstantSpec.swift
+++ b/Tests/Tests/ConstantSpec.swift
@@ -1,0 +1,20 @@
+import Foundation
+import Quick
+import Nimble
+@testable import RInAppMessaging
+
+class ConstantSpec: QuickSpec {
+
+    override func spec() {
+        describe("Constant") {
+
+            let constant = Constants.self
+
+            it("should return a valid inAppSdkVersion") {
+                // swiftlint:disable:next line_length
+                let semverRegex = #"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$"#
+                expect(constant.Versions.sdkVersion).to(match(semverRegex))
+            }
+        }
+    }
+}

--- a/Tests/Tests/DisplayPermissionServiceSpec.swift
+++ b/Tests/Tests/DisplayPermissionServiceSpec.swift
@@ -234,7 +234,7 @@ class DisplayPermissionServiceSpec: QuickSpec {
                     expect(request?.campaignId).to(equal(campaign.id))
                     expect(request?.platform).to(equal(.ios))
                     expect(request?.appVersion).to(equal(BundleInfoMock.appVersion))
-                    expect(request?.sdkVersion).to(equal(BundleInfoMock.inAppSdkVersion))
+                    expect(request?.sdkVersion).to(equal(Constants.Versions.sdkVersion))
                     expect(request?.locale).to(equal(Locale.current.normalizedIdentifier))
                     expect(request?.lastPingInMilliseconds).to(equal(111))
                 }
@@ -288,15 +288,6 @@ class DisplayPermissionServiceSpec: QuickSpec {
 
                     it("will return RequestError.missingMetadata error if host app version is missing") {
                         BundleInfoMock.appVersionMock = nil
-
-                        sendRequestAndWaitForResponse()
-
-                        let error = service.lastResponse?.getError()
-                        evaluateMetadataError(error)
-                    }
-
-                    it("will return RequestError.missingMetadata error if sdk version is missing") {
-                        BundleInfoMock.inAppSdkVersionMock = nil
 
                         sendRequestAndWaitForResponse()
 

--- a/Tests/Tests/Helpers/SharedMocks.swift
+++ b/Tests/Tests/Helpers/SharedMocks.swift
@@ -285,13 +285,11 @@ class ImpressionServiceMock: ImpressionServiceType {
 class BundleInfoMock: BundleInfo {
     static var applicationIdMock: String? = "app.id"
     static var appVersionMock: String? = "1.2.3"
-    static var inAppSdkVersionMock: String? = "0.0.5"
     static var customFontMock: String? = "blank-Bold"
 
     static func reset() {
         applicationIdMock = "app.id"
         appVersionMock = "1.2.3"
-        inAppSdkVersionMock = "0.0.5"
         customFontMock = "blank-Bold"
     }
 
@@ -301,10 +299,6 @@ class BundleInfoMock: BundleInfo {
 
     override class var appVersion: String? {
         appVersionMock
-    }
-
-    override class var inAppSdkVersion: String? {
-        inAppSdkVersionMock
     }
 
     override class var customFontNameTitle: String? {

--- a/Tests/Tests/ImpressionServiceSpec.swift
+++ b/Tests/Tests/ImpressionServiceSpec.swift
@@ -183,7 +183,7 @@ class ImpressionServiceSpec: QuickSpec {
                     let request = httpSession.decodeSentData(modelType: ImpressionRequest.self)
                     expect(request?.campaignId).to(equal(campaign.id))
                     expect(request?.appVersion).to(equal(BundleInfoMock.appVersion))
-                    expect(request?.sdkVersion).to(equal(BundleInfoMock.inAppSdkVersion))
+                    expect(request?.sdkVersion).to(equal(Constants.Versions.sdkVersion))
                 }
 
                 it("will send impressions in the request") {
@@ -279,13 +279,6 @@ class ImpressionServiceSpec: QuickSpec {
 
                 it("will return RequestError.missingMetadata error if host app version is missing") {
                     BundleInfoMock.appVersionMock = nil
-
-                    let error = service.buildHttpBody(with: nil).getError() as? RequestError
-                    evaluateMetadataError(error)
-                }
-
-                it("will return RequestError.missingMetadata error if sdk version is missing") {
-                    BundleInfoMock.inAppSdkVersionMock = nil
 
                     let error = service.buildHttpBody(with: nil).getError() as? RequestError
                     evaluateMetadataError(error)

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -22,6 +22,26 @@ platform :ios do
     sh 'git config --global --unset url."https://github.com/".insteadOf'
   end
 
+  desc "Commit version bump in _versions"
+    lane :commit_sdk_ver_bump do |options|
+      target_version = options[:version]
+      UI.user_error!("version param must be passed in") unless !target_version.to_s.empty?
+      replacing = "static let sdkVersion = \"#{target_version}\""
+      regex = "static let sdkVersion = .*"
+      constant_file = "Constants.swift"
+      sh "find .. -type f -name '#{constant_file}' -exec sed -i '' -e 's/#{regex}/#{replacing}/g' {} ';'"
+      if target_version["snapshot"]
+        UI.message "Skipping docs version bump because of snapshot version"
+      else
+        sh "echo #{target_version} >>../_versions 2>&1"
+      end
+      update_marketing_version(version_number: target_version, xcodeproj: './RInAppMessaging.xcodeproj')
+      version_bump_podspec(path: "RInAppMessaging.podspec", version_number: target_version)
+      git_commit(
+        path: ["./Sources/RInAppMessaging/Constants.swift", "_versions", "RInAppMessaging.podspec", "RInAppMessaging.xcodeproj/project.pbxproj"],
+        message: "chore: bump sdkVersion to #{target_version}")
+    end
+
   lane :run_xcov do
     xcov(
       workspace: "RInAppMessaging.xcworkspace",

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -22,25 +22,25 @@ platform :ios do
     sh 'git config --global --unset url."https://github.com/".insteadOf'
   end
 
-  desc "Commit version bump in _versions"
-    lane :commit_sdk_ver_bump do |options|
-      target_version = options[:version]
-      UI.user_error!("version param must be passed in") unless !target_version.to_s.empty?
-      replacing = "static let sdkVersion = \"#{target_version}\""
-      regex = "static let sdkVersion = .*"
-      constant_file = "Constants.swift"
-      sh "find .. -type f -name '#{constant_file}' -exec sed -i '' -e 's/#{regex}/#{replacing}/g' {} ';'"
-      if target_version["snapshot"]
-        UI.message "Skipping docs version bump because of snapshot version"
-      else
-        sh "echo #{target_version} >>../_versions 2>&1"
-      end
-      update_marketing_version(version_number: target_version, xcodeproj: './RInAppMessaging.xcodeproj')
-      version_bump_podspec(path: "RInAppMessaging.podspec", version_number: target_version)
-      git_commit(
-        path: ["./Sources/RInAppMessaging/Constants.swift", "_versions", "RInAppMessaging.podspec", "RInAppMessaging.xcodeproj/project.pbxproj"],
-        message: "chore: bump sdkVersion to #{target_version}")
+  desc "Commit version bump in Constants, podspec"
+  lane :commit_sdk_ver_bump do |options|
+    target_version = options[:version]
+    UI.user_error!("version param must be passed in") unless !target_version.to_s.empty?
+    replacing = "static let sdkVersion = \"#{target_version}\""
+    regex = "static let sdkVersion = .*"
+    constant_file = "Constants.swift"
+    sh "find .. -type f -name '#{constant_file}' -exec sed -i '' -e 's/#{regex}/#{replacing}/g' {} ';'"
+    if target_version["snapshot"]
+      UI.message "Skipping docs version bump because of snapshot version"
+    else
+      sh "echo #{target_version} >>../_versions 2>&1"
     end
+    update_marketing_version(version_number: target_version, xcodeproj: './RInAppMessaging.xcodeproj')
+    version_bump_podspec(path: "RInAppMessaging.podspec", version_number: target_version)
+    git_commit(
+      path: ["./Sources/RInAppMessaging/Constants.swift", "_versions", "RInAppMessaging.podspec", "RInAppMessaging.xcodeproj/project.pbxproj"],
+      message: "chore: bump sdkVersion to #{target_version}")
+  end
 
   lane :run_xcov do
     xcov(


### PR DESCRIPTION
# Description
Fixing the version retrieval for IAM SDK when using Swift Package Manager.

## Links
SDKCF-6622

# Checklist
- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
- [x] I have added to the [changelog](../blob/master/CHANGELOG.md#Unreleased)
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data **before every commit**, including API endpoints and keys, and internal links
- [ ] I ran `fastlane ci` without errors
- [x] All project file changes are replicated in `SampleSPM/SampleSPM.xcodeproj` project
