### PR TITLE
fix: Loading cached user data before IAM sdk initialization (SDKCF-6826)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,12 @@
 	- Added device_id to DisplayPermission request header [SDKCF-6624]
 	- Prevent calling `configure()` then RMC module is integrated [SDKCF-6710]
 	- Added rmcsdk version parameter to all api calls [SDKCF-6709]
-	- Retaining API calls until configure() is called [SDKCF-6812]
 - Improvements:
-	- Retaining API calls until `configure()` is called [SDKCF-6740]
+	- Retaining API calls until configure() is called [SDKCF-6812]
 - Fixes:
 	- Fixed Xcode 15 beta errors [SDKCF-6692]
 	- Fixed Finding RMC Bundle [SDKCF-6751]
+	- Fixed Loading cached user data before IAM initialisation [SDKCF-6826]
         
 ### 8.0.0 (2023-06-21)
 - **Breaking changes:**

--- a/README.md
+++ b/README.md
@@ -395,9 +395,10 @@ In your `Info.plist` configuration, set the PostScript names under `InAppMessagi
 * Status bar characters and icons are not visible when Full-Screen campaign is presented
   * If your app is running on iOS version below 13.0 you need to either change background color of the campaign or set proper `preferredStatusbarStyle` in the top-most view controller. (for iOS versions above 13.0 this issue is handled internally by the SDK)
 * A launch event campaign is presented more times than expected.
-  * Ensure that `registerPreference()` is called after `configure()` and before any `logEvent()` method
+  * Ideally `registerPreference()` should be called after `configure()` and before any `logEvent()` method
   * The preference object must contain up-to-date information before `registerPreference()` is called
   * Each *userId*/*idTrackingIdentifier* combination (including empty one) has its own counter for campaign impressions.
   * Killing the app or calling `closeMessage()` API while campaign is being displayed doesn't count as impression.
+  **Note:** If `registerPreference()` is called before `configure()` then it gets retained and gets triggered after `configure()` is called. 
 
 #### For other issues and more detailed information, Rakuten developers should refer to the Troubleshooting Guide on the internal developer documentation portal.

--- a/Sources/RInAppMessaging/InAppMessagingModule.swift
+++ b/Sources/RInAppMessaging/InAppMessagingModule.swift
@@ -93,6 +93,9 @@ internal class InAppMessagingModule: ErrorDelegate, CampaignDispatcherDelegate, 
         accountRepository.setPreference(preference)
 
         guard isInitialized else {
+            if accountRepository.updateUserInfo() {
+                campaignRepository.loadCachedData()
+            }
             return
         }
 

--- a/Tests/Tests/InAppMessagingModuleSpec.swift
+++ b/Tests/Tests/InAppMessagingModuleSpec.swift
@@ -304,9 +304,9 @@ class InAppMessagingModuleSpec: QuickSpec {
                             expect(accountRepository.userInfoProvider).to(beIdenticalTo(aUser))
                         }
 
-                        it("will not call checkUserChanges()") {
+                        it("will call updateUserInfo() to update cached user data") {
                             iamModule.registerPreference(aUser)
-                            expect(accountRepository.wasUpdateUserInfoCalled).to(beFalse())
+                            expect(accountRepository.wasUpdateUserInfoCalled).to(beTrue())
                         }
                     }
                 }


### PR DESCRIPTION
# Description
RCA:
When update the user preference before configuration, it was successfully updated in the `AccountRepository` but it was not fetching the campaign from the local cache in the `CampaignRepository`. That's why it was showing the campaign irrespective of impression left.

Fix:
Local cached campaign is loaded if user preference updated before configuration done.

## Links
[SDKCF-6826]

# Checklist
- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
- [x] I have added to the [changelog](../blob/master/CHANGELOG.md#Unreleased)
- [x] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data **before every commit**, including API endpoints and keys, and internal links
- [x] I ran `fastlane ci` without errors
- [ ] All project file changes are replicated in `SampleSPM/SampleSPM.xcodeproj` project
