### PR TITLE
feat: Add Push Primer feature using Custom Json (RMCCX-6702)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 ## Changelog
 
 ### Unreleased
+- Features:
+    - Added support for PushPrimer Campaign using CustomJson [RMCCX-6702]
+    - Prevent showing Push Priemr Campaign if Notificaation Permission was granted already [RMCCX-6707]
+    - Added CustomJson feature for RMC SDK users [RMCCX-6712] 
+    - Redirect user to App Notification Permission Settings if permission was denied previously in Push Primer [RMCCX-6710]
 
 ### 8.3.0 (2024-05-13) 
 - Improvements:

--- a/Sources/RInAppMessaging/CampaignsValidator.swift
+++ b/Sources/RInAppMessaging/CampaignsValidator.swift
@@ -41,9 +41,17 @@ internal struct CampaignsValidator: CampaignsValidatorType {
             guard campaign.data.isTest || (!campaign.isOptedOut && !campaign.isOutdated) else {
                 return
             }
-
-            guard campaign.pushPrimerEnabled && !isNotificationsAuthorized() else {
-                return
+            
+            if campaign.isPushPrimer {
+                guard RInAppMessaging.isRMCEnvironment else {
+                    return
+                }
+            }
+            
+            if campaign.isPushPrimer && RInAppMessaging.isRMCEnvironment {
+                guard !isNotificationAuthorized() else {
+                    return
+                }
             }
 
             guard let campaignTriggers = campaign.data.triggers else {
@@ -99,7 +107,7 @@ internal struct CampaignsValidator: CampaignsValidatorType {
         return triggeredEvents
     }
 
-    private func isNotificationsAuthorized() -> Bool {
+    private func isNotificationAuthorized() -> Bool {
         let semaphore = DispatchSemaphore(value: 0)
         var authorizationStatus: UNAuthorizationStatus = .notDetermined
 

--- a/Sources/RInAppMessaging/CampaignsValidator.swift
+++ b/Sources/RInAppMessaging/CampaignsValidator.swift
@@ -104,7 +104,7 @@ internal struct CampaignsValidator: CampaignsValidatorType {
         return triggeredEvents
     }
 
-    internal func isNotificationAuthorized() -> Bool {
+    func isNotificationAuthorized() -> Bool {
         let semaphore = DispatchSemaphore(value: 0)
         var authorizationStatus: UNAuthorizationStatus = .notDetermined
 

--- a/Sources/RInAppMessaging/CampaignsValidator.swift
+++ b/Sources/RInAppMessaging/CampaignsValidator.swift
@@ -105,18 +105,18 @@ internal struct CampaignsValidator: CampaignsValidatorType {
     }
 
     func isNotificationAuthorized(timeout: DispatchTime = .now() + 3) -> Bool {
-        var authorizationStatus = false
+        var isAuthorized = false
         let semaphore = DispatchSemaphore(value: 0)
         notificationCenter.getAuthorizationStatus { authStatus in
             if authStatus == .authorized {
-                authorizationStatus = true
+                isAuthorized = true
             }
             semaphore.signal()
         }
         if semaphore.wait(timeout: timeout) == .timedOut {
             return false
+        } else {
+            return isAuthorized
         }
-
-        return authorizationStatus
     }
 }

--- a/Sources/RInAppMessaging/CampaignsValidator.swift
+++ b/Sources/RInAppMessaging/CampaignsValidator.swift
@@ -42,7 +42,7 @@ internal struct CampaignsValidator: CampaignsValidatorType {
                 return
             }
 
-            guard !(campaign.isPushPrimer && isNotificationsAllowed()) else {
+            guard campaign.pushPrimerEnabled && !isNotificationsAuthorized() else {
                 return
             }
 
@@ -99,7 +99,7 @@ internal struct CampaignsValidator: CampaignsValidatorType {
         return triggeredEvents
     }
 
-    private func isNotificationsAllowed() -> Bool {
+    private func isNotificationsAuthorized() -> Bool {
         let semaphore = DispatchSemaphore(value: 0)
         var authorizationStatus: UNAuthorizationStatus = .notDetermined
 

--- a/Sources/RInAppMessaging/CampaignsValidator.swift
+++ b/Sources/RInAppMessaging/CampaignsValidator.swift
@@ -1,3 +1,6 @@
+import UserNotifications
+import Dispatch
+
 internal protocol CampaignsValidatorType {
 
     /// Cross references the list of campaigns from CampaignRepository

--- a/Sources/RInAppMessaging/DependencyManager/MainContainer.swift
+++ b/Sources/RInAppMessaging/DependencyManager/MainContainer.swift
@@ -1,4 +1,5 @@
 import Foundation
+import UserNotifications
 
 #if SWIFT_PACKAGE
 import RSDKUtilsMain
@@ -99,7 +100,7 @@ internal enum MainContainerFactory {
             ContainerElement(type: CampaignsValidatorType.self, factory: {
                 CampaignsValidator(campaignRepository: manager.resolve(type: CampaignRepositoryType.self)!,
                                    eventMatcher: manager.resolve(type: EventMatcherType.self)!,
-                                   notificationCenter: UNUserNotificationService())
+                                   notificationCenter: UNUserNotificationCenter.current())
             }, transient: true),
             ContainerElement(type: FullViewPresenterType.self, factory: {
                 FullViewPresenter(campaignRepository: manager.resolve(type: CampaignRepositoryType.self)!,

--- a/Sources/RInAppMessaging/DependencyManager/MainContainer.swift
+++ b/Sources/RInAppMessaging/DependencyManager/MainContainer.swift
@@ -98,7 +98,7 @@ internal enum MainContainerFactory {
         elements.append(contentsOf: [
             ContainerElement(type: CampaignsValidatorType.self, factory: {
                 CampaignsValidator(campaignRepository: manager.resolve(type: CampaignRepositoryType.self)!,
-                                   eventMatcher: manager.resolve(type: EventMatcherType.self)!)
+                                   eventMatcher: manager.resolve(type: EventMatcherType.self)!, notificationCenter: UNUserNotificationService())
             }, transient: true),
             ContainerElement(type: FullViewPresenterType.self, factory: {
                 FullViewPresenter(campaignRepository: manager.resolve(type: CampaignRepositoryType.self)!,

--- a/Sources/RInAppMessaging/DependencyManager/MainContainer.swift
+++ b/Sources/RInAppMessaging/DependencyManager/MainContainer.swift
@@ -98,7 +98,8 @@ internal enum MainContainerFactory {
         elements.append(contentsOf: [
             ContainerElement(type: CampaignsValidatorType.self, factory: {
                 CampaignsValidator(campaignRepository: manager.resolve(type: CampaignRepositoryType.self)!,
-                                   eventMatcher: manager.resolve(type: EventMatcherType.self)!, notificationCenter: UNUserNotificationService())
+                                   eventMatcher: manager.resolve(type: EventMatcherType.self)!,
+                                   notificationCenter: UNUserNotificationService())
             }, transient: true),
             ContainerElement(type: FullViewPresenterType.self, factory: {
                 FullViewPresenter(campaignRepository: manager.resolve(type: CampaignRepositoryType.self)!,

--- a/Sources/RInAppMessaging/Extensions/UIApplication+IAM.swift
+++ b/Sources/RInAppMessaging/Extensions/UIApplication+IAM.swift
@@ -35,4 +35,30 @@ extension UIApplication {
         // Only iOS 13+ is supported
         return nil
     }
+    
+    private static let notificationSettingsURLString: String? = {
+        if #available(iOS 16, *) {
+            return UIApplication.openNotificationSettingsURLString
+        }
+        
+        if #available(iOS 15.4, *) {
+            return UIApplicationOpenNotificationSettingsURLString
+        }
+        
+        if #available(iOS 8.0, *) {
+            return UIApplication.openSettingsURLString
+        }
+        
+        return nil
+    }()
+    
+    private static let appNotificationSettingsURL = URL(
+        string: notificationSettingsURLString ?? ""
+    )
+    
+    func openAppNotificationSettings() -> Void {
+        guard let url = UIApplication.appNotificationSettingsURL else { return }
+        self.open(url)
+    }
+
 }

--- a/Sources/RInAppMessaging/Extensions/UIApplication+IAM.swift
+++ b/Sources/RInAppMessaging/Extensions/UIApplication+IAM.swift
@@ -36,29 +36,30 @@ extension UIApplication {
         return nil
     }
     
-    private static let notificationSettingsURLString: String? = {
+    private static let notificationSettingsURL: URL? = {
+        let urlString: String?
+
         if #available(iOS 16, *) {
-            return UIApplication.openNotificationSettingsURLString
+            urlString = UIApplication.openNotificationSettingsURLString
+        } else if #available(iOS 15.4, *) {
+            urlString = UIApplicationOpenNotificationSettingsURLString
+        } else if #available(iOS 8.0, *) {
+            urlString = UIApplication.openSettingsURLString
+        } else {
+            urlString = nil
         }
         
-        if #available(iOS 15.4, *) {
-            return UIApplicationOpenNotificationSettingsURLString
+        guard let urlString = urlString, let url = URL(string: urlString) else {
+            return nil
         }
-        
-        if #available(iOS 8.0, *) {
-            return UIApplication.openSettingsURLString
-        }
-        
-        return nil
+
+        return url
     }()
-    
-    private static let appNotificationSettingsURL = URL(
-        string: notificationSettingsURLString ?? ""
-    )
-    
-    func openAppNotificationSettings() -> Void {
-        guard let url = UIApplication.appNotificationSettingsURL else { return }
+
+    func openAppNotificationSettings() {
+        guard let url = Self.notificationSettingsURL, self.canOpenURL(url) else {
+            return
+        }
         self.open(url)
     }
-
 }

--- a/Sources/RInAppMessaging/Extensions/UIApplication+IAM.swift
+++ b/Sources/RInAppMessaging/Extensions/UIApplication+IAM.swift
@@ -37,16 +37,16 @@ extension UIApplication {
     }
     
     private static let notificationSettingsURL: URL? = {
-        let urlString: String?
+        var urlString: String?
 
         if #available(iOS 16, *) {
             urlString = UIApplication.openNotificationSettingsURLString
-        } else if #available(iOS 15.4, *) {
+        }
+        if #available(iOS 15.4, *) {
             urlString = UIApplicationOpenNotificationSettingsURLString
-        } else if #available(iOS 8.0, *) {
+        }
+        if #available(iOS 8.0, *) {
             urlString = UIApplication.openSettingsURLString
-        } else {
-            urlString = nil
         }
         
         guard let urlString = urlString, let url = URL(string: urlString) else {
@@ -57,7 +57,7 @@ extension UIApplication {
     }()
 
     func openAppNotificationSettings() {
-        guard let url = Self.notificationSettingsURL, self.canOpenURL(url) else {
+        guard let url = Self.notificationSettingsURL else {
             return
         }
         self.open(url)

--- a/Sources/RInAppMessaging/Models/Responses/Campaign.swift
+++ b/Sources/RInAppMessaging/Models/Responses/Campaign.swift
@@ -31,7 +31,7 @@ internal struct Campaign: Codable, Hashable {
             String(substring.drop(while: { $0 != "["}).dropFirst())
         }.filter { !$0.isEmpty }
     }
-    var isPushPrimer: Bool {
+    var pushPrimerEnabled: Bool {
         return RInAppMessaging.isRMCEnvironment && data.customJson?.pushPrimer?.button != nil
     }
 

--- a/Sources/RInAppMessaging/Models/Responses/Campaign.swift
+++ b/Sources/RInAppMessaging/Models/Responses/Campaign.swift
@@ -31,6 +31,9 @@ internal struct Campaign: Codable, Hashable {
             String(substring.drop(while: { $0 != "["}).dropFirst())
         }.filter { !$0.isEmpty }
     }
+    var isPushPrimer: Bool {
+        return data.customJson?.pushPrimer?.button != nil
+    }
 
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)

--- a/Sources/RInAppMessaging/Models/Responses/Campaign.swift
+++ b/Sources/RInAppMessaging/Models/Responses/Campaign.swift
@@ -31,8 +31,8 @@ internal struct Campaign: Codable, Hashable {
             String(substring.drop(while: { $0 != "["}).dropFirst())
         }.filter { !$0.isEmpty }
     }
-    var pushPrimerEnabled: Bool {
-        return RInAppMessaging.isRMCEnvironment && data.customJson?.pushPrimer?.button != nil
+    var isPushPrimer: Bool {
+        return data.customJson?.pushPrimer?.button != nil
     }
 
     init(from decoder: Decoder) throws {

--- a/Sources/RInAppMessaging/Models/Responses/Campaign.swift
+++ b/Sources/RInAppMessaging/Models/Responses/Campaign.swift
@@ -32,7 +32,7 @@ internal struct Campaign: Codable, Hashable {
         }.filter { !$0.isEmpty }
     }
     var isPushPrimer: Bool {
-        return data.customJson?.pushPrimer?.button != nil
+        return RInAppMessaging.isRMCEnvironment && data.customJson?.pushPrimer?.button != nil
     }
 
     init(from decoder: Decoder) throws {

--- a/Sources/RInAppMessaging/Models/Responses/CampaignData.swift
+++ b/Sources/RInAppMessaging/Models/Responses/CampaignData.swift
@@ -8,6 +8,7 @@ internal struct CampaignData: Codable, Hashable {
     let hasNoEndDate: Bool
     let isCampaignDismissable: Bool
     let messagePayload: MessagePayload
+    let customJson: CustomJson?
 
     var intervalBetweenDisplaysInMS: Int {
         messagePayload.messageSettings.displaySettings.delay
@@ -21,7 +22,8 @@ internal struct CampaignData: Codable, Hashable {
          infiniteImpressions: Bool,
          hasNoEndDate: Bool,
          isCampaignDismissable: Bool,
-         messagePayload: MessagePayload) {
+         messagePayload: MessagePayload,
+         customJson: CustomJson?) {
         
         self.campaignId = campaignId
         self.maxImpressions = maxImpressions
@@ -32,6 +34,7 @@ internal struct CampaignData: Codable, Hashable {
         self.hasNoEndDate = hasNoEndDate
         self.isCampaignDismissable = isCampaignDismissable
         self.messagePayload = messagePayload
+        self.customJson = customJson
     }
 
     init(from decoder: Decoder) throws {
@@ -45,6 +48,7 @@ internal struct CampaignData: Codable, Hashable {
         hasNoEndDate = try container.decodeIfPresent(Bool.self, forKey: .hasNoEndDate) ?? false
         isCampaignDismissable = try container.decodeIfPresent(Bool.self, forKey: .isCampaignDismissable) ?? true
         messagePayload = try container.decode(MessagePayload.self, forKey: .messagePayload)
+        customJson = try container.decodeIfPresent(CustomJson.self, forKey: .customJson)
     }
 
     func hash(into hasher: inout Hasher) {

--- a/Sources/RInAppMessaging/Models/Responses/CampaignDataModels.swift
+++ b/Sources/RInAppMessaging/Models/Responses/CampaignDataModels.swift
@@ -69,3 +69,29 @@ internal struct ButtonBehavior: Codable {
     let action: ActionType
     let uri: String?
 }
+
+internal struct CustomJson: Codable {
+    let pushPrimer: PrimerButton?
+    
+    enum CodingKeys: String, CodingKey {
+        case pushPrimer
+    }
+    
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        pushPrimer = try container.decodeIfPresent(PrimerButton.self, forKey: .pushPrimer)
+    }
+}
+
+internal struct PrimerButton: Codable {
+    let button: Int?
+    
+    enum CodingKeys: String, CodingKey {
+        case button
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        button = try container.decodeIfPresent(Int.self, forKey: .button)
+    }
+}

--- a/Sources/RInAppMessaging/Models/Responses/CampaignDataModels.swift
+++ b/Sources/RInAppMessaging/Models/Responses/CampaignDataModels.swift
@@ -77,6 +77,10 @@ internal struct CustomJson: Codable {
         case pushPrimer
     }
     
+    init(pushPrimer: PrimerButton? = nil) {
+        self.pushPrimer = pushPrimer
+    }
+    
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         pushPrimer = try container.decodeIfPresent(PrimerButton.self, forKey: .pushPrimer)
@@ -88,6 +92,10 @@ internal struct PrimerButton: Codable {
     
     enum CodingKeys: String, CodingKey {
         case button
+    }
+    
+    init(button: Int? = nil) {
+        self.button = button
     }
 
     init(from decoder: Decoder) throws {

--- a/Sources/RInAppMessaging/Protocols/RemoteNotificationRequestable.swift
+++ b/Sources/RInAppMessaging/Protocols/RemoteNotificationRequestable.swift
@@ -21,3 +21,27 @@ extension UNUserNotificationCenter: RemoteNotificationRequestable {
         }
     }
 }
+
+protocol UserNotificationCenter {
+    func getNotificationSettings(completionHandler: @escaping (NotificationSettingsProtocol) -> Void)
+}
+
+protocol NotificationSettingsProtocol {
+    var authorizationStatus: UNAuthorizationStatus { get }
+}
+
+class UNUserNotificationService: UserNotificationCenter {
+    private let center: UNUserNotificationCenter
+
+    init(center: UNUserNotificationCenter = UNUserNotificationCenter.current()) {
+        self.center = center
+    }
+
+    func getNotificationSettings(completionHandler: @escaping (NotificationSettingsProtocol) -> Void) {
+        center.getNotificationSettings { settings in
+            completionHandler(settings as NotificationSettingsProtocol)
+        }
+    }
+}
+
+extension UNNotificationSettings: NotificationSettingsProtocol {}

--- a/Sources/RInAppMessaging/Protocols/RemoteNotificationRequestable.swift
+++ b/Sources/RInAppMessaging/Protocols/RemoteNotificationRequestable.swift
@@ -21,27 +21,3 @@ extension UNUserNotificationCenter: RemoteNotificationRequestable {
         }
     }
 }
-
-protocol UserNotificationCenter {
-    func getNotificationSettings(completionHandler: @escaping (NotificationSettingsProtocol) -> Void)
-}
-
-protocol NotificationSettingsProtocol {
-    var authorizationStatus: UNAuthorizationStatus { get }
-}
-
-class UNUserNotificationService: UserNotificationCenter {
-    private let center: UNUserNotificationCenter
-
-    init(center: UNUserNotificationCenter = UNUserNotificationCenter.current()) {
-        self.center = center
-    }
-
-    func getNotificationSettings(completionHandler: @escaping (NotificationSettingsProtocol) -> Void) {
-        center.getNotificationSettings { settings in
-            completionHandler(settings as NotificationSettingsProtocol)
-        }
-    }
-}
-
-extension UNNotificationSettings: NotificationSettingsProtocol {}

--- a/Sources/RInAppMessaging/Views/Presenters/FullViewPresenter.swift
+++ b/Sources/RInAppMessaging/Views/Presenters/FullViewPresenter.swift
@@ -56,7 +56,7 @@ internal class FullViewPresenter: BaseViewPresenter, FullViewPresenterType, Erro
 
     func loadButtons() {
         let buttonList = campaign.data.messagePayload.messageSettings.controlSettings.buttons
-        let pushPrimerButton = campaign.data.customJson?.pushPrimer?.button ?? nil
+        let pushPrimerButton = campaign.data.customJson?.pushPrimer?.button
         let supportedButtons = buttonList.prefix(2).filter {
             [.redirect, .deeplink, .close, .pushPrimer].contains($0.buttonBehavior.action)
         }

--- a/Sources/RInAppMessaging/Views/Presenters/FullViewPresenter.swift
+++ b/Sources/RInAppMessaging/Views/Presenters/FullViewPresenter.swift
@@ -85,7 +85,7 @@ internal class FullViewPresenter: BaseViewPresenter, FullViewPresenterType, Erro
         sendImpressions()
 
         if sender.type == .pushPrimer {
-            self.pushPrimerAction()
+            pushPrimerAction()
         } else if let unwrappedUri = sender.uri {
             guard let uriToOpen = URL(string: unwrappedUri) else {
                 if let view = view {

--- a/Sources/RInAppMessaging/Views/Presenters/FullViewPresenter.swift
+++ b/Sources/RInAppMessaging/Views/Presenters/FullViewPresenter.swift
@@ -85,9 +85,7 @@ internal class FullViewPresenter: BaseViewPresenter, FullViewPresenterType, Erro
         sendImpressions()
 
         if sender.type == .pushPrimer {
-            DispatchQueue.main.async {
-                self.pushPrimerAction()
-            }
+            self.pushPrimerAction()
         } else if let unwrappedUri = sender.uri {
             guard let uriToOpen = URL(string: unwrappedUri) else {
                 if let view = view {

--- a/Tests/Tests/CampaignsValidatorSpec.swift
+++ b/Tests/Tests/CampaignsValidatorSpec.swift
@@ -267,7 +267,8 @@ private enum MockedCampaigns {
             infiniteImpressions: false,
             hasNoEndDate: false,
             isCampaignDismissable: true,
-            messagePayload: outdatedMessagePayload
+            messagePayload: outdatedMessagePayload,
+            customJson: nil
         )
     )
 
@@ -281,7 +282,7 @@ private enum MockedCampaigns {
             infiniteImpressions: false,
             hasNoEndDate: false,
             isCampaignDismissable: true,
-            messagePayload: outdatedMessagePayload
-        )
+            messagePayload: outdatedMessagePayload,
+            customJson: nil)
     )
 }

--- a/Tests/Tests/CampaignsValidatorSpec.swift
+++ b/Tests/Tests/CampaignsValidatorSpec.swift
@@ -283,6 +283,7 @@ private enum MockedCampaigns {
             hasNoEndDate: false,
             isCampaignDismissable: true,
             messagePayload: outdatedMessagePayload,
-            customJson: nil)
+            customJson: nil
+        )
     )
 }

--- a/Tests/Tests/CampaignsValidatorSpec.swift
+++ b/Tests/Tests/CampaignsValidatorSpec.swift
@@ -11,14 +11,14 @@ class CampaignsValidatorSpec: QuickSpec {
         var campaignRepository: CampaignRepository!
         var eventMatcher: EventMatcher!
         var validatorHandler: ValidatorHandler!
-        var mockNotificationCenter: MockUserNotificationCenter!
+        var mockNotificationCenter: UNUserNotificationCenterMock!
 
         func syncRepository(with campaigns: [Campaign]) {
             campaignRepository.syncWith(list: campaigns, timestampMilliseconds: 0, ignoreTooltips: false)
         }
 
         beforeEach {
-            mockNotificationCenter = MockUserNotificationCenter()
+            mockNotificationCenter = UNUserNotificationCenterMock()
             campaignRepository = CampaignRepository(userDataCache: UserDataCacheMock(),
                                                     accountRepository: AccountRepository(userDataCache: UserDataCacheMock()))
             eventMatcher = EventMatcher(campaignRepository: campaignRepository)
@@ -229,7 +229,7 @@ class CampaignsValidatorSpec: QuickSpec {
                 }
                 context("when notification is authorized") {
                     it("returns true") {
-                        mockNotificationCenter.mockAuthorizationStatus = .authorized
+                        mockNotificationCenter.authorizationStatus = .authorized
                         let result = campaignsValidator.isNotificationAuthorized()
                         expect(result).to(beTrue())
                     }
@@ -237,7 +237,7 @@ class CampaignsValidatorSpec: QuickSpec {
 
                 context("when notification is denied") {
                     it("returns false") {
-                        mockNotificationCenter.mockAuthorizationStatus = .denied
+                        mockNotificationCenter.authorizationStatus = .denied
                         let result = campaignsValidator.isNotificationAuthorized()
                         expect(result).to(beFalse())
                     }
@@ -245,7 +245,7 @@ class CampaignsValidatorSpec: QuickSpec {
 
                 context("when notification is not determined") {
                     it("returns false") {
-                        mockNotificationCenter.mockAuthorizationStatus = .notDetermined
+                        mockNotificationCenter.authorizationStatus = .notDetermined
                         let result = campaignsValidator.isNotificationAuthorized()
                         expect(result).to(beFalse())
                     }
@@ -253,9 +253,9 @@ class CampaignsValidatorSpec: QuickSpec {
 
                 context("when notification is provisional") {
                     it("returns false") {
-                        mockNotificationCenter.mockAuthorizationStatus = .provisional
+                        mockNotificationCenter.authorizationStatus = .provisional
                         let result = campaignsValidator.isNotificationAuthorized()
-                        expect(result).to(beTrue())
+                        expect(result).to(beFalse())
                     }
                 }
             }

--- a/Tests/Tests/CampaignsValidatorSpec.swift
+++ b/Tests/Tests/CampaignsValidatorSpec.swift
@@ -11,14 +11,14 @@ class CampaignsValidatorSpec: QuickSpec {
         var campaignRepository: CampaignRepository!
         var eventMatcher: EventMatcher!
         var validatorHandler: ValidatorHandler!
-        var mockNotificationCenter: CampaignValidatorNotificationCenterMock!
+        var mockNotificationCenter: UNUserNotificationCenterMock!
 
         func syncRepository(with campaigns: [Campaign]) {
             campaignRepository.syncWith(list: campaigns, timestampMilliseconds: 0, ignoreTooltips: false)
         }
 
         beforeEach {
-            mockNotificationCenter = CampaignValidatorNotificationCenterMock()
+            mockNotificationCenter = UNUserNotificationCenterMock()
             campaignRepository = CampaignRepository(userDataCache: UserDataCacheMock(),
                                                     accountRepository: AccountRepository(userDataCache: UserDataCacheMock()))
             eventMatcher = EventMatcher(campaignRepository: campaignRepository)
@@ -229,7 +229,7 @@ class CampaignsValidatorSpec: QuickSpec {
                 }
                 context("when notification is authorized") {
                     it("returns true") {
-                        mockNotificationCenter.mockAuthorizationStatus = .authorized
+                        mockNotificationCenter.authorizationStatus = .authorized
                         let result = campaignsValidator.isNotificationAuthorized()
                         expect(result).to(beTrue())
                     }
@@ -237,7 +237,7 @@ class CampaignsValidatorSpec: QuickSpec {
 
                 context("when notification is denied") {
                     it("returns false") {
-                        mockNotificationCenter.mockAuthorizationStatus = .denied
+                        mockNotificationCenter.authorizationStatus = .denied
                         let result = campaignsValidator.isNotificationAuthorized()
                         expect(result).to(beFalse())
                     }
@@ -245,7 +245,7 @@ class CampaignsValidatorSpec: QuickSpec {
 
                 context("when notification is not determined") {
                     it("returns false") {
-                        mockNotificationCenter.mockAuthorizationStatus = .notDetermined
+                        mockNotificationCenter.authorizationStatus = .notDetermined
                         let result = campaignsValidator.isNotificationAuthorized()
                         expect(result).to(beFalse())
                     }
@@ -253,7 +253,7 @@ class CampaignsValidatorSpec: QuickSpec {
 
                 context("when notification is provisional") {
                     it("returns false") {
-                        mockNotificationCenter.mockAuthorizationStatus = .provisional
+                        mockNotificationCenter.authorizationStatus = .provisional
                         let result = campaignsValidator.isNotificationAuthorized()
                         expect(result).to(beFalse())
                     }
@@ -261,8 +261,7 @@ class CampaignsValidatorSpec: QuickSpec {
 
                 context("when authorization status is authorized before timeout") {
                     it("returns true") {
-                        mockNotificationCenter.mockAuthorizationStatus = .authorized
-                        mockNotificationCenter.delay = 1
+                        mockNotificationCenter.authorizationStatus = .authorized
                         let result = campaignsValidator.isNotificationAuthorized(timeout: .now() + 5)
                         expect(result).to(beTrue())
                     }
@@ -270,8 +269,7 @@ class CampaignsValidatorSpec: QuickSpec {
 
                 context("when authorization status is denied before timeout") {
                     it("returns false") {
-                        mockNotificationCenter.mockAuthorizationStatus = .denied
-                        mockNotificationCenter.delay = 1
+                        mockNotificationCenter.authorizationStatus = .notDetermined
                         let result = campaignsValidator.isNotificationAuthorized(timeout: .now() + 5)
                         expect(result).to(beFalse())
                     }
@@ -279,10 +277,10 @@ class CampaignsValidatorSpec: QuickSpec {
 
                 context("when authorization status request times out") {
                     it("handles the timeout correctly") {
-                        mockNotificationCenter.mockAuthorizationStatus = .authorized
-                        mockNotificationCenter.delay = 6
+                        mockNotificationCenter.authorizationStatus = .authorized
+                        mockNotificationCenter.callCompletion = false
                         let result = campaignsValidator.isNotificationAuthorized(timeout: .now() + 5)
-                        expect(result).to(beFalse()) // Or handle the expected behavior on timeout
+                        expect(result).to(beFalse())
                     }
                 }
             }

--- a/Tests/Tests/CampaignsValidatorSpec.swift
+++ b/Tests/Tests/CampaignsValidatorSpec.swift
@@ -11,14 +11,14 @@ class CampaignsValidatorSpec: QuickSpec {
         var campaignRepository: CampaignRepository!
         var eventMatcher: EventMatcher!
         var validatorHandler: ValidatorHandler!
-        var mockNotificationCenter: UNUserNotificationCenterMock!
+        var mockNotificationCenter: CampaignValidatorNotificationCenterMock!
 
         func syncRepository(with campaigns: [Campaign]) {
             campaignRepository.syncWith(list: campaigns, timestampMilliseconds: 0, ignoreTooltips: false)
         }
 
         beforeEach {
-            mockNotificationCenter = UNUserNotificationCenterMock()
+            mockNotificationCenter = CampaignValidatorNotificationCenterMock()
             campaignRepository = CampaignRepository(userDataCache: UserDataCacheMock(),
                                                     accountRepository: AccountRepository(userDataCache: UserDataCacheMock()))
             eventMatcher = EventMatcher(campaignRepository: campaignRepository)
@@ -229,7 +229,7 @@ class CampaignsValidatorSpec: QuickSpec {
                 }
                 context("when notification is authorized") {
                     it("returns true") {
-                        mockNotificationCenter.authorizationStatus = .authorized
+                        mockNotificationCenter.mockAuthorizationStatus = .authorized
                         let result = campaignsValidator.isNotificationAuthorized()
                         expect(result).to(beTrue())
                     }
@@ -237,7 +237,7 @@ class CampaignsValidatorSpec: QuickSpec {
 
                 context("when notification is denied") {
                     it("returns false") {
-                        mockNotificationCenter.authorizationStatus = .denied
+                        mockNotificationCenter.mockAuthorizationStatus = .denied
                         let result = campaignsValidator.isNotificationAuthorized()
                         expect(result).to(beFalse())
                     }
@@ -245,7 +245,7 @@ class CampaignsValidatorSpec: QuickSpec {
 
                 context("when notification is not determined") {
                     it("returns false") {
-                        mockNotificationCenter.authorizationStatus = .notDetermined
+                        mockNotificationCenter.mockAuthorizationStatus = .notDetermined
                         let result = campaignsValidator.isNotificationAuthorized()
                         expect(result).to(beFalse())
                     }
@@ -253,9 +253,36 @@ class CampaignsValidatorSpec: QuickSpec {
 
                 context("when notification is provisional") {
                     it("returns false") {
-                        mockNotificationCenter.authorizationStatus = .provisional
+                        mockNotificationCenter.mockAuthorizationStatus = .provisional
                         let result = campaignsValidator.isNotificationAuthorized()
                         expect(result).to(beFalse())
+                    }
+                }
+
+                context("when authorization status is authorized before timeout") {
+                    it("returns true") {
+                        mockNotificationCenter.mockAuthorizationStatus = .authorized
+                        mockNotificationCenter.delay = 1
+                        let result = campaignsValidator.isNotificationAuthorized(timeout: .now() + 5)
+                        expect(result).to(beTrue())
+                    }
+                }
+
+                context("when authorization status is denied before timeout") {
+                    it("returns false") {
+                        mockNotificationCenter.mockAuthorizationStatus = .denied
+                        mockNotificationCenter.delay = 1
+                        let result = campaignsValidator.isNotificationAuthorized(timeout: .now() + 5)
+                        expect(result).to(beFalse())
+                    }
+                }
+
+                context("when authorization status request times out") {
+                    it("handles the timeout correctly") {
+                        mockNotificationCenter.mockAuthorizationStatus = .authorized
+                        mockNotificationCenter.delay = 6
+                        let result = campaignsValidator.isNotificationAuthorized(timeout: .now() + 5)
+                        expect(result).to(beFalse()) // Or handle the expected behavior on timeout
                     }
                 }
             }

--- a/Tests/Tests/CustomEventValidationSpec.swift
+++ b/Tests/Tests/CustomEventValidationSpec.swift
@@ -13,21 +13,21 @@ class CustomEventValidationSpec: QuickSpec {
         var campaignRepository: CampaignRepository!
         var eventMatcher: EventMatcher!
         var validatorHandler: ValidatorHandler!
-        var mockCenter: MockUserNotificationCenter!
+        var mockNotificationCenter: UNUserNotificationCenterMock!
 
         func syncRepository(with campaigns: [Campaign]) {
             campaignRepository.syncWith(list: campaigns, timestampMilliseconds: 0, ignoreTooltips: false)
         }
 
         beforeEach {
-            mockCenter = MockUserNotificationCenter()
+            mockNotificationCenter = UNUserNotificationCenterMock()
             campaignRepository = CampaignRepository(userDataCache: UserDataCacheMock(),
                                                     accountRepository: AccountRepository(userDataCache: UserDataCacheMock()))
             eventMatcher = EventMatcher(campaignRepository: campaignRepository)
             campaignsValidator = CampaignsValidator(
                 campaignRepository: campaignRepository,
                 eventMatcher: eventMatcher,
-                notificationCenter: mockCenter)
+                notificationCenter: mockNotificationCenter)
             validatorHandler = ValidatorHandler()
         }
 

--- a/Tests/Tests/CustomEventValidationSpec.swift
+++ b/Tests/Tests/CustomEventValidationSpec.swift
@@ -13,18 +13,21 @@ class CustomEventValidationSpec: QuickSpec {
         var campaignRepository: CampaignRepository!
         var eventMatcher: EventMatcher!
         var validatorHandler: ValidatorHandler!
+        var mockCenter: MockUserNotificationCenter!
 
         func syncRepository(with campaigns: [Campaign]) {
             campaignRepository.syncWith(list: campaigns, timestampMilliseconds: 0, ignoreTooltips: false)
         }
 
         beforeEach {
+            mockCenter = MockUserNotificationCenter()
             campaignRepository = CampaignRepository(userDataCache: UserDataCacheMock(),
                                                     accountRepository: AccountRepository(userDataCache: UserDataCacheMock()))
             eventMatcher = EventMatcher(campaignRepository: campaignRepository)
             campaignsValidator = CampaignsValidator(
                 campaignRepository: campaignRepository,
-                eventMatcher: eventMatcher)
+                eventMatcher: eventMatcher,
+                notificationCenter: mockCenter)
             validatorHandler = ValidatorHandler()
         }
 

--- a/Tests/Tests/Helpers/SharedMocks.swift
+++ b/Tests/Tests/Helpers/SharedMocks.swift
@@ -696,3 +696,20 @@ extension EndpointURL {
                     impression: nil)
     }
 }
+
+class MockNotificationSettings: NotificationSettingsProtocol {
+    var authorizationStatus: UNAuthorizationStatus
+
+    init(authorizationStatus: UNAuthorizationStatus) {
+        self.authorizationStatus = authorizationStatus
+    }
+}
+
+class MockUserNotificationCenter: UserNotificationCenter {
+    var mockAuthorizationStatus: UNAuthorizationStatus = .notDetermined
+
+    func getNotificationSettings(completionHandler: @escaping (NotificationSettingsProtocol) -> Void) {
+        let settings = MockNotificationSettings(authorizationStatus: mockAuthorizationStatus)
+        completionHandler(settings)
+    }
+}

--- a/Tests/Tests/Helpers/SharedMocks.swift
+++ b/Tests/Tests/Helpers/SharedMocks.swift
@@ -696,20 +696,3 @@ extension EndpointURL {
                     impression: nil)
     }
 }
-
-class MockNotificationSettings: NotificationSettingsProtocol {
-    var authorizationStatus: UNAuthorizationStatus
-
-    init(authorizationStatus: UNAuthorizationStatus) {
-        self.authorizationStatus = authorizationStatus
-    }
-}
-
-class MockUserNotificationCenter: UserNotificationCenter {
-    var mockAuthorizationStatus: UNAuthorizationStatus = .notDetermined
-
-    func getNotificationSettings(completionHandler: @escaping (NotificationSettingsProtocol) -> Void) {
-        let settings = MockNotificationSettings(authorizationStatus: mockAuthorizationStatus)
-        completionHandler(settings)
-    }
-}

--- a/Tests/Tests/Helpers/SharedMocks.swift
+++ b/Tests/Tests/Helpers/SharedMocks.swift
@@ -696,3 +696,30 @@ extension EndpointURL {
                     impression: nil)
     }
 }
+
+final class CampaignValidatorNotificationCenterMock: RemoteNotificationRequestable {
+    private(set) var requestAuthorizationCallState: (didCall: Bool, options: UNAuthorizationOptions?) = (false, nil)
+    private(set) var didCallRegisterForRemoteNotifications = false
+    var authorizationRequestError: Error?
+    var authorizationGranted = true
+    var mockAuthorizationStatus: UNAuthorizationStatus?
+    var delay: TimeInterval = 1
+
+    func requestAuthorization(options: UNAuthorizationOptions = [],
+                              completionHandler: @escaping (Bool, Error?) -> Void) {
+        requestAuthorizationCallState = (didCall: true, options: options)
+        completionHandler(authorizationGranted, authorizationRequestError)
+    }
+
+    func registerForRemoteNotifications() {
+        didCallRegisterForRemoteNotifications = true
+    }
+
+    func getAuthorizationStatus(completionHandler: @escaping (UNAuthorizationStatus) -> Void) {
+        if let status = mockAuthorizationStatus {
+            DispatchQueue.global().asyncAfter(deadline: .now() + delay) {
+                completionHandler(status)
+            }
+        }
+    }
+}

--- a/Tests/Tests/Helpers/SharedMocks.swift
+++ b/Tests/Tests/Helpers/SharedMocks.swift
@@ -538,6 +538,7 @@ final class UNUserNotificationCenterMock: RemoteNotificationRequestable {
     var authorizationRequestError: Error?
     var authorizationGranted = true
     var authorizationStatus = UNAuthorizationStatus.notDetermined
+    var callCompletion: Bool = true
 
     func requestAuthorization(options: UNAuthorizationOptions = [],
                               completionHandler: @escaping (Bool, Error?) -> Void) {
@@ -550,7 +551,9 @@ final class UNUserNotificationCenterMock: RemoteNotificationRequestable {
     }
 
     func getAuthorizationStatus(completionHandler: @escaping (UNAuthorizationStatus) -> Void) {
-        completionHandler(authorizationStatus)
+        if callCompletion {
+            completionHandler(authorizationStatus)
+        }
     }
 }
 
@@ -694,32 +697,5 @@ extension EndpointURL {
         EndpointURL(ping: nil,
                     displayPermission: nil,
                     impression: nil)
-    }
-}
-
-final class CampaignValidatorNotificationCenterMock: RemoteNotificationRequestable {
-    private(set) var requestAuthorizationCallState: (didCall: Bool, options: UNAuthorizationOptions?) = (false, nil)
-    private(set) var didCallRegisterForRemoteNotifications = false
-    var authorizationRequestError: Error?
-    var authorizationGranted = true
-    var mockAuthorizationStatus: UNAuthorizationStatus?
-    var delay: TimeInterval = 1
-
-    func requestAuthorization(options: UNAuthorizationOptions = [],
-                              completionHandler: @escaping (Bool, Error?) -> Void) {
-        requestAuthorizationCallState = (didCall: true, options: options)
-        completionHandler(authorizationGranted, authorizationRequestError)
-    }
-
-    func registerForRemoteNotifications() {
-        didCallRegisterForRemoteNotifications = true
-    }
-
-    func getAuthorizationStatus(completionHandler: @escaping (UNAuthorizationStatus) -> Void) {
-        if let status = mockAuthorizationStatus {
-            DispatchQueue.global().asyncAfter(deadline: .now() + delay) {
-                completionHandler(status)
-            }
-        }
     }
 }

--- a/Tests/Tests/Helpers/TestHelpers.swift
+++ b/Tests/Tests/Helpers/TestHelpers.swift
@@ -34,7 +34,8 @@ struct TestHelpers {
                                  hasImage: Bool = false,
                                  content: Content? = nil,
                                  triggers: [Trigger]? = nil,
-                                 buttons: [Button] = []) -> Campaign {
+                                 buttons: [Button] = [],
+                                 customJson: CustomJson? = nil) -> Campaign {
         Campaign(
             data: CampaignData(
                 campaignId: id,
@@ -70,7 +71,7 @@ struct TestHelpers {
                             buttons: buttons,
                             content: content))
                 ),
-                customJson: nil
+                customJson: customJson
             )
         )
     }

--- a/Tests/Tests/Helpers/TestHelpers.swift
+++ b/Tests/Tests/Helpers/TestHelpers.swift
@@ -69,7 +69,8 @@ struct TestHelpers {
                         controlSettings: ControlSettings(
                             buttons: buttons,
                             content: content))
-                )
+                ),
+                customJson: nil
             )
         )
     }
@@ -120,7 +121,8 @@ struct TestHelpers {
                         controlSettings: ControlSettings(
                             buttons: [],
                             content: nil))
-                )
+                ),
+                customJson: nil
             )
         )
     }

--- a/Tests/Tests/Payloads/ping_success.json
+++ b/Tests/Tests/Payloads/ping_success.json
@@ -65,6 +65,11 @@
                         "attributes": []
                     }
                 ],
+                "customJson": {
+                    "pushPrimer": {
+                        "button": 2
+                    }
+                },
                 "messagePayload": {
                     "title": "Campaign with image test-1",
                     "messageBody": "body",
@@ -129,6 +134,11 @@
                         "attributes": []
                     }
                 ],
+                "customJson": {
+                    "pushPrimer": {
+                        "button": 2
+                    }
+                },
                 "messagePayload": {
                     "title": "Campaign with image test-1",
                     "messageBody": "body",

--- a/Tests/Tests/SerializationSpec.swift
+++ b/Tests/Tests/SerializationSpec.swift
@@ -226,7 +226,8 @@ class SerializationSpec: QuickSpec {
                             controlSettings: ControlSettings(
                                 buttons: [],
                                 content: nil))
-                    )
+                    ),
+                    customJson: nil
                 )
             )
         }
@@ -273,6 +274,7 @@ private enum MockedCampaigns {
                         html: false,
                         delay: 0),
                     controlSettings: ControlSettings(buttons: [], content: nil))
-            )
+            ),
+            customJson: nil
         ))
 }

--- a/Tests/Tests/SerializationSpec.swift
+++ b/Tests/Tests/SerializationSpec.swift
@@ -276,5 +276,6 @@ private enum MockedCampaigns {
                     controlSettings: ControlSettings(buttons: [], content: nil))
             ),
             customJson: nil
-        ))
+        )
+    )
 }

--- a/Tests/Tests/ViewPresenterSpec.swift
+++ b/Tests/Tests/ViewPresenterSpec.swift
@@ -658,6 +658,85 @@ class ViewPresenterSpec: QuickSpec {
                     expect(impressionService.sentImpressions?.list).toNot(contain(.optOut))
                 }
             }
+            context("when custom json data is available in Campaign Data") {
+                it("will replace the existing function and enable push primer function for the button") {
+                    let campaignPrimer = TestHelpers.generateCampaign(id: "PushPrimer", buttons: [
+                        Button(buttonText: "button1",
+                               buttonTextColor: "#000000",
+                               buttonBackgroundColor: "#000000",
+                               buttonBehavior: ButtonBehavior(action: .close, uri: nil),
+                               campaignTrigger: Trigger(type: .event,
+                                                        eventType: .custom,
+                                                        eventName: "trigger",
+                                                        attributes: []))
+                    ],
+                    customJson: CustomJson(pushPrimer: PrimerButton(button: 1))
+                    )
+                    presenter.campaign = campaignPrimer
+                    presenter.loadButtons()
+                    expect(view.addedButtons.map({ $0.0.type })).to(equal([ActionType.pushPrimer]))
+                }
+
+                it("will enable retain the button function if pushPrimer data in invalid in custom Json") {
+                    let campaignPrimer = TestHelpers.generateCampaign(id: "PushPrimer", buttons: [
+                        Button(buttonText: "button1",
+                               buttonTextColor: "#000000",
+                               buttonBackgroundColor: "#000000",
+                               buttonBehavior: ButtonBehavior(action: .close, uri: nil),
+                               campaignTrigger: Trigger(type: .event,
+                                                        eventType: .custom,
+                                                        eventName: "trigger",
+                                                        attributes: []))
+                    ],
+                    customJson: CustomJson(pushPrimer: nil)
+                    )
+                    presenter.campaign = campaignPrimer
+                    presenter.loadButtons()
+                    expect(view.addedButtons.map({ $0.0.type })).to(equal([ActionType.close]))
+                }
+
+                it("will enable retain the button function if push primer button value in invalid") {
+                    let campaignPrimer = TestHelpers.generateCampaign(id: "PushPrimer", buttons: [
+                        Button(buttonText: "button1",
+                               buttonTextColor: "#000000",
+                               buttonBackgroundColor: "#000000",
+                               buttonBehavior: ButtonBehavior(action: .close, uri: nil),
+                               campaignTrigger: Trigger(type: .event,
+                                                        eventType: .custom,
+                                                        eventName: "trigger",
+                                                        attributes: []))
+                    ],
+                    customJson: CustomJson(pushPrimer: PrimerButton(button: 99))
+                    )
+                    presenter.campaign = campaignPrimer
+                    presenter.loadButtons()
+                    expect(view.addedButtons.map({ $0.0.type })).to(equal([ActionType.close]))
+                }
+
+                it("will enable pushPrimer for the exact button number when there are multiple buttons") {
+                    let campaignPrimer = TestHelpers.generateCampaign(id: "PushPrimer", buttons: [
+                        Button(buttonText: "button1",
+                               buttonTextColor: "#000000",
+                               buttonBackgroundColor: "#000000",
+                               buttonBehavior: ButtonBehavior(action: .close, uri: nil),
+                               campaignTrigger: Trigger(type: .event,
+                                                        eventType: .custom,
+                                                        eventName: "trigger",
+                                                        attributes: [])),
+                        Button(buttonText: "button2",
+                               buttonTextColor: "#ffffff",
+                               buttonBackgroundColor: "#ffffff",
+                               buttonBehavior: ButtonBehavior(action: .redirect, uri: "uri"),
+                               campaignTrigger: nil)
+                    ],
+                    customJson: CustomJson(pushPrimer: PrimerButton(button: 2))
+                    )
+                    presenter.campaign = campaignPrimer
+                    presenter.loadButtons()
+                    expect(view.addedButtons.map({ $0.0.type })[0]).to(equal(ActionType.close))
+                    expect(view.addedButtons.map({ $0.0.type })[1]).to(equal(ActionType.pushPrimer))
+                }
+            }
         }
     }
 }

--- a/Tests/Tests/ViewPresenterSpec.swift
+++ b/Tests/Tests/ViewPresenterSpec.swift
@@ -658,7 +658,7 @@ class ViewPresenterSpec: QuickSpec {
                     expect(impressionService.sentImpressions?.list).toNot(contain(.optOut))
                 }
             }
-            context("when custom json data is available in Campaign Data") {
+            context("when push primer content is available available in Campaign Data") {
                 it("will replace the existing function and enable push primer function for the button") {
                     let campaignPrimer = TestHelpers.generateCampaign(id: "PushPrimer", buttons: [
                         Button(buttonText: "button1",
@@ -677,7 +677,7 @@ class ViewPresenterSpec: QuickSpec {
                     expect(view.addedButtons.map({ $0.0.type })).to(equal([ActionType.pushPrimer]))
                 }
 
-                it("will enable retain the button function if pushPrimer data in invalid in custom Json") {
+                it("will retain the button function if pushPrimer data in invalid") {
                     let campaignPrimer = TestHelpers.generateCampaign(id: "PushPrimer", buttons: [
                         Button(buttonText: "button1",
                                buttonTextColor: "#000000",
@@ -695,7 +695,7 @@ class ViewPresenterSpec: QuickSpec {
                     expect(view.addedButtons.map({ $0.0.type })).to(equal([ActionType.close]))
                 }
 
-                it("will enable retain the button function if push primer button value in invalid") {
+                it("will retain the button function if push primer button value is invalid") {
                     let campaignPrimer = TestHelpers.generateCampaign(id: "PushPrimer", buttons: [
                         Button(buttonText: "button1",
                                buttonTextColor: "#000000",


### PR DESCRIPTION
# Description
Added PushPrimer feature using Custom JSON
Added functionality to navigate to settings when authorization is previously denied 
Added check for not displaying campaign if authorization is previously allowed
Added check for displaying Push Primer campaigns only for RMC users

## Links
[RMCCX-6702]

# Checklist
- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
- [x] I have added to the [changelog](../blob/master/CHANGELOG.md#Unreleased)
- [ ] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data **before every commit**, including API endpoints and keys, and internal links
- [ ] I ran `fastlane ci` without errors
- [ ] All project file changes are replicated in `SampleSPM/SampleSPM.xcodeproj` project
