### PR TITLE
feat: ignore `configure()` calls when RMC module is integrated (SDKCF-6710)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 	- Added User preference input in Sample App [SDKCF-6641]
 	- Added device_id to all the RAT events [SDKCF-6625]
 	- Added device_id to DisplayPermission request header [SDKCF-6624]
+	- Prevent calling `configure()` then RMC module is integrated [SDKCF-6710]
 - Fixes:
 	- Fixed Xcode 15 beta errors [SDKCF-6692]
         

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -10,20 +10,20 @@ PODS:
   - Quick (5.0.1)
   - RInAppMessaging (8.1.0-snapshot):
     - RSDKUtils (~> 4.0)
-  - RSDKUtils (4.0.0):
-    - RSDKUtils/Main (= 4.0.0)
-  - RSDKUtils/Main (4.0.0):
+  - RSDKUtils (4.0.1):
+    - RSDKUtils/Main (= 4.0.1)
+  - RSDKUtils/Main (4.0.1):
     - RSDKUtils/RLogger
-  - RSDKUtils/Nimble (4.0.0):
+  - RSDKUtils/Nimble (4.0.1):
     - Nimble
     - RSDKUtils/Main
-  - RSDKUtils/RLogger (4.0.0)
-  - RSDKUtils/TestHelpers (4.0.0):
+  - RSDKUtils/RLogger (4.0.1)
+  - RSDKUtils/TestHelpers (4.0.1):
     - RSDKUtils/Main
   - Shock (6.1.3):
     - GRMustache.swift (~> 4.0.1)
     - SwiftNIOHTTP1 (~> 2.40.0)
-  - SwiftLint (0.51.0)
+  - SwiftLint (0.52.4)
   - SwiftNIO (2.40.0):
     - _NIODataStructures (= 2.40.0)
     - CNIOAtomics (= 2.40.0)
@@ -113,9 +113,9 @@ SPEC CHECKSUMS:
   Nimble: 5316ef81a170ce87baf72dd961f22f89a602ff84
   Quick: 749aa754fd1e7d984f2000fe051e18a3a9809179
   RInAppMessaging: b82c9a138ea061954f121a5188d187e3cf84a7f6
-  RSDKUtils: e2a63eb729298706abe02e735436a2586c65e164
+  RSDKUtils: 9eb9637aec081c1b7d8a7dee69aac0c9811c0906
   Shock: 34def30d5e729f6c1eea2a5b5c2d024b875af86c
-  SwiftLint: 1b7561918a19e23bfed960e40759086e70f4dba5
+  SwiftLint: 1cc5cd61ba9bacb2194e340aeb47a2a37fda00b3
   SwiftNIO: 829958aab300642625091f82fc2f49cb7cf4ef24
   SwiftNIOConcurrencyHelpers: 697370136789b1074e4535eaae75cbd7f900370e
   SwiftNIOCore: 473fdfe746534d7aa25766916459eeaf6f92ef49

--- a/Sources/RInAppMessaging/Constants.swift
+++ b/Sources/RInAppMessaging/Constants.swift
@@ -2,8 +2,6 @@ import typealias Foundation.TimeInterval
 
 internal enum Constants {
 
-    static let rmcSubscriptionIDSuffix = "-rmc"
-
     enum CampaignMessage {
         static let imageRequestTimeoutSeconds: TimeInterval = 20
         static let imageResourceTimeoutSeconds: TimeInterval = 300
@@ -62,6 +60,10 @@ internal enum Constants {
             static let pushPermission = "push_permission"
             static let deviceID = "device_id"
         }
+    }
+
+    enum RMC {
+        static let subscriptionIDSuffix = "-rmc"
     }
 
     enum Retry {

--- a/Sources/RInAppMessaging/Constants.swift
+++ b/Sources/RInAppMessaging/Constants.swift
@@ -2,6 +2,8 @@ import typealias Foundation.TimeInterval
 
 internal enum Constants {
 
+    static let rmcSubscriptionIDSuffix = "-rmc"
+
     enum CampaignMessage {
         static let imageRequestTimeoutSeconds: TimeInterval = 20
         static let imageResourceTimeoutSeconds: TimeInterval = 300

--- a/Sources/RInAppMessaging/RInAppMessaging.swift
+++ b/Sources/RInAppMessaging/RInAppMessaging.swift
@@ -224,7 +224,7 @@ import RSDKUtils
             return true
         }
 
-        return subscriptionID?.hasSuffix(Constants.rmcSubscriptionIDSuffix) == true
+        return subscriptionID?.hasSuffix(Constants.RMC.subscriptionIDSuffix) == true
     }
 
     /// Removes '-rmc' suffix from subscriptionId if it's present.
@@ -233,11 +233,11 @@ import RSDKUtils
             return nil
         }
 
-        guard subscriptionID.hasSuffix(Constants.rmcSubscriptionIDSuffix) else {
+        guard subscriptionID.hasSuffix(Constants.RMC.subscriptionIDSuffix) else {
             return subscriptionID
         }
 
-        return String(subscriptionID.prefix(subscriptionID.count - Constants.rmcSubscriptionIDSuffix.count))
+        return String(subscriptionID.prefix(subscriptionID.count - Constants.RMC.subscriptionIDSuffix.count))
     }
 
     // MARK: - Unit tests helpers

--- a/Sources/RInAppMessaging/RInAppMessaging.swift
+++ b/Sources/RInAppMessaging/RInAppMessaging.swift
@@ -20,7 +20,7 @@ import RSDKUtils
     }
     /// Returns `true` when RMC module is integrated in the host app
     internal static var isRMCEnvironment: Bool {
-        NSClassFromString("RMCInAppMessaging.RMCInAppMessaging") != nil
+        Bundle.rmcResources != nil
     }
 
     private override init() { super.init() }

--- a/Sources/RInAppMessaging/RInAppMessaging.swift
+++ b/Sources/RInAppMessaging/RInAppMessaging.swift
@@ -60,11 +60,14 @@ import RSDKUtils
     /// - Parameters:
     ///     - subscriptionKey: your app's subscription key. (This setting will override the `InAppMessagingAppSubscriptionID` value in Info.plist)
     ///     - configurationURL: a configuration URL. (This setting will override the `InAppMessagingConfigurationURL` value in Info.plist)
-    ///     - enableTooltipFeature: set to `true` to enable Tooltip campaigns. This feature is currently in beta phase. Default value: `false`
+    ///     - enableTooltipFeature: set to `true` to enable Tooltip campaigns. This feature is currently in beta phase. Default value: `false`.
+    ///     - caller: for internal use only.
     @objc public static func configure(subscriptionID: String? = nil,
                                        configurationURL: String? = nil,
-                                       enableTooltipFeature: Bool = false) {
-        guard initializedModule == nil else {
+                                       enableTooltipFeature: Bool = false,
+                                       caller: String = #file) {
+
+        guard verifyRMCEnvironment(caller: caller), initializedModule == nil else {
             return
         }
 
@@ -209,6 +212,17 @@ import RSDKUtils
         }
 
         return configURL
+    }
+
+    /// Checks the existence of RMC module and verifies the `configure()` caller.
+    /// - Parameter caller: a path to the source file that called `configure()`
+    /// - Returns: `false` if RMC module is integrated and the method wasn't called from the RMC module.
+    private static func verifyRMCEnvironment(caller: String) -> Bool {
+        guard NSClassFromString("RMCInAppMessaging.RMCInAppMessaging") != nil else {
+            return true
+        }
+
+        return caller.hasSuffix("RMCInAppMessaging/RMCInAppMessaging.swift") || caller.hasSuffix("RMC/RMC.swift")
     }
 
     // MARK: - Unit tests helpers

--- a/Sources/RInAppMessaging/Utilities/BundleInfo.swift
+++ b/Sources/RInAppMessaging/Utilities/BundleInfo.swift
@@ -59,6 +59,10 @@ internal extension Bundle {
         .init(identifier: "jp.co.rakuten.inappmessaging.Tests") ?? .init(identifier: "Tests")
     }
 
+    static var rmcResources: Bundle? {
+        .init(identifier: "RMC-RMC-resources")
+    }
+
     private static var sdk: Bundle? {
         sdkBundle(name: "RInAppMessaging")
     }

--- a/Tests/Tests/BundleSpec.swift
+++ b/Tests/Tests/BundleSpec.swift
@@ -73,9 +73,9 @@ class BundleMock: Bundle {
         infoDictionaryMock
     }
 
-    init() {
+    init(infoDictionary: [String: Any] = [:]) {
+        infoDictionaryMock = infoDictionary
         // super.init(path:) creates a new instance only if `path` is not bound to any existing Bundle instance
         super.init(path: Bundle.main.bundlePath + "/Frameworks")!
-        infoDictionaryMock.removeAll()
     }
 }

--- a/Tests/Tests/PublicAPISpec.swift
+++ b/Tests/Tests/PublicAPISpec.swift
@@ -667,7 +667,7 @@ class PublicAPISpec: QuickSpec {
                     expect(RInAppMessaging.sanitizeSubscriptionID(subscriptionID)).toEventually(equal("myKey"))
                 }
 
-                it("will not remove '-rmc' substring if it's not at the and of the string") {
+                it("will not remove '-rmc' substring if it's not at the end of the string") {
                     let subscriptionID = "my-rmcKey"
                     expect(RInAppMessaging.sanitizeSubscriptionID(subscriptionID)).toEventually(equal("my-rmcKey"))
                 }


### PR DESCRIPTION
# Description
When RMC module is integrated, allow only `configure()` calls that come from RMC source code.

Note:
I couldn't find a way to write unit tests for this feature without complicating the code.

## Links
SDKCF-6710

# Checklist
- [X] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
- [X] I have added to the [changelog](../blob/master/CHANGELOG.md#Unreleased)
- [ ] I wrote/updated tests for new/changed code
- [X] I removed all sensitive data **before every commit**, including API endpoints and keys, and internal links
- [ ] I ran `fastlane ci` without errors
- [ ] All project file changes are replicated in `SampleSPM/SampleSPM.xcodeproj` project
