### PR TITLE
chore: Fix for displaying two images on a single page in fullscreen Image Carousel campaign (RMCCX-8178)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
     - Implement Carousel UI display with manual scroll [RMCCX-7619]
     - Implement user click behavior on Carousel Images [RMCCX-7618]
     - Implement autoscroll behavior for Carousel [RMCCX-7620]
+- Fixes:
+    - Fix issue of two images appearing on a single page in fullscreen Image Carousel campaign [RMCCX-8178]
 
 ### 9.0.0 (2024-10-22) 
 - Features:

--- a/Sources/RInAppMessaging/CampaignDispatcher.swift
+++ b/Sources/RInAppMessaging/CampaignDispatcher.swift
@@ -264,7 +264,7 @@ extension CampaignDispatcher {
         }.resume()
     }
 
-     func fetchImage(from url: URL, for campaign: Campaign) {
+    func fetchImage(from url: URL, for campaign: Campaign) {
         data(from: url) { imgBlob in
             self.dispatchQueue.async {
                 guard let imgBlob = imgBlob else {

--- a/Sources/RInAppMessaging/Views/CarouselView.swift
+++ b/Sources/RInAppMessaging/Views/CarouselView.swift
@@ -6,6 +6,7 @@ import UIKit
     @IBOutlet weak var carouselHeightConstraint: NSLayoutConstraint!
 
     var carouselData: [CarouselData] = []
+    private var isFullScreen = false
     private var timer: Timer?
     private var currentIndex = 0
     private var hasReachedLastImage = false
@@ -21,9 +22,10 @@ import UIKit
         stopAutoScroll()
     }
 
-    func configure(carouselData: [CarouselData], presenter: FullViewPresenterType) {
+    func configure(carouselData: [CarouselData], presenter: FullViewPresenterType, isFullScreen: Bool) {
         self.carouselData = carouselData
         self.presenter = presenter
+        self.isFullScreen = isFullScreen
         setupCollectionView()
         setupPageControl()
         startAutoScroll()
@@ -81,6 +83,9 @@ extension CarouselView: UICollectionViewDataSource, UICollectionViewDelegateFlow
     }
 
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
+        if isFullScreen {
+            return CGSize(width: collectionView.bounds.width, height: collectionView.bounds.height)
+        }
         let itemWidth = collectionView.frame.width
         let itemHeight = itemWidth * getMaxImageAspectRatio()
         return  CGSize(width: itemWidth, height: adjustHeight(height: itemHeight))

--- a/Sources/RInAppMessaging/Views/FullView.swift
+++ b/Sources/RInAppMessaging/Views/FullView.swift
@@ -378,7 +378,8 @@ internal class FullView: UIView, FullViewType, RichContentBrowsable {
 
     func configureCarouselView(viewModel: FullViewModel) {
         guard layout == .carousel, let carouselData = viewModel.carouselData else { return }
-        carouselView.configure(carouselData: carouselData, presenter: presenter)
+        let isFullScreen = (mode == .fullScreen)
+        carouselView.configure(carouselData: carouselData, presenter: presenter, isFullScreen: isFullScreen)
     }
 
     @objc private func onActionButtonClick(_ sender: ActionButton) {


### PR DESCRIPTION

# Description
Two images were displayed in a single screen when smaller images were used in Full Screen Campaign. Modified the sizeforItem of collection view to return collectionview height and width only for Full screen campaigns.

## Links
[RMCCX-8178]

# Checklist
- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
- [x] I have added to the [changelog](../blob/master/CHANGELOG.md#Unreleased)
- [ ] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data **before every commit**, including API endpoints and keys, and internal links
- [ ] I ran `fastlane ci` without errors
- [ ] All project file changes are replicated in `SampleSPM/SampleSPM.xcodeproj` project
