### PR TITLE
chore: enable dark background only for Modal Campaign (RMCCX-7328)

### DIFF
--- a/Sources/RInAppMessaging/Views/FullView.swift
+++ b/Sources/RInAppMessaging/Views/FullView.swift
@@ -152,11 +152,11 @@ internal class FullView: UIView, FullViewType, RichContentBrowsable {
         layoutUIComponents(viewModel: viewModel)
         createMessageBody(viewModel: viewModel)
         if RInAppMessaging.isRMCEnvironment,
+           case .modal = mode,
            let opacity = viewModel.customJson?.background?.opacity,
            (0...1).contains(opacity) {
             backgroundViewColor = .black.withAlphaComponent(opacity)
-        }
-        else {
+        } else {
             backgroundViewColor = uiConstants.backgroundColor ?? viewModel.backgroundColor
         }
 


### PR DESCRIPTION
# Description
Added check for enabling dark background only for modal campaign

## Links
[RMCCX-7328]

# Checklist
- [ ] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
- [ ] I have added to the [changelog](../blob/master/CHANGELOG.md#Unreleased)
- [ ] I wrote/updated tests for new/changed code
- [ ] I removed all sensitive data **before every commit**, including API endpoints and keys, and internal links
- [ ] I ran `fastlane ci` without errors
- [ ] All project file changes are replicated in `SampleSPM/SampleSPM.xcodeproj` project
