### PR TITLE
fix: fix user preference registration in sample app, fix assertions (SDKCF-6641)

### DIFF
--- a/Sample/Shared/Helpers/UserInfoHelper.swift
+++ b/Sample/Shared/Helpers/UserInfoHelper.swift
@@ -1,8 +1,11 @@
 import Foundation
+
 struct UserInfoHelper {
     enum ErrorType {
         case duplicateTracker
     }
+
+    static let sharedPreference = UserInfo()
 
     static func validateInput(userID: String?, idTracker: String?, token: String?) -> ErrorType? {
         guard idTracker.isEmpty || token.isEmpty else {

--- a/Sample/SwiftUI/MainView.swift
+++ b/Sample/SwiftUI/MainView.swift
@@ -72,6 +72,7 @@ struct MainView: View {
             return
         }
         RInAppMessaging.configure(enableTooltipFeature: enableTooltipFeature)
+        RInAppMessaging.registerPreference(UserInfoHelper.sharedPreference)
         isOnFinishedAlertPresented = true
     }
 }

--- a/Sample/SwiftUI/UserInfoView.swift
+++ b/Sample/SwiftUI/UserInfoView.swift
@@ -11,15 +11,11 @@ struct UserInfoView: View {
     @State private var isDuplicateTrackerAlertPresented = false
     @State private var isSuccessAlertPresented = false
 
-    private let userInfo = UserInfo()
+    private let userInfo = UserInfoHelper.sharedPreference
     private var textFields: [(title: String, text: Binding<String>)] {
         [("USER ID:", $userIDText),
          ("ID TRACKING IDENTIFIER:", $idTrackerText),
          ("ACCESS TOKEN:", $accessTokenText)]
-    }
-
-    init() {
-        RInAppMessaging.registerPreference(userInfo)
     }
 
     var body: some View {
@@ -34,6 +30,7 @@ struct UserInfoView: View {
                     }
                     .textFieldStyle(.roundedBorder)
                     .autocorrectionDisabled()
+                    .autocapitalization(.none)
                 }
             }
             Spacer()

--- a/Sample/UIKit/UserInfoViewController.swift
+++ b/Sample/UIKit/UserInfoViewController.swift
@@ -7,12 +7,11 @@ class UserInfoViewController: UIViewController {
     @IBOutlet private weak var idTrackingIdentifierTextField: UITextField!
     @IBOutlet private weak var accessTokenTextField: UITextField!
 
-    private let userInfo = UserInfo()
+    private let userInfo = UserInfoHelper.sharedPreference
 
     override func viewDidLoad() {
         super.viewDidLoad()
         view.addGestureRecognizer(UITapGestureRecognizer(target: view, action: #selector(view.endEditing)))
-        RInAppMessaging.registerPreference(userInfo)
     }
 
     override func viewDidAppear(_ animated: Bool) {

--- a/Sample/UIKit/ViewController.swift
+++ b/Sample/UIKit/ViewController.swift
@@ -58,6 +58,7 @@ class ViewController: UIViewController {
             return
         }
         RInAppMessaging.configure(enableTooltipFeature: enableTooltipFeature)
+        RInAppMessaging.registerPreference(UserInfoHelper.sharedPreference)
         showAlert(title: "alert_message_init_successful".localized)
     }
 }

--- a/Sources/RInAppMessaging/Repositories/AccountRepository.swift
+++ b/Sources/RInAppMessaging/Repositories/AccountRepository.swift
@@ -76,7 +76,7 @@ final class AccountRepository: AccountRepositoryType {
     func checkAssertions() {
         assert(!(userInfoProvider?.getAccessToken()?.isEmpty == false && userInfoProvider?.getUserID()?.isEmpty != false),
                "userId must be present and not empty when accessToken is specified")
-        assert(!(userInfoProvider?.getIDTrackingIdentifier() != nil && userInfoProvider?.getAccessToken() != nil),
+        assert(!(userInfoProvider?.getIDTrackingIdentifier().isEmpty == false && userInfoProvider?.getAccessToken().isEmpty == false),
                "accessToken and idTrackingIdentifier shouldn't be used at the same time")
     }
 }

--- a/Tests/Tests/AccountRepositorySpec.swift
+++ b/Tests/Tests/AccountRepositorySpec.swift
@@ -268,6 +268,12 @@ class AccountRepositorySpec: QuickSpec {
                     it("will not throw an error for empty preference") {
                         expect(accountRepository.checkAssertions()).toNot(throwAssertion())
                     }
+
+                    it("will not throw an error if idTrackingIdentifier is specified and accessToken is empty") {
+                        userInfoProvider.accessToken = ""
+                        userInfoProvider.idTrackingIdentifier = "tracking-id"
+                        expect(accountRepository.checkAssertions()).toNot(throwAssertion())
+                    }
                 }
             }
         }


### PR DESCRIPTION
# Description
`registerPreference()` must not be called before `configure()` (and should be called only once).
Fixed assertions to allow empty values (not just nils)

## Links
SDKCF-6641

# Checklist
- [X] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
- [ ] I have added to the [changelog](../blob/master/CHANGELOG.md#Unreleased)
- [X] I wrote/updated tests for new/changed code
- [X] I removed all sensitive data **before every commit**, including API endpoints and keys, and internal links
- [X] I ran `fastlane ci` without errors
- [X] All project file changes are replicated in `SampleSPM/SampleSPM.xcodeproj` project
