### PR TITLE
feat: add rmcsdk version parameter to all api calls (SDKCF-6709)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 	- Added device_id to all the RAT events [SDKCF-6625]
 	- Added device_id to DisplayPermission request header [SDKCF-6624]
 	- Prevent calling `configure()` then RMC module is integrated [SDKCF-6710]
+	- Added rmcsdk version parameter to all api calls [SDKCF-6709]
 - Fixes:
 	- Fixed Xcode 15 beta errors [SDKCF-6692]
         

--- a/Sources/RInAppMessaging/Constants.swift
+++ b/Sources/RInAppMessaging/Constants.swift
@@ -46,12 +46,6 @@ internal enum Constants {
 
     enum Versions {
         static let sdkVersion = "8.1.0-snapshot"
-        static var rmcSdkVersion: String? {
-            if let rmcBundle = Bundle(identifier: "RMC-RMC-resources") {
-                return rmcBundle.value(for: "CFBundleShortVersionString") ?? nil
-            }
-            return nil
-        }
     }
 
     enum RAnalytics: String {

--- a/Sources/RInAppMessaging/Constants.swift
+++ b/Sources/RInAppMessaging/Constants.swift
@@ -45,6 +45,12 @@ internal enum Constants {
 
     enum Versions {
         static let sdkVersion = "8.1.0-snapshot"
+        static var rmcSdkVersion: String? {
+            if let rmcBundle = Bundle(identifier: "RMC-RMC-resources") {
+                return rmcBundle.bundleIdentifier
+            }
+            return nil
+        }
     }
 
     enum RAnalytics: String {

--- a/Sources/RInAppMessaging/Constants.swift
+++ b/Sources/RInAppMessaging/Constants.swift
@@ -1,3 +1,4 @@
+import Foundation
 import typealias Foundation.TimeInterval
 
 internal enum Constants {

--- a/Sources/RInAppMessaging/Constants.swift
+++ b/Sources/RInAppMessaging/Constants.swift
@@ -47,7 +47,7 @@ internal enum Constants {
         static let sdkVersion = "8.1.0-snapshot"
         static var rmcSdkVersion: String? {
             if let rmcBundle = Bundle(identifier: "RMC-RMC-resources") {
-                return rmcBundle.bundleIdentifier
+                return rmcBundle.value(for: "CFBundleShortVersionString") ?? nil
             }
             return nil
         }

--- a/Sources/RInAppMessaging/Constants.swift
+++ b/Sources/RInAppMessaging/Constants.swift
@@ -1,4 +1,3 @@
-import Foundation
 import typealias Foundation.TimeInterval
 
 internal enum Constants {

--- a/Sources/RInAppMessaging/Models/Requests/DisplayPermissionRequest.swift
+++ b/Sources/RInAppMessaging/Models/Requests/DisplayPermissionRequest.swift
@@ -8,6 +8,7 @@ internal struct DisplayPermissionRequest: Codable {
         case sdkVersion
         case locale
         case lastPingInMilliseconds = "lastPingInMillis"
+        case rmcSdkVersion
     }
 
     let subscriptionId: String
@@ -18,4 +19,5 @@ internal struct DisplayPermissionRequest: Codable {
     let sdkVersion: String
     let locale: String
     let lastPingInMilliseconds: Int64
+    let rmcSdkVersion: String?
 }

--- a/Sources/RInAppMessaging/Models/Requests/GetConfigRequest.swift
+++ b/Sources/RInAppMessaging/Models/Requests/GetConfigRequest.swift
@@ -26,7 +26,7 @@ extension GetConfigRequest {
         queryItems.append(URLQueryItem(name: CodingKeys.appVersion.rawValue, value: appVersion))
         queryItems.append(URLQueryItem(name: CodingKeys.sdkVersion.rawValue, value: sdkVersion))
         queryItems.append(URLQueryItem(name: CodingKeys.locale.rawValue, value: locale))
-        if let rmcSdkVersion = rmcSdkVersion {
+        if let rmcSdkVersion {
             queryItems.append(URLQueryItem(name: CodingKeys.rmcSdkVersion.rawValue, value: rmcSdkVersion))
         }
         return queryItems

--- a/Sources/RInAppMessaging/Models/Requests/GetConfigRequest.swift
+++ b/Sources/RInAppMessaging/Models/Requests/GetConfigRequest.swift
@@ -1,4 +1,3 @@
-import Foundation
 import struct Foundation.URLQueryItem
 
 internal struct GetConfigRequest: Codable {
@@ -27,7 +26,7 @@ extension GetConfigRequest {
         queryItems.append(URLQueryItem(name: CodingKeys.appVersion.rawValue, value: appVersion))
         queryItems.append(URLQueryItem(name: CodingKeys.sdkVersion.rawValue, value: sdkVersion))
         queryItems.append(URLQueryItem(name: CodingKeys.locale.rawValue, value: locale))
-        if Bundle.rmcSdkVersion != nil {
+        if let rmcSdkVersion = rmcSdkVersion {
             queryItems.append(URLQueryItem(name: CodingKeys.rmcSdkVersion.rawValue, value: rmcSdkVersion))
         }
         return queryItems

--- a/Sources/RInAppMessaging/Models/Requests/GetConfigRequest.swift
+++ b/Sources/RInAppMessaging/Models/Requests/GetConfigRequest.swift
@@ -7,6 +7,7 @@ internal struct GetConfigRequest: Codable {
         case platform
         case appId
         case sdkVersion
+        case rmcSDKVersion
     }
 
     let locale: String
@@ -14,6 +15,7 @@ internal struct GetConfigRequest: Codable {
     let platform: Platform
     let appId: String
     let sdkVersion: String
+    let rmcSDKVersion: String?
 }
 
 extension GetConfigRequest {
@@ -24,6 +26,7 @@ extension GetConfigRequest {
         queryItems.append(URLQueryItem(name: CodingKeys.appVersion.rawValue, value: appVersion))
         queryItems.append(URLQueryItem(name: CodingKeys.sdkVersion.rawValue, value: sdkVersion))
         queryItems.append(URLQueryItem(name: CodingKeys.locale.rawValue, value: locale))
+        queryItems.append(URLQueryItem(name: CodingKeys.locale.rawValue, value: rmcSDKVersion))
         return queryItems
     }
 }

--- a/Sources/RInAppMessaging/Models/Requests/GetConfigRequest.swift
+++ b/Sources/RInAppMessaging/Models/Requests/GetConfigRequest.swift
@@ -1,3 +1,4 @@
+import Foundation
 import struct Foundation.URLQueryItem
 
 internal struct GetConfigRequest: Codable {
@@ -7,7 +8,7 @@ internal struct GetConfigRequest: Codable {
         case platform
         case appId
         case sdkVersion
-        case rmcSDKVersion
+        case rmcSdkVersion
     }
 
     let locale: String
@@ -15,7 +16,7 @@ internal struct GetConfigRequest: Codable {
     let platform: Platform
     let appId: String
     let sdkVersion: String
-    let rmcSDKVersion: String?
+    let rmcSdkVersion: String?
 }
 
 extension GetConfigRequest {
@@ -26,7 +27,9 @@ extension GetConfigRequest {
         queryItems.append(URLQueryItem(name: CodingKeys.appVersion.rawValue, value: appVersion))
         queryItems.append(URLQueryItem(name: CodingKeys.sdkVersion.rawValue, value: sdkVersion))
         queryItems.append(URLQueryItem(name: CodingKeys.locale.rawValue, value: locale))
-        queryItems.append(URLQueryItem(name: CodingKeys.locale.rawValue, value: rmcSDKVersion))
+        if Bundle.rmcSdkVersion != nil {
+            queryItems.append(URLQueryItem(name: CodingKeys.rmcSdkVersion.rawValue, value: rmcSdkVersion))
+        }
         return queryItems
     }
 }

--- a/Sources/RInAppMessaging/Models/Requests/ImpressionRequest.swift
+++ b/Sources/RInAppMessaging/Models/Requests/ImpressionRequest.swift
@@ -5,4 +5,5 @@ internal struct ImpressionRequest: Codable {
     let sdkVersion: String
     let impressions: [Impression]
     let userIdentifiers: [UserIdentifier]
+    let rmcSdkVersion: String?
 }

--- a/Sources/RInAppMessaging/Models/Requests/PingRequest.swift
+++ b/Sources/RInAppMessaging/Models/Requests/PingRequest.swift
@@ -2,4 +2,5 @@ internal struct PingRequest: Codable {
     let userIdentifiers: [UserIdentifier]
     let appVersion: String
     let supportedCampaignTypes: [CampaignType]
+    let rmcSdkVersion: String?
 }

--- a/Sources/RInAppMessaging/RInAppMessaging.swift
+++ b/Sources/RInAppMessaging/RInAppMessaging.swift
@@ -18,6 +18,7 @@ import RSDKUtils
     internal static var swiftUIEventHandler: SwiftUIViewEventHandlerType? {
         dependencyManager?.resolve(type: SwiftUIViewEventHandlerType.self)
     }
+
     /// Returns `true` when RMC module is integrated in the host app
     internal static var isRMCEnvironment: Bool {
         Bundle.rmcResources != nil

--- a/Sources/RInAppMessaging/Services/ConfigurationService.swift
+++ b/Sources/RInAppMessaging/Services/ConfigurationService.swift
@@ -87,7 +87,8 @@ extension ConfigurationService {
             appVersion: appVersion,
             platform: .ios,
             appId: appId,
-            sdkVersion: Constants.Versions.sdkVersion
+            sdkVersion: Constants.Versions.sdkVersion,
+            rmcSDKVersion: Constants.Versions.rmcSdkVersion
         )
     }
 

--- a/Sources/RInAppMessaging/Services/ConfigurationService.swift
+++ b/Sources/RInAppMessaging/Services/ConfigurationService.swift
@@ -88,7 +88,7 @@ extension ConfigurationService {
             platform: .ios,
             appId: appId,
             sdkVersion: Constants.Versions.sdkVersion,
-            rmcSDKVersion: Constants.Versions.rmcSdkVersion
+            rmcSdkVersion: Bundle.rmcSdkVersion
         )
     }
 

--- a/Sources/RInAppMessaging/Services/ConfigurationService.swift
+++ b/Sources/RInAppMessaging/Services/ConfigurationService.swift
@@ -88,7 +88,7 @@ extension ConfigurationService {
             platform: .ios,
             appId: appId,
             sdkVersion: Constants.Versions.sdkVersion,
-            rmcSdkVersion: Bundle.rmcSdkVersion
+            rmcSdkVersion: bundleInfo.rmcSdkVersion
         )
     }
 

--- a/Sources/RInAppMessaging/Services/DisplayPermissionService.swift
+++ b/Sources/RInAppMessaging/Services/DisplayPermissionService.swift
@@ -100,8 +100,7 @@ extension DisplayPermissionService {
                                                          sdkVersion: Constants.Versions.sdkVersion,
                                                          locale: Locale.current.normalizedIdentifier,
                                                          lastPingInMilliseconds: campaignRepository.lastSyncInMilliseconds ?? 0,
-                                                         rmcSdkVersion: bundleInfo.rmcSdkVersion
-                                                         )
+                                                         rmcSdkVersion: bundleInfo.rmcSdkVersion)
         do {
             let body = try JSONEncoder().encode(permissionRequest)
             return .success(body)

--- a/Sources/RInAppMessaging/Services/DisplayPermissionService.swift
+++ b/Sources/RInAppMessaging/Services/DisplayPermissionService.swift
@@ -100,7 +100,7 @@ extension DisplayPermissionService {
                                                          sdkVersion: Constants.Versions.sdkVersion,
                                                          locale: Locale.current.normalizedIdentifier,
                                                          lastPingInMilliseconds: campaignRepository.lastSyncInMilliseconds ?? 0,
-                                                         rmcSdkVersion: Bundle.rmcSdkVersion ?? ""
+                                                         rmcSdkVersion: Bundle.rmcSdkVersion
                                                          )
         do {
             let body = try JSONEncoder().encode(permissionRequest)

--- a/Sources/RInAppMessaging/Services/DisplayPermissionService.swift
+++ b/Sources/RInAppMessaging/Services/DisplayPermissionService.swift
@@ -100,7 +100,7 @@ extension DisplayPermissionService {
                                                          sdkVersion: Constants.Versions.sdkVersion,
                                                          locale: Locale.current.normalizedIdentifier,
                                                          lastPingInMilliseconds: campaignRepository.lastSyncInMilliseconds ?? 0,
-                                                         rmcSdkVersion: Constants.Versions.rmcSdkVersion ?? ""
+                                                         rmcSdkVersion: Bundle.rmcSdkVersion ?? ""
                                                          )
         do {
             let body = try JSONEncoder().encode(permissionRequest)

--- a/Sources/RInAppMessaging/Services/DisplayPermissionService.swift
+++ b/Sources/RInAppMessaging/Services/DisplayPermissionService.swift
@@ -99,7 +99,9 @@ extension DisplayPermissionService {
                                                          appVersion: appVersion,
                                                          sdkVersion: Constants.Versions.sdkVersion,
                                                          locale: Locale.current.normalizedIdentifier,
-                                                         lastPingInMilliseconds: campaignRepository.lastSyncInMilliseconds ?? 0)
+                                                         lastPingInMilliseconds: campaignRepository.lastSyncInMilliseconds ?? 0,
+                                                         rmcSdkVersion: Constants.Versions.rmcSdkVersion ?? ""
+                                                         )
         do {
             let body = try JSONEncoder().encode(permissionRequest)
             return .success(body)

--- a/Sources/RInAppMessaging/Services/DisplayPermissionService.swift
+++ b/Sources/RInAppMessaging/Services/DisplayPermissionService.swift
@@ -100,7 +100,7 @@ extension DisplayPermissionService {
                                                          sdkVersion: Constants.Versions.sdkVersion,
                                                          locale: Locale.current.normalizedIdentifier,
                                                          lastPingInMilliseconds: campaignRepository.lastSyncInMilliseconds ?? 0,
-                                                         rmcSdkVersion: Bundle.rmcSdkVersion
+                                                         rmcSdkVersion: bundleInfo.rmcSdkVersion
                                                          )
         do {
             let body = try JSONEncoder().encode(permissionRequest)

--- a/Sources/RInAppMessaging/Services/ImpressionService.swift
+++ b/Sources/RInAppMessaging/Services/ImpressionService.swift
@@ -119,7 +119,8 @@ extension ImpressionService {
             appVersion: appVersion,
             sdkVersion: Constants.Versions.sdkVersion,
             impressions: impressions,
-            userIdentifiers: accountRepository.getUserIdentifiers()
+            userIdentifiers: accountRepository.getUserIdentifiers(),
+            rmcSdkVersion: Constants.Versions.rmcSdkVersion
         )
 
         do {

--- a/Sources/RInAppMessaging/Services/ImpressionService.swift
+++ b/Sources/RInAppMessaging/Services/ImpressionService.swift
@@ -120,7 +120,7 @@ extension ImpressionService {
             sdkVersion: Constants.Versions.sdkVersion,
             impressions: impressions,
             userIdentifiers: accountRepository.getUserIdentifiers(),
-            rmcSdkVersion: Bundle.rmcSdkVersion
+            rmcSdkVersion: bundleInfo.rmcSdkVersion
         )
 
         do {

--- a/Sources/RInAppMessaging/Services/ImpressionService.swift
+++ b/Sources/RInAppMessaging/Services/ImpressionService.swift
@@ -120,7 +120,7 @@ extension ImpressionService {
             sdkVersion: Constants.Versions.sdkVersion,
             impressions: impressions,
             userIdentifiers: accountRepository.getUserIdentifiers(),
-            rmcSdkVersion: Constants.Versions.rmcSdkVersion
+            rmcSdkVersion: Bundle.rmcSdkVersion
         )
 
         do {

--- a/Sources/RInAppMessaging/Services/MessageMixerService.swift
+++ b/Sources/RInAppMessaging/Services/MessageMixerService.swift
@@ -88,7 +88,7 @@ extension MessageMixerService {
             userIdentifiers: accountRepository.getUserIdentifiers(),
             appVersion: appVersion,
             supportedCampaignTypes: [.pushPrimer, .regular],
-            rmcSdkVersion: Constants.Versions.rmcSdkVersion)
+            rmcSdkVersion: Bundle.rmcSdkVersion)
 
         do {
             let body = try JSONEncoder().encode(pingRequest)

--- a/Sources/RInAppMessaging/Services/MessageMixerService.swift
+++ b/Sources/RInAppMessaging/Services/MessageMixerService.swift
@@ -87,7 +87,8 @@ extension MessageMixerService {
         let pingRequest = PingRequest(
             userIdentifiers: accountRepository.getUserIdentifiers(),
             appVersion: appVersion,
-            supportedCampaignTypes: [.pushPrimer, .regular])
+            supportedCampaignTypes: [.pushPrimer, .regular],
+            rmcSdkVersion: Constants.Versions.rmcSdkVersion)
 
         do {
             let body = try JSONEncoder().encode(pingRequest)

--- a/Sources/RInAppMessaging/Services/MessageMixerService.swift
+++ b/Sources/RInAppMessaging/Services/MessageMixerService.swift
@@ -88,7 +88,7 @@ extension MessageMixerService {
             userIdentifiers: accountRepository.getUserIdentifiers(),
             appVersion: appVersion,
             supportedCampaignTypes: [.pushPrimer, .regular],
-            rmcSdkVersion: Bundle.rmcSdkVersion)
+            rmcSdkVersion: bundleInfo.rmcSdkVersion)
 
         do {
             let body = try JSONEncoder().encode(pingRequest)

--- a/Sources/RInAppMessaging/Utilities/BundleInfo.swift
+++ b/Sources/RInAppMessaging/Utilities/BundleInfo.swift
@@ -68,9 +68,12 @@ internal extension Bundle {
     }
     
     static var rmcSdkVersion: String? {
-        if let path = rmcResources?.path(forResource: "Version", ofType: "plist") {
-                let versionDict = NSDictionary(contentsOfFile: path)
-                return versionDict?["rmcSdkVersion"] as? String
+        if let path = rmcResources?.path(forResource: "RmcInfo", ofType: "plist") {
+            if let versionDict = NSDictionary(contentsOfFile: path) {
+                if let rmcSdkVersion = versionDict["rmcSdkVersion"] as? String {
+                    return rmcSdkVersion
+                }
+            }
         }
         return nil
     }

--- a/Sources/RInAppMessaging/Utilities/BundleInfo.swift
+++ b/Sources/RInAppMessaging/Utilities/BundleInfo.swift
@@ -13,7 +13,7 @@ internal class BundleInfo {
     }
 
     class var rmcBundle: Bundle? {
-         .rmcResources
+        .rmcResources
     }
         
     class var applicationId: String? {

--- a/Sources/RInAppMessaging/Utilities/BundleInfo.swift
+++ b/Sources/RInAppMessaging/Utilities/BundleInfo.swift
@@ -68,11 +68,9 @@ internal extension Bundle {
     }
     
     static var rmcSdkVersion: String? {
-        if let rmcBundle = Bundle(identifier: "RMC-RMC-resources") {
-            if let path = rmcBundle.path(forResource: "RMC/Resources/Version", ofType: "plist") {
+        if let path = rmcResources?.path(forResource: "RMC/Resources/Version", ofType: "plist") {
                 let versionDict = NSDictionary(contentsOfFile: path)
                 return versionDict?["rmcSdkVersion"] as? String
-            }
         }
         return nil
     }

--- a/Sources/RInAppMessaging/Utilities/BundleInfo.swift
+++ b/Sources/RInAppMessaging/Utilities/BundleInfo.swift
@@ -12,6 +12,10 @@ internal class BundleInfo {
         .main
     }
 
+    class var rmcBundle: Bundle? {
+         .rmcResources
+    }
+        
     class var applicationId: String? {
         bundle.infoDictionary?["CFBundleIdentifier"] as? String
     }
@@ -38,6 +42,10 @@ internal class BundleInfo {
 
     class var customFontNameButton: String? {
         bundle.infoDictionary?[Constants.Info.customFontNameButtonKey] as? String
+    }
+    
+    class var rmcSdkVersion: String? {
+        rmcBundle?.getRMCSdkVersion()
     }
 }
 
@@ -67,8 +75,8 @@ internal extension Bundle {
         sdkBundle(name: "RInAppMessaging")
     }
     
-    static var rmcSdkVersion: String? {
-        guard let path = rmcResources?.path(forResource: "RmcInfo", ofType: "plist"),
+    func getRMCSdkVersion() -> String? {
+        guard let path = path(forResource: "RmcInfo", ofType: "plist"),
               let versionDict = NSDictionary(contentsOfFile: path),
               let rmcSdkVersion = versionDict["rmcSdkVersion"] as? String
         else { return nil }

--- a/Sources/RInAppMessaging/Utilities/BundleInfo.swift
+++ b/Sources/RInAppMessaging/Utilities/BundleInfo.swift
@@ -68,13 +68,10 @@ internal extension Bundle {
     }
     
     static var rmcSdkVersion: String? {
-        if let path = rmcResources?.path(forResource: "RmcInfo", ofType: "plist") {
-            if let versionDict = NSDictionary(contentsOfFile: path) {
-                if let rmcSdkVersion = versionDict["rmcSdkVersion"] as? String {
-                    return rmcSdkVersion
-                }
-            }
-        }
-        return nil
+        guard let path = rmcResources?.path(forResource: "RmcInfo", ofType: "plist"),
+              let versionDict = NSDictionary(contentsOfFile: path),
+              let rmcSdkVersion = versionDict["rmcSdkVersion"] as? String
+        else { return nil }
+        return rmcSdkVersion
     }
 }

--- a/Sources/RInAppMessaging/Utilities/BundleInfo.swift
+++ b/Sources/RInAppMessaging/Utilities/BundleInfo.swift
@@ -68,7 +68,7 @@ internal extension Bundle {
     }
     
     static var rmcSdkVersion: String? {
-        if let path = rmcResources?.path(forResource: "RMC/Resources/Version", ofType: "plist") {
+        if let path = rmcResources?.path(forResource: "Version", ofType: "plist") {
                 let versionDict = NSDictionary(contentsOfFile: path)
                 return versionDict?["rmcSdkVersion"] as? String
         }

--- a/Sources/RInAppMessaging/Utilities/BundleInfo.swift
+++ b/Sources/RInAppMessaging/Utilities/BundleInfo.swift
@@ -66,4 +66,14 @@ internal extension Bundle {
     private static var sdk: Bundle? {
         sdkBundle(name: "RInAppMessaging")
     }
+    
+    static var rmcSdkVersion: String? {
+        if let rmcBundle = Bundle(identifier: "RMC-RMC-resources") {
+            if let path = rmcBundle.path(forResource: "RMC/Resources/Version", ofType: "plist") {
+                let versionDict = NSDictionary(contentsOfFile: path)
+                return versionDict?["rmcSdkVersion"] as? String
+            }
+        }
+        return nil
+    }
 }

--- a/Sources/RInAppMessaging/Utilities/BundleInfo.swift
+++ b/Sources/RInAppMessaging/Utilities/BundleInfo.swift
@@ -75,7 +75,7 @@ internal extension Bundle {
         sdkBundle(name: "RInAppMessaging")
     }
     
-    func getRMCSdkVersion() -> String? {
+    private func getRMCSdkVersion() -> String? {
         guard let path = path(forResource: "RmcInfo", ofType: "plist"),
               let versionDict = NSDictionary(contentsOfFile: path),
               let rmcSdkVersion = versionDict["rmcSdkVersion"] as? String

--- a/Sources/RInAppMessaging/Utilities/BundleInfo.swift
+++ b/Sources/RInAppMessaging/Utilities/BundleInfo.swift
@@ -75,7 +75,7 @@ internal extension Bundle {
         sdkBundle(name: "RInAppMessaging")
     }
     
-    private func getRMCSdkVersion() -> String? {
+    fileprivate func getRMCSdkVersion() -> String? {
         guard let path = path(forResource: "RmcInfo", ofType: "plist"),
               let versionDict = NSDictionary(contentsOfFile: path),
               let rmcSdkVersion = versionDict["rmcSdkVersion"] as? String

--- a/Tests/Tests/BundleSpec.swift
+++ b/Tests/Tests/BundleSpec.swift
@@ -84,7 +84,7 @@ class BundleMock: Bundle {
     var infoDictionaryMock = [String: Any]()
     var resourceFiles = [String: [String: Any]]() {
         didSet {
-            recreteResourceFiles()
+            recreateResourceFiles()
         }
     }
     override var infoDictionary: [String: Any]? {
@@ -108,7 +108,7 @@ class BundleMock: Bundle {
         return path
     }
 
-    private func recreteResourceFiles() {
+    private func recreateResourceFiles() {
         let fileManager = FileManager.default
         let resourceURL: URL! = URL(string: "file://\(plistDirectory!)")
 

--- a/Tests/Tests/BundleSpec.swift
+++ b/Tests/Tests/BundleSpec.swift
@@ -102,7 +102,7 @@ class BundleMock: Bundle {
             return nil
         }
         var path = plistDirectory?.appending("/\(name)")
-        if let ext = ext {
+        if let ext {
             path?.append(".\(ext)")
         }
         return path

--- a/Tests/Tests/BundleSpec.swift
+++ b/Tests/Tests/BundleSpec.swift
@@ -50,6 +50,11 @@ class BundleSpec: QuickSpec {
                 bundleMock.infoDictionaryMock[Constants.Info.customFontNameButtonKey] = "font-button"
                 expect(bundleInfo.customFontNameButton).to(equal("font-button"))
             }
+
+            it("should return rmcSdk version from plist") {
+                bundleMock.resourceFiles = ["RmcInfo.plist": ["rmcSdkVersion": "1.0.1"]]
+                expect(bundleInfo.rmcSdkVersion).to(equal("1.0.1"))
+            }
         }
 
         describe("Bundle extensions") {
@@ -65,10 +70,23 @@ class BundleInfoMocked: BundleInfo {
     override class var bundle: Bundle {
         bundleMock
     }
+    override class var rmcBundle: Bundle? {
+        bundleMock
+    }
 }
 
 class BundleMock: Bundle {
+
+    private let plistDirectory: String! = {
+        let documentDirectory = NSSearchPathForDirectoriesInDomains(.documentDirectory, .userDomainMask, true).first
+        return documentDirectory?.appending("/PlistMocks")
+    }()
     var infoDictionaryMock = [String: Any]()
+    var resourceFiles = [String: [String: Any]]() {
+        didSet {
+            recreteResourceFiles()
+        }
+    }
     override var infoDictionary: [String: Any]? {
         infoDictionaryMock
     }
@@ -77,5 +95,33 @@ class BundleMock: Bundle {
         infoDictionaryMock = infoDictionary
         // super.init(path:) creates a new instance only if `path` is not bound to any existing Bundle instance
         super.init(path: Bundle.main.bundlePath + "/Frameworks")!
+    }
+
+    override func path(forResource name: String?, ofType ext: String?) -> String? {
+        guard let name = name else {
+            return nil
+        }
+        var path = plistDirectory?.appending("/\(name)")
+        if let ext = ext {
+            path?.append(".\(ext)")
+        }
+        return path
+    }
+
+    private func recreteResourceFiles() {
+        let fileManager = FileManager.default
+        let resourceURL: URL! = URL(string: "file://\(plistDirectory!)")
+
+        try? fileManager.removeItem(at: resourceURL)
+        try? fileManager.createDirectory(at: resourceURL, withIntermediateDirectories: true)
+
+        resourceFiles.forEach { fileName, content in
+            let url = resourceURL.appendingPathComponent(fileName)
+            do {
+                try NSDictionary(dictionary: content).write(to: url)
+            } catch {
+                assertionFailure(error.localizedDescription)
+            }
+        }
     }
 }

--- a/Tests/Tests/ConfigurationServiceSpec.swift
+++ b/Tests/Tests/ConfigurationServiceSpec.swift
@@ -286,42 +286,47 @@ class ConfigurationServiceSpec: QuickSpec {
                     expect(httpSession.sentRequest?.url?.host).to(equal(configURL.host))
                 }
 
-                it("will send a valid data object when rmcSdk is integrated") {
-                    waitUntil { done in
-                        requestQueue.async {
-                            _ = service.getConfigData()
-                            done()
+                context("when rmc sdk is integrated") {
+                    it("will send a valid data object and will contain rmcSdk version") {
+                        waitUntil { done in
+                            requestQueue.async {
+                                _ = service.getConfigData()
+                                done()
+                            }
                         }
+
+                        let request = httpSession.decodeQueryItems(modelType: GetConfigRequest.self)
+
+                        expect(request).toNot(beNil())
+                        expect(request?.locale).to(equal(Locale.current.normalizedIdentifier))
+                        expect(request?.appVersion).to(equal(BundleInfoMock.appVersion))
+                        expect(request?.platform).to(equal(.ios))
+                        expect(request?.appId).to(equal(BundleInfoMock.applicationId))
+                        expect(request?.sdkVersion).to(equal(Constants.Versions.sdkVersion))
+                        expect(request?.rmcSdkVersion).to(equal(BundleInfoMock.rmcSdkVersion))
                     }
-
-                    let request = httpSession.decodeQueryItems(modelType: GetConfigRequest.self)
-
-                    expect(request).toNot(beNil())
-                    expect(request?.locale).to(equal(Locale.current.normalizedIdentifier))
-                    expect(request?.appVersion).to(equal(BundleInfoMock.appVersion))
-                    expect(request?.platform).to(equal(.ios))
-                    expect(request?.appId).to(equal(BundleInfoMock.applicationId))
-                    expect(request?.sdkVersion).to(equal(Constants.Versions.sdkVersion))
-                    expect(request?.rmcSdkVersion).to(equal(BundleInfoMock.rmcSdkVersion))
                 }
-                it("will send a valid data object when rmcSdk is not integrated") {
-                    BundleInfoMock.rmcSdkVersionMock = nil
-                    waitUntil { done in
-                        requestQueue.async {
-                            _ = service.getConfigData()
-                            done()
+
+                context("when rmc sdk is not integrated") {
+                    it("will send a valid data object and not contain rmcSdk version") {
+                        BundleInfoMock.rmcSdkVersionMock = nil
+                        waitUntil { done in
+                            requestQueue.async {
+                                _ = service.getConfigData()
+                                done()
+                            }
                         }
+
+                        let request = httpSession.decodeQueryItems(modelType: GetConfigRequest.self)
+
+                        expect(request).toNot(beNil())
+                        expect(request?.locale).to(equal(Locale.current.normalizedIdentifier))
+                        expect(request?.appVersion).to(equal(BundleInfoMock.appVersion))
+                        expect(request?.platform).to(equal(.ios))
+                        expect(request?.appId).to(equal(BundleInfoMock.applicationId))
+                        expect(request?.sdkVersion).to(equal(Constants.Versions.sdkVersion))
+                        expect(request?.rmcSdkVersion).to(beNil())
                     }
-
-                    let request = httpSession.decodeQueryItems(modelType: GetConfigRequest.self)
-
-                    expect(request).toNot(beNil())
-                    expect(request?.locale).to(equal(Locale.current.normalizedIdentifier))
-                    expect(request?.appVersion).to(equal(BundleInfoMock.appVersion))
-                    expect(request?.platform).to(equal(.ios))
-                    expect(request?.appId).to(equal(BundleInfoMock.applicationId))
-                    expect(request?.sdkVersion).to(equal(Constants.Versions.sdkVersion))
-                    expect(request?.rmcSdkVersion).to(beNil())
                 }
 
                 it("will send subscription id in header") {

--- a/Tests/Tests/ConfigurationServiceSpec.swift
+++ b/Tests/Tests/ConfigurationServiceSpec.swift
@@ -286,7 +286,7 @@ class ConfigurationServiceSpec: QuickSpec {
                     expect(httpSession.sentRequest?.url?.host).to(equal(configURL.host))
                 }
 
-                it("will send a valid data object when rmcSdk integrated") {
+                it("will send a valid data object when rmcSdk is integrated") {
                     waitUntil { done in
                         requestQueue.async {
                             _ = service.getConfigData()
@@ -304,7 +304,7 @@ class ConfigurationServiceSpec: QuickSpec {
                     expect(request?.sdkVersion).to(equal(Constants.Versions.sdkVersion))
                     expect(request?.rmcSdkVersion).to(equal(BundleInfoMock.rmcSdkVersion))
                 }
-                it("will send a valid data object when rmcSdk not integrated") {
+                it("will send a valid data object when rmcSdk is not integrated") {
                     BundleInfoMock.rmcSdkVersionMock = nil
                     waitUntil { done in
                         requestQueue.async {

--- a/Tests/Tests/ConfigurationServiceSpec.swift
+++ b/Tests/Tests/ConfigurationServiceSpec.swift
@@ -286,7 +286,7 @@ class ConfigurationServiceSpec: QuickSpec {
                     expect(httpSession.sentRequest?.url?.host).to(equal(configURL.host))
                 }
 
-                it("will send a valid data object") {
+                it("will send a valid data object when rmcSdk integrated") {
                     waitUntil { done in
                         requestQueue.async {
                             _ = service.getConfigData()
@@ -302,6 +302,26 @@ class ConfigurationServiceSpec: QuickSpec {
                     expect(request?.platform).to(equal(.ios))
                     expect(request?.appId).to(equal(BundleInfoMock.applicationId))
                     expect(request?.sdkVersion).to(equal(Constants.Versions.sdkVersion))
+                    expect(request?.rmcSdkVersion).to(equal(BundleInfoMock.rmcSdkVersion))
+                }
+                it("will send a valid data object when rmcSdk not integrated") {
+                    BundleInfoMock.rmcSdkVersionMock = nil
+                    waitUntil { done in
+                        requestQueue.async {
+                            _ = service.getConfigData()
+                            done()
+                        }
+                    }
+
+                    let request = httpSession.decodeQueryItems(modelType: GetConfigRequest.self)
+
+                    expect(request).toNot(beNil())
+                    expect(request?.locale).to(equal(Locale.current.normalizedIdentifier))
+                    expect(request?.appVersion).to(equal(BundleInfoMock.appVersion))
+                    expect(request?.platform).to(equal(.ios))
+                    expect(request?.appId).to(equal(BundleInfoMock.applicationId))
+                    expect(request?.sdkVersion).to(equal(Constants.Versions.sdkVersion))
+                    expect(request?.rmcSdkVersion).to(beNil())
                 }
 
                 it("will send subscription id in header") {

--- a/Tests/Tests/DisplayPermissionServiceSpec.swift
+++ b/Tests/Tests/DisplayPermissionServiceSpec.swift
@@ -223,38 +223,41 @@ class DisplayPermissionServiceSpec: QuickSpec {
                     service.bundleInfo = BundleInfoMock.self
                 }
 
-                it("will send a valid data object when rmcSdk is integrated") {
-                    campaignRepository.lastSyncInMilliseconds = 111
-                    sendRequestAndWaitForResponse()
+                context("when rmc sdk is integrated") {
+                    it("will send a valid data object and will contain rmcSdk version") {
+                        campaignRepository.lastSyncInMilliseconds = 111
+                        sendRequestAndWaitForResponse()
+                        let request = httpSession.decodeSentData(modelType: DisplayPermissionRequest.self)
 
-                    let request = httpSession.decodeSentData(modelType: DisplayPermissionRequest.self)
-
-                    expect(request).toNot(beNil())
-                    expect(request?.subscriptionId).to(equal(moduleConfig.subscriptionID))
-                    expect(request?.campaignId).to(equal(campaign.id))
-                    expect(request?.platform).to(equal(.ios))
-                    expect(request?.appVersion).to(equal(BundleInfoMock.appVersion))
-                    expect(request?.sdkVersion).to(equal(Constants.Versions.sdkVersion))
-                    expect(request?.locale).to(equal(Locale.current.normalizedIdentifier))
-                    expect(request?.lastPingInMilliseconds).to(equal(111))
-                    expect(request?.rmcSdkVersion).to(equal(BundleInfoMock.rmcSdkVersion))
+                        expect(request).toNot(beNil())
+                        expect(request?.subscriptionId).to(equal(moduleConfig.subscriptionID))
+                        expect(request?.campaignId).to(equal(campaign.id))
+                        expect(request?.platform).to(equal(.ios))
+                        expect(request?.appVersion).to(equal(BundleInfoMock.appVersion))
+                        expect(request?.sdkVersion).to(equal(Constants.Versions.sdkVersion))
+                        expect(request?.locale).to(equal(Locale.current.normalizedIdentifier))
+                        expect(request?.lastPingInMilliseconds).to(equal(111))
+                        expect(request?.rmcSdkVersion).to(equal(BundleInfoMock.rmcSdkVersion))
+                    }
                 }
 
-                it("will send valid data object when rmcSdk is not integrated") {
-                    campaignRepository.lastSyncInMilliseconds = 111
-                    BundleInfoMock.rmcSdkVersionMock = nil
-                    sendRequestAndWaitForResponse()
-                    let request = httpSession.decodeSentData(modelType: DisplayPermissionRequest.self)
+                context("when rmc sdk is not integrated") {
+                    it("will send a valid data object and not contain rmc sdk version") {
+                        campaignRepository.lastSyncInMilliseconds = 111
+                        BundleInfoMock.rmcSdkVersionMock = nil
+                        sendRequestAndWaitForResponse()
+                        let request = httpSession.decodeSentData(modelType: DisplayPermissionRequest.self)
 
-                    expect(request).toNot(beNil())
-                    expect(request?.subscriptionId).to(equal(moduleConfig.subscriptionID))
-                    expect(request?.campaignId).to(equal(campaign.id))
-                    expect(request?.platform).to(equal(.ios))
-                    expect(request?.appVersion).to(equal(BundleInfoMock.appVersion))
-                    expect(request?.sdkVersion).to(equal(Constants.Versions.sdkVersion))
-                    expect(request?.locale).to(equal(Locale.current.normalizedIdentifier))
-                    expect(request?.lastPingInMilliseconds).to(equal(111))
-                    expect(request?.rmcSdkVersion).to(beNil())
+                        expect(request).toNot(beNil())
+                        expect(request?.subscriptionId).to(equal(moduleConfig.subscriptionID))
+                        expect(request?.campaignId).to(equal(campaign.id))
+                        expect(request?.platform).to(equal(.ios))
+                        expect(request?.appVersion).to(equal(BundleInfoMock.appVersion))
+                        expect(request?.sdkVersion).to(equal(Constants.Versions.sdkVersion))
+                        expect(request?.locale).to(equal(Locale.current.normalizedIdentifier))
+                        expect(request?.lastPingInMilliseconds).to(equal(111))
+                        expect(request?.rmcSdkVersion).to(beNil())
+                    }
                 }
 
                 it("will send user preferences in the request") {

--- a/Tests/Tests/DisplayPermissionServiceSpec.swift
+++ b/Tests/Tests/DisplayPermissionServiceSpec.swift
@@ -223,7 +223,7 @@ class DisplayPermissionServiceSpec: QuickSpec {
                     service.bundleInfo = BundleInfoMock.self
                 }
 
-                it("will send a valid data object when rmcSdk integrated") {
+                it("will send a valid data object when rmcSdk is integrated") {
                     campaignRepository.lastSyncInMilliseconds = 111
                     sendRequestAndWaitForResponse()
 
@@ -240,7 +240,7 @@ class DisplayPermissionServiceSpec: QuickSpec {
                     expect(request?.rmcSdkVersion).to(equal(BundleInfoMock.rmcSdkVersion))
                 }
 
-                it("will send valid data object when rmcSdk not integrated") {
+                it("will send valid data object when rmcSdk is not integrated") {
                     campaignRepository.lastSyncInMilliseconds = 111
                     BundleInfoMock.rmcSdkVersionMock = nil
                     sendRequestAndWaitForResponse()

--- a/Tests/Tests/DisplayPermissionServiceSpec.swift
+++ b/Tests/Tests/DisplayPermissionServiceSpec.swift
@@ -223,7 +223,7 @@ class DisplayPermissionServiceSpec: QuickSpec {
                     service.bundleInfo = BundleInfoMock.self
                 }
 
-                it("will send a valid data object") {
+                it("will send a valid data object when rmcSdk integrated") {
                     campaignRepository.lastSyncInMilliseconds = 111
                     sendRequestAndWaitForResponse()
 
@@ -237,6 +237,24 @@ class DisplayPermissionServiceSpec: QuickSpec {
                     expect(request?.sdkVersion).to(equal(Constants.Versions.sdkVersion))
                     expect(request?.locale).to(equal(Locale.current.normalizedIdentifier))
                     expect(request?.lastPingInMilliseconds).to(equal(111))
+                    expect(request?.rmcSdkVersion).to(equal(BundleInfoMock.rmcSdkVersion))
+                }
+
+                it("will send valid data object when rmcSdk not integrated") {
+                    campaignRepository.lastSyncInMilliseconds = 111
+                    BundleInfoMock.rmcSdkVersionMock = nil
+                    sendRequestAndWaitForResponse()
+                    let request = httpSession.decodeSentData(modelType: DisplayPermissionRequest.self)
+
+                    expect(request).toNot(beNil())
+                    expect(request?.subscriptionId).to(equal(moduleConfig.subscriptionID))
+                    expect(request?.campaignId).to(equal(campaign.id))
+                    expect(request?.platform).to(equal(.ios))
+                    expect(request?.appVersion).to(equal(BundleInfoMock.appVersion))
+                    expect(request?.sdkVersion).to(equal(Constants.Versions.sdkVersion))
+                    expect(request?.locale).to(equal(Locale.current.normalizedIdentifier))
+                    expect(request?.lastPingInMilliseconds).to(equal(111))
+                    expect(request?.rmcSdkVersion).to(beNil())
                 }
 
                 it("will send user preferences in the request") {

--- a/Tests/Tests/Helpers/SharedMocks.swift
+++ b/Tests/Tests/Helpers/SharedMocks.swift
@@ -286,11 +286,13 @@ class BundleInfoMock: BundleInfo {
     static var applicationIdMock: String? = "app.id"
     static var appVersionMock: String? = "1.2.3"
     static var customFontMock: String? = "blank-Bold"
+    static var rmcSdkVersionMock: String? = "1.0"
 
     static func reset() {
         applicationIdMock = "app.id"
         appVersionMock = "1.2.3"
         customFontMock = "blank-Bold"
+        rmcSdkVersionMock = "1.0"
     }
 
     override class var applicationId: String? {
@@ -311,6 +313,9 @@ class BundleInfoMock: BundleInfo {
 
     override class var customFontNameButton: String? {
         customFontMock
+    }
+    override class var rmcSdkVersion: String? {
+        rmcSdkVersionMock
     }
 }
 

--- a/Tests/Tests/ImpressionServiceSpec.swift
+++ b/Tests/Tests/ImpressionServiceSpec.swift
@@ -175,7 +175,7 @@ class ImpressionServiceSpec: QuickSpec {
                     bundleInfo.reset()
                 }
 
-                it("will send a valid data object when rmcSdk integrated") {
+                it("will send a valid data object when rmcSdk is integrated") {
                     sendRequestAndWaitForResponse()
 
                     expect(httpSession.decodeSentData(modelType: ImpressionRequest.self))
@@ -186,7 +186,7 @@ class ImpressionServiceSpec: QuickSpec {
                     expect(request?.sdkVersion).to(equal(Constants.Versions.sdkVersion))
                     expect(request?.rmcSdkVersion).to(equal(BundleInfoMock.rmcSdkVersion))
                 }
-                it("will send a valid data object when rmcSdk integrated") {
+                it("will send a valid data object when rmcSdk is not integrated") {
                     BundleInfoMock.rmcSdkVersionMock = nil
                     sendRequestAndWaitForResponse()
 

--- a/Tests/Tests/ImpressionServiceSpec.swift
+++ b/Tests/Tests/ImpressionServiceSpec.swift
@@ -175,7 +175,7 @@ class ImpressionServiceSpec: QuickSpec {
                     bundleInfo.reset()
                 }
 
-                it("will send a valid data object") {
+                it("will send a valid data object when rmcSdk integrated") {
                     sendRequestAndWaitForResponse()
 
                     expect(httpSession.decodeSentData(modelType: ImpressionRequest.self))
@@ -184,6 +184,19 @@ class ImpressionServiceSpec: QuickSpec {
                     expect(request?.campaignId).to(equal(campaign.id))
                     expect(request?.appVersion).to(equal(BundleInfoMock.appVersion))
                     expect(request?.sdkVersion).to(equal(Constants.Versions.sdkVersion))
+                    expect(request?.rmcSdkVersion).to(equal(BundleInfoMock.rmcSdkVersion))
+                }
+                it("will send a valid data object when rmcSdk integrated") {
+                    BundleInfoMock.rmcSdkVersionMock = nil
+                    sendRequestAndWaitForResponse()
+
+                    expect(httpSession.decodeSentData(modelType: ImpressionRequest.self))
+                        .toEventuallyNot(beNil())
+                    let request = httpSession.decodeSentData(modelType: ImpressionRequest.self)
+                    expect(request?.campaignId).to(equal(campaign.id))
+                    expect(request?.appVersion).to(equal(BundleInfoMock.appVersion))
+                    expect(request?.sdkVersion).to(equal(Constants.Versions.sdkVersion))
+                    expect(request?.rmcSdkVersion).to(beNil())
                 }
 
                 it("will send impressions in the request") {

--- a/Tests/Tests/ImpressionServiceSpec.swift
+++ b/Tests/Tests/ImpressionServiceSpec.swift
@@ -175,28 +175,33 @@ class ImpressionServiceSpec: QuickSpec {
                     bundleInfo.reset()
                 }
 
-                it("will send a valid data object when rmcSdk is integrated") {
-                    sendRequestAndWaitForResponse()
+                context("when rmc sdk is integrated") {
+                    it("will send a valid data object and will contain rmcSdk version") {
+                        sendRequestAndWaitForResponse()
 
-                    expect(httpSession.decodeSentData(modelType: ImpressionRequest.self))
-                        .toEventuallyNot(beNil())
-                    let request = httpSession.decodeSentData(modelType: ImpressionRequest.self)
-                    expect(request?.campaignId).to(equal(campaign.id))
-                    expect(request?.appVersion).to(equal(BundleInfoMock.appVersion))
-                    expect(request?.sdkVersion).to(equal(Constants.Versions.sdkVersion))
-                    expect(request?.rmcSdkVersion).to(equal(BundleInfoMock.rmcSdkVersion))
+                        expect(httpSession.decodeSentData(modelType: ImpressionRequest.self))
+                            .toEventuallyNot(beNil())
+                        let request = httpSession.decodeSentData(modelType: ImpressionRequest.self)
+                        expect(request?.campaignId).to(equal(campaign.id))
+                        expect(request?.appVersion).to(equal(BundleInfoMock.appVersion))
+                        expect(request?.sdkVersion).to(equal(Constants.Versions.sdkVersion))
+                        expect(request?.rmcSdkVersion).to(equal(BundleInfoMock.rmcSdkVersion))
+                    }
                 }
-                it("will send a valid data object when rmcSdk is not integrated") {
-                    BundleInfoMock.rmcSdkVersionMock = nil
-                    sendRequestAndWaitForResponse()
 
-                    expect(httpSession.decodeSentData(modelType: ImpressionRequest.self))
-                        .toEventuallyNot(beNil())
-                    let request = httpSession.decodeSentData(modelType: ImpressionRequest.self)
-                    expect(request?.campaignId).to(equal(campaign.id))
-                    expect(request?.appVersion).to(equal(BundleInfoMock.appVersion))
-                    expect(request?.sdkVersion).to(equal(Constants.Versions.sdkVersion))
-                    expect(request?.rmcSdkVersion).to(beNil())
+                context("when rmc sdk is not integrated") {
+                    it("will send a valid data object and not contain rmcSdk version") {
+                        BundleInfoMock.rmcSdkVersionMock = nil
+                        sendRequestAndWaitForResponse()
+
+                        expect(httpSession.decodeSentData(modelType: ImpressionRequest.self))
+                            .toEventuallyNot(beNil())
+                        let request = httpSession.decodeSentData(modelType: ImpressionRequest.self)
+                        expect(request?.campaignId).to(equal(campaign.id))
+                        expect(request?.appVersion).to(equal(BundleInfoMock.appVersion))
+                        expect(request?.sdkVersion).to(equal(Constants.Versions.sdkVersion))
+                        expect(request?.rmcSdkVersion).to(beNil())
+                    }
                 }
 
                 it("will send impressions in the request") {

--- a/Tests/Tests/MessageMixerServiceSpec.swift
+++ b/Tests/Tests/MessageMixerServiceSpec.swift
@@ -253,25 +253,29 @@ class MessageMixerServiceSpec: QuickSpec {
                     expect(httpSession.sentRequest?.url).to(equal(configData.endpoints?.ping))
                 }
 
-                it("will send a valid data object when rmcSdk is integrated") {
-                    sendRequestAndWaitForResponse()
+                context("when rmc sdk is integrated") {
+                    it("will send a valid data object and will contain rmcSdk version") {
+                        sendRequestAndWaitForResponse()
 
-                    let request = httpSession.decodeSentData(modelType: PingRequest.self)
-                    expect(request).toNot(beNil())
-                    expect(request?.appVersion).to(equal(BundleInfoMock.appVersion))
-                    expect(request?.supportedCampaignTypes).to(elementsEqualOrderAgnostic([.regular, .pushPrimer]))
-                    expect(request?.rmcSdkVersion).to(equal(BundleInfoMock.rmcSdkVersion))
+                        let request = httpSession.decodeSentData(modelType: PingRequest.self)
+                        expect(request).toNot(beNil())
+                        expect(request?.appVersion).to(equal(BundleInfoMock.appVersion))
+                        expect(request?.supportedCampaignTypes).to(elementsEqualOrderAgnostic([.regular, .pushPrimer]))
+                        expect(request?.rmcSdkVersion).to(equal(BundleInfoMock.rmcSdkVersion))
+                    }
                 }
 
-                it("will send a valid data object when rmcSdk is not integrated") {
-                    BundleInfoMock.rmcSdkVersionMock = nil
-                    sendRequestAndWaitForResponse()
+                context("when rmc sdk is not integrated") {
+                    it("will send a valid data object and not contain rmcSdk version") {
+                        BundleInfoMock.rmcSdkVersionMock = nil
+                        sendRequestAndWaitForResponse()
 
-                    let request = httpSession.decodeSentData(modelType: PingRequest.self)
-                    expect(request).toNot(beNil())
-                    expect(request?.appVersion).to(equal(BundleInfoMock.appVersion))
-                    expect(request?.supportedCampaignTypes).to(elementsEqualOrderAgnostic([.regular, .pushPrimer]))
-                    expect(request?.rmcSdkVersion).to(beNil())
+                        let request = httpSession.decodeSentData(modelType: PingRequest.self)
+                        expect(request).toNot(beNil())
+                        expect(request?.appVersion).to(equal(BundleInfoMock.appVersion))
+                        expect(request?.supportedCampaignTypes).to(elementsEqualOrderAgnostic([.regular, .pushPrimer]))
+                        expect(request?.rmcSdkVersion).to(beNil())
+                    }
                 }
 
                 it("will send user preferences in the request") {

--- a/Tests/Tests/MessageMixerServiceSpec.swift
+++ b/Tests/Tests/MessageMixerServiceSpec.swift
@@ -253,14 +253,25 @@ class MessageMixerServiceSpec: QuickSpec {
                     expect(httpSession.sentRequest?.url).to(equal(configData.endpoints?.ping))
                 }
 
-                it("will send a valid data object") {
+                it("will send a valid data object when rmcSdk integrated") {
                     sendRequestAndWaitForResponse()
 
                     let request = httpSession.decodeSentData(modelType: PingRequest.self)
-
                     expect(request).toNot(beNil())
                     expect(request?.appVersion).to(equal(BundleInfoMock.appVersion))
                     expect(request?.supportedCampaignTypes).to(elementsEqualOrderAgnostic([.regular, .pushPrimer]))
+                    expect(request?.rmcSdkVersion).to(equal(BundleInfoMock.rmcSdkVersion))
+                }
+
+                it("will send a valid data object when rmcSdk not integrated") {
+                    BundleInfoMock.rmcSdkVersionMock = nil
+                    sendRequestAndWaitForResponse()
+
+                    let request = httpSession.decodeSentData(modelType: PingRequest.self)
+                    expect(request).toNot(beNil())
+                    expect(request?.appVersion).to(equal(BundleInfoMock.appVersion))
+                    expect(request?.supportedCampaignTypes).to(elementsEqualOrderAgnostic([.regular, .pushPrimer]))
+                    expect(request?.rmcSdkVersion).to(beNil())
                 }
 
                 it("will send user preferences in the request") {

--- a/Tests/Tests/MessageMixerServiceSpec.swift
+++ b/Tests/Tests/MessageMixerServiceSpec.swift
@@ -253,7 +253,7 @@ class MessageMixerServiceSpec: QuickSpec {
                     expect(httpSession.sentRequest?.url).to(equal(configData.endpoints?.ping))
                 }
 
-                it("will send a valid data object when rmcSdk integrated") {
+                it("will send a valid data object when rmcSdk is integrated") {
                     sendRequestAndWaitForResponse()
 
                     let request = httpSession.decodeSentData(modelType: PingRequest.self)
@@ -263,7 +263,7 @@ class MessageMixerServiceSpec: QuickSpec {
                     expect(request?.rmcSdkVersion).to(equal(BundleInfoMock.rmcSdkVersion))
                 }
 
-                it("will send a valid data object when rmcSdk not integrated") {
+                it("will send a valid data object when rmcSdk is not integrated") {
                     BundleInfoMock.rmcSdkVersionMock = nil
                     sendRequestAndWaitForResponse()
 


### PR DESCRIPTION
# Description
Passed RMCSDK version with IAM APIs

## Links
[SDKCF-6709]

# Checklist
- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
- [x] I have added to the [changelog](../blob/master/CHANGELOG.md#Unreleased)
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data **before every commit**, including API endpoints and keys, and internal links
- [x] I ran `fastlane ci` without errors
- [ ] All project file changes are replicated in `SampleSPM/SampleSPM.xcodeproj` project
