### PR TITLE
chore: bump sdk version to 8.2.0-snapshot (SDKCF-6865)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Unreleased
 
-### 8.1.0 (2023-12-12)
+### 8.1.0 (2023-12-12) 
 - Features:
 	- Added User preference input in Sample App [SDKCF-6641]
 	- Added device_id to all the RAT events [SDKCF-6625]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Changelog
 
+### Unreleased
+
 ### 8.1.0 (2023-12-12)
 - Features:
 	- Added User preference input in Sample App [SDKCF-6641]

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -8,7 +8,7 @@ PODS:
   - GRMustache.swift (4.0.1)
   - Nimble (10.0.0)
   - Quick (5.0.1)
-  - RInAppMessaging (8.1.0):
+  - RInAppMessaging (8.2.0-snapshot):
     - RSDKUtils (~> 4.0)
   - RSDKUtils (4.0.1):
     - RSDKUtils/Main (= 4.0.1)
@@ -112,7 +112,7 @@ SPEC CHECKSUMS:
   GRMustache.swift: a6436504284b22b4b05daf5f46f77bd3fe00a9a2
   Nimble: 5316ef81a170ce87baf72dd961f22f89a602ff84
   Quick: 749aa754fd1e7d984f2000fe051e18a3a9809179
-  RInAppMessaging: 0a1ae9f563de9da7d7384521d186ec2f1e88aaff
+  RInAppMessaging: 2037bfbb5cf4c31433bcaf8f520cefb15559d611
   RSDKUtils: 9eb9637aec081c1b7d8a7dee69aac0c9811c0906
   Shock: 34def30d5e729f6c1eea2a5b5c2d024b875af86c
   SwiftLint: 1cc5cd61ba9bacb2194e340aeb47a2a37fda00b3

--- a/RInAppMessaging.podspec
+++ b/RInAppMessaging.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'RInAppMessaging'
-  s.version          = '8.1.0'
+  s.version          = '8.2.0-snapshot'
   s.summary          = 'Rakuten module to manage and display in-app messages'
   s.homepage         = 'https://github.com/rakutentech/ios-inappmessaging'
   s.license          = { :type => 'MIT', :file => 'LICENSE' }

--- a/Sources/RInAppMessaging/Constants.swift
+++ b/Sources/RInAppMessaging/Constants.swift
@@ -44,7 +44,7 @@ internal enum Constants {
     }
 
     enum Versions {
-        static let sdkVersion = "8.1.0"
+        static let sdkVersion = "8.2.0-snapshot"
     }
 
     enum RAnalytics: String {


### PR DESCRIPTION
# Description
Snapshot update

## Links
[SDKCF-6865]

# Checklist
- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
- [x] I have added to the [changelog](../blob/master/CHANGELOG.md#Unreleased)
- [ ] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data **before every commit**, including API endpoints and keys, and internal links
- [ ] I ran `fastlane ci` without errors
- [ ] All project file changes are replicated in `SampleSPM/SampleSPM.xcodeproj` project
