### PR TITLE
fix: Prevent sending impressions for visible but expired campaigns (SDKCF-6910)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## Changelog
 
 ### Unreleased
+- Improvements:
+	- Prevent sending impressions for expired campaigns [SDKCF-6910]
 
 ### 8.2.0 (2024-04-08) 
 - Improvements:

--- a/Sources/RInAppMessaging/Protocols/ImpressionTrackable.swift
+++ b/Sources/RInAppMessaging/Protocols/ImpressionTrackable.swift
@@ -18,9 +18,11 @@ internal protocol ImpressionTrackable: AnyObject {
 
 extension ImpressionTrackable {
     func sendImpressions(for campaign: Campaign) {
-        impressionService.pingImpression(
-            impressions: impressions,
-            campaignData: campaign.data)
+        if !campaign.isOutdated {
+            impressionService.pingImpression(
+                impressions: impressions,
+                campaignData: campaign.data)
+        }
     }
 
     func logImpression(type: ImpressionType) {


### PR DESCRIPTION

# Description
RCA:
When campaigns are not dismissed even after they are expired, on closing the campaign impressions requests are being sent. So Impressions are seen for expired campaigns which is not the expected behaviour 

Fix:
Validated the campaign if its outdated while sending the impression. Impressions for outdated campaigns will not be sent now

## Links
[SDKCF-6910]

# Checklist
- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
- [x] I have added to the [changelog](../blob/master/CHANGELOG.md#Unreleased)
- [ ] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data **before every commit**, including API endpoints and keys, and internal links
- [x] I ran `fastlane ci` without errors
- [ ] All project file changes are replicated in `SampleSPM/SampleSPM.xcodeproj` project
