### PR TITLE
chore: Fix for displaying two images on a single page in fullscreen Image Carousel campaign (RMCCX-8178)(RMCCX-8192)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@
     - Implement user click behavior on Carousel Images [RMCCX-7618]
     - Implement autoscroll behavior for Carousel [RMCCX-7620]
 - Fixes:
-    - Fix issue of two images appearing on a single page in fullscreen Image Carousel campaign [RMCCX-8178]
+    - Fixed issue of two images appearing on a single page in fullscreen Image Carousel campaign [RMCCX-8178]
+    - Uploaded Image should be displayed when single image is uploaded to JSON for carousel [RMCCX-8192]
 
 ### 9.0.0 (2024-10-22) 
 - Features:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
     - Implement Carousel UI display with manual scroll [RMCCX-7619]
     - Implement user click behavior on Carousel Images [RMCCX-7618]
     - Implement autoscroll behavior for Carousel [RMCCX-7620]
+- Fixes:
+    - Fix issue of two images appearing on a single page in fullscreen Image Carousel campaign [RMCCX-8178]
 
 ### 9.0.0 (2024-10-22) 
 - Features:

--- a/Gemfile
+++ b/Gemfile
@@ -9,4 +9,5 @@ gem "xcov", ">= 1.7.3", "< 2.0.0"
 gem "danger"
 gem "danger-xcov"
 gem "slather"
-gem "activesupport", "= 7.0.8"
+gem 'activesupport', '>= 6.1.7.5', '< 7.1.0'
+gem 'concurrent-ruby', '< 1.3.4'

--- a/Gemfile
+++ b/Gemfile
@@ -9,5 +9,6 @@ gem "xcov", ">= 1.7.3", "< 2.0.0"
 gem "danger"
 gem "danger-xcov"
 gem "slather"
-gem 'activesupport', '>= 6.1.7.5', '< 7.1.0'
-gem 'concurrent-ruby', '< 1.3.4'
+gem "activesupport", "= 7.0.8"
+# fix for bitrise error https://github.com/facebook/react-native/issues/48746
+gem "concurrent-ruby", "< 1.3.4" 

--- a/Sources/RInAppMessaging/CampaignDispatcher.swift
+++ b/Sources/RInAppMessaging/CampaignDispatcher.swift
@@ -264,7 +264,7 @@ extension CampaignDispatcher {
         }.resume()
     }
 
-     func fetchImage(from url: URL, for campaign: Campaign) {
+    func fetchImage(from url: URL, for campaign: Campaign) {
         data(from: url) { imgBlob in
             self.dispatchQueue.async {
                 guard let imgBlob = imgBlob else {

--- a/Sources/RInAppMessaging/CampaignDispatcher.swift
+++ b/Sources/RInAppMessaging/CampaignDispatcher.swift
@@ -108,8 +108,10 @@ internal class CampaignDispatcher: CampaignDispatcherType, TaskSchedulable {
     
     func fetchCampaignImagesAndDisplay(campaign: Campaign) {
         if let carouselData = campaign.data.customJson?.carousel,
-           !(carouselData.images?.isEmpty ?? true),
-           RInAppMessaging.isRMCEnvironment {
+           let images = carouselData.images,
+           !images.isEmpty,
+           images.count > 1,
+           !RInAppMessaging.isRMCEnvironment {
             fetchImagesArray(from: carouselData) { images in
                 guard let carouselData = carouselData.images else { return }
                 let carouselHandler = self.createCarouselDataList(from: carouselData, using: images)

--- a/Sources/RInAppMessaging/CampaignDispatcher.swift
+++ b/Sources/RInAppMessaging/CampaignDispatcher.swift
@@ -111,7 +111,7 @@ internal class CampaignDispatcher: CampaignDispatcherType, TaskSchedulable {
            let images = carouselData.images,
            !images.isEmpty,
            images.count > 1,
-           !RInAppMessaging.isRMCEnvironment {
+           RInAppMessaging.isRMCEnvironment {
             fetchImagesArray(from: carouselData) { images in
                 guard let carouselData = carouselData.images else { return }
                 let carouselHandler = self.createCarouselDataList(from: carouselData, using: images)

--- a/Sources/RInAppMessaging/Views/CarouselView.swift
+++ b/Sources/RInAppMessaging/Views/CarouselView.swift
@@ -9,7 +9,7 @@ import UIKit
     private var timer: Timer?
     private var currentIndex = 0
     private var hasReachedLastImage = false
-    private var isFullScreen = false
+    private var campaignMode: Mode = .none
     var presenter: FullViewPresenterType?
 
     required init?(coder: NSCoder) {
@@ -22,10 +22,10 @@ import UIKit
         stopAutoScroll()
     }
 
-    func configure(carouselData: [CarouselData], presenter: FullViewPresenterType,isFullScreen: Bool) {
+    func configure(carouselData: [CarouselData], presenter: FullViewPresenterType, campaignMode: Mode) {
         self.carouselData = carouselData
         self.presenter = presenter
-        self.isFullScreen = isFullScreen
+        self.campaignMode = campaignMode
         setupCollectionView()
         setupPageControl()
         startAutoScroll()
@@ -83,7 +83,7 @@ extension CarouselView: UICollectionViewDataSource, UICollectionViewDelegateFlow
     }
 
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
-        if isFullScreen {
+        if campaignMode == .fullScreen {
             return CGSize(width: collectionView.bounds.width, height: collectionView.bounds.height)
         }
         let itemWidth = collectionView.frame.width

--- a/Sources/RInAppMessaging/Views/CarouselView.swift
+++ b/Sources/RInAppMessaging/Views/CarouselView.swift
@@ -9,6 +9,7 @@ import UIKit
     private var timer: Timer?
     private var currentIndex = 0
     private var hasReachedLastImage = false
+    private var isFullScreen = false
     var presenter: FullViewPresenterType?
 
     required init?(coder: NSCoder) {
@@ -21,9 +22,10 @@ import UIKit
         stopAutoScroll()
     }
 
-    func configure(carouselData: [CarouselData], presenter: FullViewPresenterType) {
+    func configure(carouselData: [CarouselData], presenter: FullViewPresenterType,isFullScreen: Bool) {
         self.carouselData = carouselData
         self.presenter = presenter
+        self.isFullScreen = isFullScreen
         setupCollectionView()
         setupPageControl()
         startAutoScroll()
@@ -81,6 +83,9 @@ extension CarouselView: UICollectionViewDataSource, UICollectionViewDelegateFlow
     }
 
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
+        if isFullScreen {
+            return CGSize(width: collectionView.bounds.width, height: collectionView.bounds.height)
+        }
         let itemWidth = collectionView.frame.width
         let itemHeight = itemWidth * getMaxImageAspectRatio()
         return  CGSize(width: itemWidth, height: adjustHeight(height: itemHeight))

--- a/Sources/RInAppMessaging/Views/FullView.swift
+++ b/Sources/RInAppMessaging/Views/FullView.swift
@@ -27,12 +27,6 @@ internal class FullView: UIView, FullViewType, RichContentBrowsable {
         var textTopMarginForNotDismissableCampaigns: CGFloat = 20 // A space added between top edge and text/body view when exit button is hidden.
     }
 
-    internal enum Mode: Equatable {
-        case none
-        case modal(maxWindowHeightPercentage: CGFloat)
-        case fullScreen
-    }
-
     internal enum Layout: String {
         case html
         case textOnly
@@ -378,8 +372,7 @@ internal class FullView: UIView, FullViewType, RichContentBrowsable {
 
     func configureCarouselView(viewModel: FullViewModel) {
         guard layout == .carousel, let carouselData = viewModel.carouselData else { return }
-        let isFullScreen = (mode == .fullScreen)
-        carouselView.configure(carouselData: carouselData, presenter: presenter, isFullScreen: isFullScreen)
+        carouselView.configure(carouselData: carouselData, presenter: presenter, campaignMode: mode)
     }
 
     @objc private func onActionButtonClick(_ sender: ActionButton) {
@@ -393,4 +386,10 @@ internal class FullView: UIView, FullViewType, RichContentBrowsable {
     @objc private func onClickCampaignImage() {
         presenter.didClickCampaignImage(url: clickableImageUrl)
     }
+}
+
+enum Mode: Equatable {
+    case none
+    case modal(maxWindowHeightPercentage: CGFloat)
+    case fullScreen
 }

--- a/Sources/RInAppMessaging/Views/FullView.swift
+++ b/Sources/RInAppMessaging/Views/FullView.swift
@@ -378,7 +378,8 @@ internal class FullView: UIView, FullViewType, RichContentBrowsable {
 
     func configureCarouselView(viewModel: FullViewModel) {
         guard layout == .carousel, let carouselData = viewModel.carouselData else { return }
-        carouselView.configure(carouselData: carouselData, presenter: presenter)
+        let isFullScreen = (mode == .fullScreen)
+        carouselView.configure(carouselData: carouselData, presenter: presenter, isFullScreen: isFullScreen)
     }
 
     @objc private func onActionButtonClick(_ sender: ActionButton) {

--- a/Tests/Tests/ViewSpec.swift
+++ b/Tests/Tests/ViewSpec.swift
@@ -98,7 +98,7 @@ class ViewSpec: QuickSpec {
             }
 
             it("will have .none mode set") {
-                expect(view.mode).to(equal(FullView.Mode.none))
+                expect(view.mode).to(equal(Mode.none))
             }
 
             it("will call viewDidInitialize on presenter after init") {


### PR DESCRIPTION
# Description
Two images were displayed in a single screen when smaller images were used in Full Screen Campaign. Modified the sizeforItem of collection view to return collectionview height and width only for Full screen campaigns.

Uploaded Image should be displayed when single image is uploaded to JSON for carousel , added check. 

## Links
[RMCCX-8178]

# Checklist
- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
- [x] I have added to the [changelog](../blob/master/CHANGELOG.md#Unreleased)
- [ ] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data **before every commit**, including API endpoints and keys, and internal links
- [ ] I ran `fastlane ci` without errors
- [ ] All project file changes are replicated in `SampleSPM/SampleSPM.xcodeproj` project
