### PR TITLE
chore: Implement console warning if LogEvent is called before calling RegisterPreference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
     - Redirect user to App Notification Permission Settings if permission was denied previously in Push Primer [RMCCX-6710]
     - Send RMC impression event to RAT [RMCCX-6939]
     - Send RMC push primer event to RAT [RMCCX-6938]
+    - Implement console warning if LogEvent is called before calling RegisterPreference [RMCCX-7109]
 
 ### 8.3.0 (2024-05-13) 
 - Improvements:

--- a/Sources/RInAppMessaging/RInAppMessaging.swift
+++ b/Sources/RInAppMessaging/RInAppMessaging.swift
@@ -23,6 +23,7 @@ import RSDKUtils
     internal static var isInitialized: Bool {
         interactor.iamModule != nil
     }
+    internal static var isUserRegistered: Bool = false
     internal static let interactor = InAppMessagingInteractor()
 
     /// Returns `true` when RMC module is integrated in the host app
@@ -124,6 +125,9 @@ import RSDKUtils
     /// Log the event name passed in and also pass the event name to the view controller to display a matching campaign.
     /// - Parameter event: The Event object to log.
     @objc public static func logEvent(_ event: Event) {
+        if !isUserRegistered {
+            Logger.debug("⚠️ Warning: RegisterPreference should be called before logging any Events.")
+        }
         inAppQueue.async {
             interactor.logEvent(event)
         }
@@ -136,6 +140,7 @@ import RSDKUtils
     /// - Note: This method creates a strong reference to provided object.
     /// - Parameter provider: object that will always contain up-to-date user information.
     @objc public static func registerPreference(_ provider: UserInfoProvider) {
+        isUserRegistered = true
         inAppQueue.async {
             interactor.userPerference = provider
         }

--- a/Sources/RInAppMessaging/Utilities/AnalyticsTracker.swift
+++ b/Sources/RInAppMessaging/Utilities/AnalyticsTracker.swift
@@ -14,7 +14,9 @@ internal struct AnalyticsTracker {
         if let customAccNumber = BundleInfo.rmcRATAccountId, RInAppMessaging.isRMCEnvironment {
             let rmcEventName = name.rawValue == Constants.RAnalytics.impressionsEventName.rawValue ? Constants.RAnalytics.rmcImpressionsEventName : Constants.RAnalytics.rmcPushPrimerEventName
             AnalyticsBroadcaster.sendEventName(rmcEventName.rawValue, dataObject: eventData, customAccountNumber: customAccNumber)
+            AnalyticsBroadcaster.sendEventName(rmcEventName.rawValue, dataObject: eventData)
+        } else {
+            AnalyticsBroadcaster.sendEventName(name.rawValue, dataObject: eventData)
         }
-        AnalyticsBroadcaster.sendEventName(name.rawValue, dataObject: eventData)
     }
 }


### PR DESCRIPTION
# Description
Implement console warning if logEvents are called before calling RegisterPreference . 
Refactor RAT events for RMC users 

## Links
[RMCCX-7109]

# Checklist
- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
- [x] I have added to the [changelog](../blob/master/CHANGELOG.md#Unreleased)
- [ ] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data **before every commit**, including API endpoints and keys, and internal links
- [ ] I ran `fastlane ci` without errors
- [ ] All project file changes are replicated in `SampleSPM/SampleSPM.xcodeproj` project
