### PR TITLE
chore: fix push Primer redirection to Settings (RMCCX-6938)

### DIFF
--- a/Sources/RInAppMessaging/Extensions/UIApplication+IAM.swift
+++ b/Sources/RInAppMessaging/Extensions/UIApplication+IAM.swift
@@ -41,11 +41,9 @@ extension UIApplication {
 
         if #available(iOS 16, *) {
             urlString = UIApplication.openNotificationSettingsURLString
-        }
-        if #available(iOS 15.4, *) {
+        } else if #available(iOS 15.4, *) {
             urlString = UIApplicationOpenNotificationSettingsURLString
-        }
-        if #available(iOS 8.0, *) {
+        } else if #available(iOS 12.0, *) {
             urlString = UIApplication.openSettingsURLString
         }
         


### PR DESCRIPTION
# Description
Fix settings navigation on PushPrimer 

## Links
[RMCCX-6938]

# Checklist
- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
- [x] I have added to the [changelog](../blob/master/CHANGELOG.md#Unreleased)
- [ ] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data **before every commit**, including API endpoints and keys, and internal links
- [x] I ran `fastlane ci` without errors
- [ ] All project file changes are replicated in `SampleSPM/SampleSPM.xcodeproj` project
