### PR TITLE
chore: bump sdk version to 8.1.0-snapshot (SDKCF-6551)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Changelog
 
+### Unreleased
+
 ### 8.0.0 (2023-06-21)
 - **Breaking changes:**
     - Update Swift version support for package to 5.7.1 [SDKCF-6515]

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -8,7 +8,7 @@ PODS:
   - GRMustache.swift (4.0.1)
   - Nimble (10.0.0)
   - Quick (5.0.1)
-  - RInAppMessaging (8.0.0):
+  - RInAppMessaging (8.1.0-snapshot):
     - RSDKUtils (~> 4.0)
   - RSDKUtils (4.0.0):
     - RSDKUtils/Main (= 4.0.0)
@@ -112,7 +112,7 @@ SPEC CHECKSUMS:
   GRMustache.swift: a6436504284b22b4b05daf5f46f77bd3fe00a9a2
   Nimble: 5316ef81a170ce87baf72dd961f22f89a602ff84
   Quick: 749aa754fd1e7d984f2000fe051e18a3a9809179
-  RInAppMessaging: c53d5ccc5d2f818a2cd6897c68622a12e1158cdc
+  RInAppMessaging: b82c9a138ea061954f121a5188d187e3cf84a7f6
   RSDKUtils: e2a63eb729298706abe02e735436a2586c65e164
   Shock: 34def30d5e729f6c1eea2a5b5c2d024b875af86c
   SwiftLint: 1b7561918a19e23bfed960e40759086e70f4dba5

--- a/RInAppMessaging.podspec
+++ b/RInAppMessaging.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'RInAppMessaging'
-  s.version          = '8.0.0'
+  s.version          = '8.1.0-snapshot'
   s.summary          = 'Rakuten module to manage and display in-app messages'
   s.homepage         = 'https://github.com/rakutentech/ios-inappmessaging'
   s.license          = { :type => 'MIT', :file => 'LICENSE' }

--- a/Sources/RInAppMessaging/Resources/Versions.plist
+++ b/Sources/RInAppMessaging/Resources/Versions.plist
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>IAMCurrentModuleVersion</key>
-	<string>8.0.0</string>
+	<string>8.1.0-snapshot</string>
 </dict>
 </plist>


### PR DESCRIPTION
# Description
Snapshot update

## Links
(SDKCF-6551)

# Checklist
- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
- [x ] I have added to the [changelog](../blob/master/CHANGELOG.md#Unreleased)
- [ ] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data **before every commit**, including API endpoints and keys, and internal links
- [ ] I ran `fastlane ci` without errors
- [ ] All project file changes are replicated in `SampleSPM/SampleSPM.xcodeproj` project
