### PR TITLE
improve: send device id in all RAT events (SDKCF-6625)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Unreleased
 - Features:
 	- Added User preference input in Sample App [SDKCF-6641]
+	- Added device_id to all the RAT events [SDKCF-6625]
 
 ### 8.0.0 (2023-06-21)
 - **Breaking changes:**

--- a/Sources/RInAppMessaging/Constants.swift
+++ b/Sources/RInAppMessaging/Constants.swift
@@ -47,9 +47,9 @@ internal enum Constants {
         static let sdkVersion = "8.1.0-snapshot"
     }
 
-    enum RAnalytics {
-        static let impressionsEventName = "_rem_iam_impressions"
-        static let pushPrimerEventName = "_rem_iam_pushprimer"
+    enum RAnalytics: String {
+        case impressionsEventName = "_rem_iam_impressions"
+        case pushPrimerEventName = "_rem_iam_pushprimer"
 
         enum Keys {
             static let action = "action"
@@ -58,6 +58,7 @@ internal enum Constants {
             static let campaignID = "campaign_id"
             static let subscriptionID = "subscription_id"
             static let pushPermission = "push_permission"
+            static let deviceID = "device_id"
         }
     }
 

--- a/Sources/RInAppMessaging/Extensions/UIDevice+IAM.swift
+++ b/Sources/RInAppMessaging/Extensions/UIDevice+IAM.swift
@@ -1,0 +1,8 @@
+import class UIKit.UIDevice
+
+/// Extension to `UIDevice` class to provide addtional initializers required by InAppMessaging.
+internal extension UIDevice {
+    static var deviceID: String? {
+        current.identifierForVendor?.uuidString
+    }
+}

--- a/Sources/RInAppMessaging/Services/ImpressionService.swift
+++ b/Sources/RInAppMessaging/Services/ImpressionService.swift
@@ -1,11 +1,5 @@
 import Foundation
 
-#if SWIFT_PACKAGE
-import class RSDKUtilsMain.AnalyticsBroadcaster
-#else
-import class RSDKUtils.AnalyticsBroadcaster
-#endif
-
 internal protocol ImpressionServiceType: ErrorReportable {
     func pingImpression(impressions: [Impression], campaignData: CampaignData)
 }
@@ -53,7 +47,7 @@ internal class ImpressionService: ImpressionServiceType, HttpRequestable, TaskSc
         // Broadcast impression data to RAnalytics.
         // `impression` type is sent separately, just after campaign is displayed.
         let impressionData = impressions.filter({ $0.type != .impression }).encodeForAnalytics()
-        AnalyticsBroadcaster.sendEventName(Constants.RAnalytics.impressionsEventName,
+        AnalyticsTracker.sendEventName(Constants.RAnalytics.impressionsEventName,
                                            dataObject: [Constants.RAnalytics.Keys.impressions: impressionData,
                                                         Constants.RAnalytics.Keys.campaignID: campaignData.campaignId,
                                                         Constants.RAnalytics.Keys.subscriptionID: configurationRepository.getSubscriptionID() ?? "n/a"])

--- a/Sources/RInAppMessaging/Services/ImpressionService.swift
+++ b/Sources/RInAppMessaging/Services/ImpressionService.swift
@@ -48,9 +48,9 @@ internal class ImpressionService: ImpressionServiceType, HttpRequestable, TaskSc
         // `impression` type is sent separately, just after campaign is displayed.
         let impressionData = impressions.filter({ $0.type != .impression }).encodeForAnalytics()
         AnalyticsTracker.sendEventName(Constants.RAnalytics.impressionsEventName,
-                                           dataObject: [Constants.RAnalytics.Keys.impressions: impressionData,
-                                                        Constants.RAnalytics.Keys.campaignID: campaignData.campaignId,
-                                                        Constants.RAnalytics.Keys.subscriptionID: configurationRepository.getSubscriptionID() ?? "n/a"])
+                                       dataObject: [Constants.RAnalytics.Keys.impressions: impressionData,
+                                                    Constants.RAnalytics.Keys.campaignID: campaignData.campaignId,
+                                                    Constants.RAnalytics.Keys.subscriptionID: configurationRepository.getSubscriptionID() ?? "n/a"])
         
         sendImpressionRequest(endpoint: impressionEndpoint, parameters: parameters)
     }

--- a/Sources/RInAppMessaging/Utilities/AnalyticsTracker.swift
+++ b/Sources/RInAppMessaging/Utilities/AnalyticsTracker.swift
@@ -7,9 +7,9 @@ import class RSDKUtils.AnalyticsBroadcaster
 #endif
 
 internal struct AnalyticsTracker {
-    static func sendEventName(_ name: Constants.RAnalytics, dataObject: [String: Any]? = nil) {
-        var eventData = dataObject ?? [:]
-        eventData[Constants.RAnalytics.Keys.deviceID] = UIDevice.current.identifierForVendor?.uuidString
+    static func sendEventName(_ name: Constants.RAnalytics, dataObject: [String: Any] = [:]) {
+        var eventData = dataObject
+        eventData[Constants.RAnalytics.Keys.deviceID] = UIDevice.deviceID
         AnalyticsBroadcaster.sendEventName(name.rawValue,
                                            dataObject: eventData)
     }

--- a/Sources/RInAppMessaging/Utilities/AnalyticsTracker.swift
+++ b/Sources/RInAppMessaging/Utilities/AnalyticsTracker.swift
@@ -1,0 +1,16 @@
+import class UIKit.UIDevice
+
+#if SWIFT_PACKAGE
+import class RSDKUtilsMain.AnalyticsBroadcaster
+#else
+import class RSDKUtils.AnalyticsBroadcaster
+#endif
+
+internal struct AnalyticsTracker {
+    static func sendEventName(_ name: Constants.RAnalytics, dataObject: [String: Any]? = nil) {
+        var eventData = dataObject ?? [:]
+        eventData[Constants.RAnalytics.Keys.deviceID] = UIDevice.current.identifierForVendor?.uuidString
+        AnalyticsBroadcaster.sendEventName(name.rawValue,
+                                           dataObject: eventData)
+    }
+}

--- a/Sources/RInAppMessaging/Utilities/HeaderAttributesBuilder.swift
+++ b/Sources/RInAppMessaging/Utilities/HeaderAttributesBuilder.swift
@@ -6,7 +6,7 @@ struct HeaderAttributesBuilder {
 
     @discardableResult
     mutating func addDeviceID() -> Bool {
-        guard let deviceId = UIDevice.current.identifierForVendor?.uuidString else {
+        guard let deviceId = UIDevice.deviceID else {
             return false
         }
         addedHeaders.append(HeaderAttribute(key: Keys.deviceID, value: deviceId))

--- a/Sources/RInAppMessaging/Views/Presenters/BaseViewPresenter.swift
+++ b/Sources/RInAppMessaging/Views/Presenters/BaseViewPresenter.swift
@@ -81,8 +81,8 @@ extension BaseViewPresenter {
         // Broadcast only `impression` type here. Other types are sent after campaign is closed.
         let impressionData = [impression].encodeForAnalytics()
         AnalyticsTracker.sendEventName(Constants.RAnalytics.impressionsEventName,
-                                           dataObject: [Constants.RAnalytics.Keys.impressions: impressionData,
-                                                        Constants.RAnalytics.Keys.campaignID: campaign.id,
-                                                        Constants.RAnalytics.Keys.subscriptionID: configurationRepository.getSubscriptionID() ?? "n/a"])
+                                       dataObject: [Constants.RAnalytics.Keys.impressions: impressionData,
+                                                    Constants.RAnalytics.Keys.campaignID: campaign.id,
+                                                    Constants.RAnalytics.Keys.subscriptionID: configurationRepository.getSubscriptionID() ?? "n/a"])
     }
 }

--- a/Sources/RInAppMessaging/Views/Presenters/BaseViewPresenter.swift
+++ b/Sources/RInAppMessaging/Views/Presenters/BaseViewPresenter.swift
@@ -1,11 +1,5 @@
 import UIKit
 
-#if SWIFT_PACKAGE
-import class RSDKUtilsMain.AnalyticsBroadcaster
-#else
-import class RSDKUtils.AnalyticsBroadcaster
-#endif
-
 internal protocol BaseViewPresenterType: ImpressionTrackable {
     var campaign: Campaign! { get set }
     var associatedImage: UIImage? { get set }
@@ -86,7 +80,7 @@ extension BaseViewPresenter {
         }
         // Broadcast only `impression` type here. Other types are sent after campaign is closed.
         let impressionData = [impression].encodeForAnalytics()
-        AnalyticsBroadcaster.sendEventName(Constants.RAnalytics.impressionsEventName,
+        AnalyticsTracker.sendEventName(Constants.RAnalytics.impressionsEventName,
                                            dataObject: [Constants.RAnalytics.Keys.impressions: impressionData,
                                                         Constants.RAnalytics.Keys.campaignID: campaign.id,
                                                         Constants.RAnalytics.Keys.subscriptionID: configurationRepository.getSubscriptionID() ?? "n/a"])

--- a/Sources/RInAppMessaging/Views/Presenters/FullViewPresenter.swift
+++ b/Sources/RInAppMessaging/Views/Presenters/FullViewPresenter.swift
@@ -150,8 +150,8 @@ internal class FullViewPresenter: BaseViewPresenter, FullViewPresenterType, Erro
 
     private func trackPushPrimerAction(didOptIn: Bool) {
         AnalyticsTracker.sendEventName(Constants.RAnalytics.pushPrimerEventName,
-                                           dataObject: [Constants.RAnalytics.Keys.pushPermission: didOptIn ? 1 : 0,
-                                                        Constants.RAnalytics.Keys.campaignID: campaign.id,
-                                                        Constants.RAnalytics.Keys.subscriptionID: configurationRepository.getSubscriptionID() ?? "n/a"])
+                                       dataObject: [Constants.RAnalytics.Keys.pushPermission: didOptIn ? 1 : 0,
+                                                    Constants.RAnalytics.Keys.campaignID: campaign.id,
+                                                    Constants.RAnalytics.Keys.subscriptionID: configurationRepository.getSubscriptionID() ?? "n/a"])
     }
 }

--- a/Sources/RInAppMessaging/Views/Presenters/FullViewPresenter.swift
+++ b/Sources/RInAppMessaging/Views/Presenters/FullViewPresenter.swift
@@ -1,12 +1,6 @@
 import UIKit
 import UserNotifications
 
-#if canImport(RSDKUtils)
-import class RSDKUtils.AnalyticsBroadcaster
-#else // SPM version
-import class RSDKUtilsMain.AnalyticsBroadcaster
-#endif
-
 internal protocol FullViewPresenterType: BaseViewPresenterType {
     var view: FullViewType? { get set }
 
@@ -155,7 +149,7 @@ internal class FullViewPresenter: BaseViewPresenter, FullViewPresenterType, Erro
     }
 
     private func trackPushPrimerAction(didOptIn: Bool) {
-        AnalyticsBroadcaster.sendEventName(Constants.RAnalytics.pushPrimerEventName,
+        AnalyticsTracker.sendEventName(Constants.RAnalytics.pushPrimerEventName,
                                            dataObject: [Constants.RAnalytics.Keys.pushPermission: didOptIn ? 1 : 0,
                                                         Constants.RAnalytics.Keys.campaignID: campaign.id,
                                                         Constants.RAnalytics.Keys.subscriptionID: configurationRepository.getSubscriptionID() ?? "n/a"])

--- a/Tests/Tests/ViewPresenterSpec.swift
+++ b/Tests/Tests/ViewPresenterSpec.swift
@@ -506,7 +506,7 @@ class ViewPresenterSpec: QuickSpec {
                             return false
                         }
 
-                        return params["eventName"] as? String == Constants.RAnalytics.pushPrimerEventName &&
+                        return params["eventName"] as? String == Constants.RAnalytics.pushPrimerEventName.rawValue &&
                         data[Constants.RAnalytics.Keys.pushPermission] as? Int == Int(booleanLiteral: expectedFlag) &&
                         data[Constants.RAnalytics.Keys.subscriptionID] as? String == configurationRepository.getSubscriptionID() &&
                         data[Constants.RAnalytics.Keys.campaignID] as? String == campaign.id


### PR DESCRIPTION
# Description
- Send `device_id` as a custom parameter in all RAT events

## Links
SDKCF-6625

# Checklist
- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
- [x] I have added to the [changelog](../blob/master/CHANGELOG.md#Unreleased)
- [x] I wrote/updated tests for new/changed code
- [ ] I removed all sensitive data **before every commit**, including API endpoints and keys, and internal links
- [x] I ran `fastlane ci` without errors
- [ ] All project file changes are replicated in `SampleSPM/SampleSPM.xcodeproj` project
