### PR TITLE
chore: Change carousel cell color to campaign background color, fix layout issues on moving from background to foreground (RMCCX-8178) (RMCCX-8247) (RMCCX-8274)

### DIFF
--- a/Sources/RInAppMessaging/Views/CarouselCell.swift
+++ b/Sources/RInAppMessaging/Views/CarouselCell.swift
@@ -48,8 +48,9 @@ final class CarouselCell: UICollectionViewCell {
         textLabel.frame = CGRect(x: textX, y: textY, width: textSize.width, height: textSize.height)
     }
 
-    func configure(with image: UIImage?, altText: String?) {
+    func configure(with image: UIImage?, altText: String?, cellBgColor: UIColor) {
         let hasImage = (image != nil)
+        backgroundColor = hasImage ? cellBgColor : .clear
         imageView.isHidden = !hasImage
         imageView.image = image
         textLabel.isHidden = hasImage

--- a/Sources/RInAppMessaging/Views/CarouselView.swift
+++ b/Sources/RInAppMessaging/Views/CarouselView.swift
@@ -10,6 +10,7 @@ import UIKit
     private var currentIndex = 0
     private var hasReachedLastImage = false
     private var campaignMode: Mode = .none
+    private var carouselBgColor: UIColor = .clear
     var presenter: FullViewPresenterType?
 
     required init?(coder: NSCoder) {
@@ -24,10 +25,11 @@ import UIKit
         stopAutoScroll()
     }
 
-    func configure(carouselData: [CarouselData], presenter: FullViewPresenterType, campaignMode: Mode) {
+    func configure(carouselData: [CarouselData], presenter: FullViewPresenterType, campaignMode: Mode, backgroundColor: UIColor) {
         self.carouselData = carouselData
         self.presenter = presenter
         self.campaignMode = campaignMode
+        self.carouselBgColor = backgroundColor
         setupCollectionView()
         setupPageControl()
         startAutoScroll()
@@ -79,8 +81,11 @@ extension CarouselView: UICollectionViewDataSource, UICollectionViewDelegateFlow
         guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: CarouselCell.identifier, for: indexPath) as? CarouselCell else {
             return UICollectionViewCell()
         }
+
+        collectionView.backgroundColor = (carouselData[indexPath.item].image != nil) ? carouselBgColor : .clear
         cell.configure(with: carouselData[indexPath.item].image,
-                       altText: carouselData[indexPath.item].altText)
+                       altText: carouselData[indexPath.item].altText,
+                       cellBgColor: carouselBgColor)
         return cell
     }
 

--- a/Sources/RInAppMessaging/Views/CarouselView.swift
+++ b/Sources/RInAppMessaging/Views/CarouselView.swift
@@ -128,14 +128,23 @@ extension CarouselView {
                                                selector: #selector(appdidBecomeActive),
                                                name: UIApplication.didBecomeActiveNotification,
                                                object: nil)
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(handleAppWillEnterForeground),
+                                               name: UIApplication.willEnterForegroundNotification,
+                                               object: nil)
     }
-    
+
     @objc private func appDidEnterBackground(){
         stopAutoScroll()
     }
 
     @objc private func appdidBecomeActive() {
         startAutoScroll()
+    }
+
+    @objc private func handleAppWillEnterForeground() {
+        collectionView.collectionViewLayout.invalidateLayout()
+        collectionView.reloadData()
     }
 
     @objc func handleOrientationChange() {
@@ -154,7 +163,7 @@ extension CarouselView {
         let currentPage = carouselPageControl.currentPage
         collectionView.scrollToItem(at: IndexPath(item: currentPage, section: 0), at: .centeredHorizontally, animated: true)
     }
-    
+
     func adjustHeight(height: CGFloat) -> CGFloat {
         return height < Constants.Carousel.minHeight ? Constants.Carousel.defaultHeight : height
     }

--- a/Sources/RInAppMessaging/Views/CarouselView.swift
+++ b/Sources/RInAppMessaging/Views/CarouselView.swift
@@ -22,6 +22,7 @@ import UIKit
         NotificationCenter.default.removeObserver(self, name: UIDevice.orientationDidChangeNotification, object: nil)
         NotificationCenter.default.removeObserver(self, name: UIApplication.didEnterBackgroundNotification, object: nil)
         NotificationCenter.default.removeObserver(self, name: UIApplication.didBecomeActiveNotification, object: nil)
+        NotificationCenter.default.removeObserver(self, name: UIApplication.willEnterForegroundNotification, object: nil)
         stopAutoScroll()
     }
 

--- a/Sources/RInAppMessaging/Views/FullView.swift
+++ b/Sources/RInAppMessaging/Views/FullView.swift
@@ -372,7 +372,10 @@ internal class FullView: UIView, FullViewType, RichContentBrowsable {
 
     func configureCarouselView(viewModel: FullViewModel) {
         guard layout == .carousel, let carouselData = viewModel.carouselData else { return }
-        carouselView.configure(carouselData: carouselData, presenter: presenter, campaignMode: mode)
+        carouselView.configure(carouselData: carouselData,
+                               presenter: presenter,
+                               campaignMode: mode,
+                               backgroundColor: viewModel.backgroundColor)
     }
 
     @objc private func onActionButtonClick(_ sender: ActionButton) {

--- a/Tests/Tests/CarouselCellSpec.swift
+++ b/Tests/Tests/CarouselCellSpec.swift
@@ -35,46 +35,50 @@ class CarouselCellSpec: QuickSpec {
             context("when configured with an image") {
                 it("should display the image and hide the textLabel") {
                     let image = UIImage()
-                    cell.configure(with: image, altText: "Alt Text")
+                    cell.configure(with: image, altText: "Alt Text", cellBgColor: .black)
 
                     expect(cell.imageView.image).to(equal(image))
                     expect(cell.textLabel.isHidden).to(beTrue())
+                    expect(cell.backgroundColor).to(equal(.black))
                 }
 
                 it("should not display the alt text") {
                     let image = UIImage()
-                    cell.configure(with: image, altText: "Alt Text")
-
+                    cell.configure(with: image, altText: "Alt Text", cellBgColor: .black)
                     expect(cell.textLabel.text).to(equal("Alt Text"))
                     expect(cell.textLabel.isHidden).to(beTrue())
+                    expect(cell.backgroundColor).to(equal(.black))
                 }
             }
 
             context("when configured without an image") {
                 it("should display the alt text and imageView should have nil image") {
-                    cell.configure(with: nil, altText: "Alt Text")
+                    cell.configure(with: nil, altText: "Alt Text", cellBgColor: .black)
 
                     expect(cell.imageView.image).to(beNil())
                     expect(cell.textLabel.isHidden).to(beFalse())
                     expect(cell.textLabel.text).to(equal("Alt Text"))
+                    expect(cell.backgroundColor).to(equal(.clear))
                 }
             }
 
             context("when configured with an empty alt text") {
                 it("should display an empty alt text") {
-                    cell.configure(with: nil, altText: "")
+                    cell.configure(with: nil, altText: "", cellBgColor: .black)
 
                     expect(cell.textLabel.text).to(equal(""))
                     expect(cell.textLabel.isHidden).to(beFalse())
+                    expect(cell.backgroundColor).to(equal(.clear))
                 }
             }
 
             context("when configured with a nil alt text") {
                 it("should display the default alt text") {
-                    cell.configure(with: nil, altText: nil)
+                    cell.configure(with: nil, altText: nil, cellBgColor: .black)
 
                     expect(cell.textLabel.text).to(equal("carousel_image_load_error".localized))
                     expect(cell.textLabel.isHidden).to(beFalse())
+                    expect(cell.backgroundColor).to(equal(.clear))
                 }
             }
 


### PR DESCRIPTION
# Description
Change carousel cell color to campaign background color. Currently it was always white, this is visible when there images of different dimensions in a carousel . 

Fixed layout issues on moving from background to foreground

## Links
[RMCCX-8178][RMCCX-8247][RMCCX-8274]

# Checklist
- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
- [ ] I have added to the [changelog](../blob/master/CHANGELOG.md#Unreleased)
- [ ] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data **before every commit**, including API endpoints and keys, and internal links
- [ ] I ran `fastlane ci` without errors
- [ ] All project file changes are replicated in `SampleSPM/SampleSPM.xcodeproj` project
