### PR TITLE
feat: add device id in display permissions request header (SDKCF-6624)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 - Features:
 	- Added User preference input in Sample App [SDKCF-6641]
 	- Added device_id to all the RAT events [SDKCF-6625]
-
+	- Added device_id to DisplayPermission request header [SDKCF-6624]
+        
 ### 8.0.0 (2023-06-21)
 - **Breaking changes:**
     - Update Swift version support for package to 5.7.1 [SDKCF-6515]

--- a/Sources/RInAppMessaging/Services/DisplayPermissionService.swift
+++ b/Sources/RInAppMessaging/Services/DisplayPermissionService.swift
@@ -113,7 +113,8 @@ extension DisplayPermissionService {
         var builder = HeaderAttributesBuilder()
         builder.addSubscriptionID(configurationRepository: configurationRepository)
         builder.addAccessToken(accountRepository: accountRepository)
-
+        builder.addDeviceID()
+        
         return builder.build()
     }
 }

--- a/Tests/Tests/DisplayPermissionServiceSpec.swift
+++ b/Tests/Tests/DisplayPermissionServiceSpec.swift
@@ -260,6 +260,7 @@ class DisplayPermissionServiceSpec: QuickSpec {
                     let Keys = Constants.Request.Header.self
                     let headers = httpSession.sentRequest?.allHTTPHeaderFields
                     expect(headers).toNot(beEmpty())
+                    expect(headers?[Keys.deviceID]).toNot(beEmpty())
                     expect(headers?[Keys.subscriptionID]).to(equal(moduleConfig.subscriptionID))
                     expect(headers?[Keys.authorization]).to(equal("OAuth2 token"))
                 }


### PR DESCRIPTION
# Description
add device id in display permissions request header 

## Links
(SDKCF-6624)

# Checklist
- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
- [x] I have added to the [changelog](../blob/master/CHANGELOG.md#Unreleased)
- [ ] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data **before every commit**, including API endpoints and keys, and internal links
- [ ] I ran `fastlane ci` without errors
- [ ] All project file changes are replicated in `SampleSPM/SampleSPM.xcodeproj` project
