### PR TITLE
fix: remove deprecated property from Checkbox (Xcode 15 fix) (SDKCF-6692)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 	- Added User preference input in Sample App [SDKCF-6641]
 	- Added device_id to all the RAT events [SDKCF-6625]
 	- Added device_id to DisplayPermission request header [SDKCF-6624]
+- Fixes:
+	- Fixed Xcode 15 beta errors [SDKCF-6692]
         
 ### 8.0.0 (2023-06-21)
 - **Breaking changes:**

--- a/Sources/RInAppMessaging/Views/Components/Checkbox.swift
+++ b/Sources/RInAppMessaging/Views/Components/Checkbox.swift
@@ -76,10 +76,6 @@ internal class Checkbox: UIControl {
     /// **Default:** The current tintColor.
     var checkmarkColor: UIColor!
 
-    /// **Default:** White.
-    @available(swift, obsoleted: 4.1, renamed: "checkboxFillColor", message: "Defaults to a clear color")
-    var checkboxBackgroundColor: UIColor! = .white
-
     /// The checkboxes fill color.
     ///
     /// **Default:** `UIColoe.Clear`


### PR DESCRIPTION
# Description
Fix for Xcode 15 beta error:
```
/Users/vagrant/git/ios/Pods/RInAppMessaging/Sources/RInAppMessaging/Views/Components/Checkbox.swift:80:6: stored properties cannot be marked unavailable with '@available'
    @available(swift, obsoleted: 4.1, renamed: "checkboxFillColor", message: "Defaults to a clear color")
```

## Links
SDKCF-6692

# Checklist
- [X] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
- [X] I have added to the [changelog](../blob/master/CHANGELOG.md#Unreleased)
- [ ] I wrote/updated tests for new/changed code
- [X] I removed all sensitive data **before every commit**, including API endpoints and keys, and internal links
- [ ] I ran `fastlane ci` without errors
- [X] All project file changes are replicated in `SampleSPM/SampleSPM.xcodeproj` project
