### PR TITLE
chore: Update RSDKUtils version to 5.0.0 for cocoaPod and SPM (RMCCX-8311)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
     - Uploaded Image should be displayed when single image is uploaded to JSON for carousel [RMCCX-8192]
     - Auto scrolling should be stopped once the auto scroll reaches last image [RMCCX-8236]
     - Prevent images on carousel getting zoomed in after the app is brought back to foreground from background [RMCCX-8247]
+    - Updated RDKSUtils version to 5.0.0 for cocoaPod and SPM [RMCCX-8311]
 
 ### 9.0.0 (2024-10-22) 
 - Features:

--- a/Package.resolved
+++ b/Package.resolved
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/rakutentech/ios-sdkutils.git",
       "state" : {
-        "revision" : "dedb314c2b8b5cfa2887fdbf7d0e18bf44c0cb26",
-        "version" : "4.2.0"
+        "revision" : "794ea18ce446ae3b016b5c2c76e25869aaa1f366",
+        "version" : "5.0.0"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mattgallagher/CwlCatchException.git",
       "state" : {
-        "revision" : "35f9e770f54ce62dd8526470f14c6e137cef3eea",
-        "version" : "2.1.1"
+        "revision" : "07b2ba21d361c223e25e3c1e924288742923f08c",
+        "version" : "2.2.1"
       }
     },
     {
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mattgallagher/CwlPreconditionTesting.git",
       "state" : {
-        "revision" : "c21f7bab5ca8eee0a9998bbd17ca1d0eb45d4688",
-        "version" : "2.1.0"
+        "revision" : "0139c665ebb45e6a9fbdb68aabfd7c39f3fe0071",
+        "version" : "2.2.2"
       }
     },
     {
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Quick/Nimble.git",
       "state" : {
-        "revision" : "c93f16c25af5770f0d3e6af27c9634640946b068",
-        "version" : "9.2.1"
+        "revision" : "831000dd1939bc2096df572c5fd156f41d858bfa",
+        "version" : "12.1.0"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
             targets: ["RInAppMessaging"])
     ],
     dependencies: [
-        .package(url: "https://github.com/rakutentech/ios-sdkutils.git", .upToNextMajor(from: "4.2.0"))
+        .package(url: "https://github.com/rakutentech/ios-sdkutils.git", .upToNextMajor(from: "5.0.0"))
     ],
     targets: [
         .target(

--- a/Podfile
+++ b/Podfile
@@ -1,5 +1,5 @@
 use_frameworks!
-platform :ios, '12.0'
+platform :ios, '14.0'
 
 secrets = ["RIAM_CONFIG_URL", "RIAM_APP_SUBSCRIPTION_KEY"]
 
@@ -8,7 +8,7 @@ project 'RInAppMessaging', 'UITests' => :debug
 target 'RInAppMessaging_Example' do
   pod 'RInAppMessaging', :path => '.'
   pod 'SwiftLint', '~> 0.50'
-  pod 'RSDKUtils', '~> 4.2.0', :testspecs => ['Nimble', 'TestHelpers']
+  pod 'RSDKUtils', '~> 5.0.0', :testspecs => ['Nimble', 'TestHelpers']
   pod 'Shock', '~> 6.1.2'
 
   abstract_target 'Tests-Common' do

--- a/Podfile
+++ b/Podfile
@@ -13,7 +13,7 @@ target 'RInAppMessaging_Example' do
 
   abstract_target 'Tests-Common' do
     pod 'Quick', '~> 5.0'
-    pod 'Nimble'
+    pod 'Nimble',  '~> 12.1.0'
 
     target 'Tests'
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -6,7 +6,7 @@ PODS:
   - CNIOLinux (2.40.0)
   - CNIOWindows (2.40.0)
   - GRMustache.swift (4.0.1)
-  - Nimble (10.0.0)
+  - Nimble (12.1.0)
   - Quick (5.0.1)
   - RInAppMessaging (9.0.0):
     - RSDKUtils (~> 5.0.0)
@@ -68,7 +68,7 @@ PODS:
     - SwiftNIOCore (= 2.40.0)
 
 DEPENDENCIES:
-  - Nimble
+  - Nimble (~> 12.1.0)
   - Quick (~> 5.0)
   - RInAppMessaging (from `.`)
   - RSDKUtils (~> 5.0.0)
@@ -110,7 +110,7 @@ SPEC CHECKSUMS:
   CNIOLinux: 62e3505f50de558c393dc2f273dde71dcce518da
   CNIOWindows: 3047f2d8165848a3936a0a755fee27c6b5ee479b
   GRMustache.swift: a6436504284b22b4b05daf5f46f77bd3fe00a9a2
-  Nimble: 5316ef81a170ce87baf72dd961f22f89a602ff84
+  Nimble: 7badc051fbff5e14e3798e2392b9389de67f75ea
   Quick: 749aa754fd1e7d984f2000fe051e18a3a9809179
   RInAppMessaging: 37523bc00d31183a794ae67d06a7e2d1a0f62cf6
   RSDKUtils: cf3b35c03684ef59f7831da729c0738ecd4809b8
@@ -123,6 +123,6 @@ SPEC CHECKSUMS:
   SwiftNIOHTTP1: ef56706550a1dc135ea69d65215b9941e643c23b
   SwiftNIOPosix: b49af4bdbecaadfadd5c93dfe28594d6722b75e4
 
-PODFILE CHECKSUM: ec7e3a478688578543cabb0b7440453a1e684d3e
+PODFILE CHECKSUM: 481b38f7140325e5f16466bc1a8dd0855b1fa4c8
 
 COCOAPODS: 1.16.2

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -9,16 +9,16 @@ PODS:
   - Nimble (10.0.0)
   - Quick (5.0.1)
   - RInAppMessaging (9.0.0):
-    - RSDKUtils (~> 4.0)
-  - RSDKUtils (4.2.0):
-    - RSDKUtils/Main (= 4.2.0)
-  - RSDKUtils/Main (4.2.0):
+    - RSDKUtils (~> 5.0.0)
+  - RSDKUtils (5.0.0):
+    - RSDKUtils/Main (= 5.0.0)
+  - RSDKUtils/Main (5.0.0):
     - RSDKUtils/RLogger
-  - RSDKUtils/Nimble (4.2.0):
+  - RSDKUtils/Nimble (5.0.0):
     - Nimble
     - RSDKUtils/Main
-  - RSDKUtils/RLogger (4.2.0)
-  - RSDKUtils/TestHelpers (4.2.0):
+  - RSDKUtils/RLogger (5.0.0)
+  - RSDKUtils/TestHelpers (5.0.0):
     - RSDKUtils/Main
   - Shock (6.1.3):
     - GRMustache.swift (~> 4.0.1)
@@ -71,9 +71,9 @@ DEPENDENCIES:
   - Nimble
   - Quick (~> 5.0)
   - RInAppMessaging (from `.`)
-  - RSDKUtils (~> 4.2.0)
-  - RSDKUtils/Nimble (~> 4.2.0)
-  - RSDKUtils/TestHelpers (~> 4.2.0)
+  - RSDKUtils (~> 5.0.0)
+  - RSDKUtils/Nimble (~> 5.0.0)
+  - RSDKUtils/TestHelpers (~> 5.0.0)
   - Shock (~> 6.1.2)
   - SwiftLint (~> 0.50)
 
@@ -112,8 +112,8 @@ SPEC CHECKSUMS:
   GRMustache.swift: a6436504284b22b4b05daf5f46f77bd3fe00a9a2
   Nimble: 5316ef81a170ce87baf72dd961f22f89a602ff84
   Quick: 749aa754fd1e7d984f2000fe051e18a3a9809179
-  RInAppMessaging: e67e3d3db5792201041fcba320f981c40ed763ec
-  RSDKUtils: 4ef7a283108a78e879f335c788d78bbd5699f907
+  RInAppMessaging: 37523bc00d31183a794ae67d06a7e2d1a0f62cf6
+  RSDKUtils: cf3b35c03684ef59f7831da729c0738ecd4809b8
   Shock: 34def30d5e729f6c1eea2a5b5c2d024b875af86c
   SwiftLint: 1cc5cd61ba9bacb2194e340aeb47a2a37fda00b3
   SwiftNIO: 829958aab300642625091f82fc2f49cb7cf4ef24
@@ -123,6 +123,6 @@ SPEC CHECKSUMS:
   SwiftNIOHTTP1: ef56706550a1dc135ea69d65215b9941e643c23b
   SwiftNIOPosix: b49af4bdbecaadfadd5c93dfe28594d6722b75e4
 
-PODFILE CHECKSUM: d93126c6ae225ff9f7bcfc59f0e4ced878216e9b
+PODFILE CHECKSUM: ec7e3a478688578543cabb0b7440453a1e684d3e
 
-COCOAPODS: 1.15.2
+COCOAPODS: 1.16.2

--- a/RInAppMessaging.podspec
+++ b/RInAppMessaging.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = '14.0'
   s.swift_versions = ['5.7.1']
   s.resources = ['Sources/RInAppMessaging/Resources/PrivacyInfo.xcprivacy']
-  s.dependency 'RSDKUtils', '~> 4.0'
+  s.dependency 'RSDKUtils', '~> 5.0.0'
   s.source_files = 'Sources/RInAppMessaging/**/*.swift'
   s.resource_bundles = { 'RInAppMessagingResources' => ['Sources/RInAppMessaging/Resources/*'] }
 end


### PR DESCRIPTION

# Description
Update RDSKUtils version to 5.0.0 for cocoaPod and SPM

## Links
[RMCCX-8311]

# Checklist
- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
- [x] I have added to the [changelog](../blob/master/CHANGELOG.md#Unreleased)
- [] I wrote/updated tests for new/changed code
- [x] I removed all sensitive data **before every commit**, including API endpoints and keys, and internal links
- [ ] I ran `fastlane ci` without errors
- [ ] All project file changes are replicated in `SampleSPM/SampleSPM.xcodeproj` project
