### PR TITLE
fix: fix getting RMC bundle (SDKCF-6751)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 	- Added rmcsdk version parameter to all api calls [SDKCF-6709]
 - Fixes:
 	- Fixed Xcode 15 beta errors [SDKCF-6692]
+	- Fixed Finding RMC Bundle [SDKCF-751]
         
 ### 8.0.0 (2023-06-21)
 - **Breaking changes:**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 	- Added rmcsdk version parameter to all api calls [SDKCF-6709]
 - Fixes:
 	- Fixed Xcode 15 beta errors [SDKCF-6692]
-	- Fixed Finding RMC Bundle [SDKCF-751]
+	- Fixed Finding RMC Bundle [SDKCF-6751]
         
 ### 8.0.0 (2023-06-21)
 - **Breaking changes:**

--- a/Sources/RInAppMessaging/RInAppMessaging.swift
+++ b/Sources/RInAppMessaging/RInAppMessaging.swift
@@ -21,7 +21,7 @@ import RSDKUtils
 
     /// Returns `true` when RMC module is integrated in the host app
     internal static var isRMCEnvironment: Bool {
-        Bundle.rmcResources != nil
+        BundleInfo.rmcBundle != nil
     }
 
     private override init() { super.init() }

--- a/Sources/RInAppMessaging/Utilities/BundleInfo.swift
+++ b/Sources/RInAppMessaging/Utilities/BundleInfo.swift
@@ -69,7 +69,7 @@ internal extension Bundle {
 
     static var rmcResources: Bundle? {
         guard let rmcBundleUrl = main.resourceURL?.appendingPathComponent("RMC_RMC.bundle"),
-        let bundle = Bundle(url: rmcBundleUrl) else {
+              let bundle = Bundle(url: rmcBundleUrl) else {
             return nil
         }
         return bundle

--- a/Sources/RInAppMessaging/Utilities/BundleInfo.swift
+++ b/Sources/RInAppMessaging/Utilities/BundleInfo.swift
@@ -68,7 +68,11 @@ internal extension Bundle {
     }
 
     static var rmcResources: Bundle? {
-        .init(identifier: "RMC-RMC-resources")
+        guard let rmcBundleUrl = main.resourceURL?.appendingPathComponent("RMC_RMC.bundle"),
+        let bundle = Bundle(url: rmcBundleUrl) else {
+            return nil
+        }
+        return bundle
     }
 
     private static var sdk: Bundle? {


### PR DESCRIPTION
# Description
- Initializing the RMC bundle using the Bundle URL

## Links
- SDKCF-6751

# Checklist
- [ ] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
- [ ] I have added to the [changelog](../blob/master/CHANGELOG.md#Unreleased)
- [ ] I wrote/updated tests for new/changed code
- [ ] I removed all sensitive data **before every commit**, including API endpoints and keys, and internal links
- [ ] I ran `fastlane ci` without errors
- [ ] All project file changes are replicated in `SampleSPM/SampleSPM.xcodeproj` project
